### PR TITLE
Use 0.99-cliff in inputRange of CardStyleInterpolator for Android

### DIFF
--- a/src/views/CardStackStyleInterpolator.js
+++ b/src/views/CardStackStyleInterpolator.js
@@ -140,7 +140,7 @@ function forFadeFromBottomAndroid(props: NavigationSceneRendererProps): Object {
   }
 
   const index = scene.index;
-  const inputRange = [index - 1, index, index + 1, index + 1];
+  const inputRange = [index - 1, index, index + 0.99, index + 1];
   const height = layout.initHeight;
 
   const opacity = position.interpolate({


### PR DESCRIPTION
The duplicated `index + 1` here looks like a typo to me. I think we still need to use a "0.99-cliff" to quickly set the opacity of the previous scene to 0 for performance reason.

**Test plan (required)**

- Run NavigationPlayground on an Android emulator
- Select "Stack Example"
- Select "GO TO A PROFILE SCREEN"
- Use Hierarchy Viewer to find the view of the old scene
- Its `alpha` value should be `0`.
