### PR TITLE
Allow custom style

### DIFF
--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -118,6 +118,7 @@ All `navigationOptions` for the `StackNavigator`:
   - `visible` - Boolean toggle of header visibility. Only works when `headerMode` is `screen`.
   - `title` - Title string used by the navigation bar, or a custom React component
   - `right` - Custom component displayed on the right side of the header
+  - `style` - Style object for the navigation bar
 
 ### Examples
 

--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -8,6 +8,7 @@ import {
 
 import type {
   HeaderMode,
+  HeaderProps,
 } from './views/Header';
 
 /**
@@ -242,7 +243,7 @@ export type NavigationContainerConfig = {
 export type NavigationStackViewConfig = {
   mode?: 'card' | 'modal',
   headerMode?: HeaderMode,
-  headerComponent?: ReactClass<*>,
+  headerComponent?: ReactClass<HeaderProps>,
 };
 
 export type NavigationStackRouterConfig = {

--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -112,8 +112,11 @@ export type HeaderConfig = {
    */
   right?: React.Element<*>,
 
-  // Style passed into navigation bar container
-  // style?: HeaderStyleInterpolators,
+  /**
+   * Style passed into navigation bar container
+   */
+  style?: Object,
+
   // // Style of title text
   // titleTextStyle?: $NavigationThunk<Object>,
   // // Tint color of navigation bar contents
@@ -122,8 +125,6 @@ export type HeaderConfig = {
   // height?: $NavigationThunk<number>,
   // // Navigation bar translucentcy
   // translucent?: $NavigationThunk<boolean>,
-  // // Renders a custom title component
-  // renderTitle?: $NavigationThunk<React.Element<*>>,
   // // Renders a custom left component
   // renderLeft?: React.Element<*> |
   //   (navigation: NavigationProp<*>, canGoBack: boolean) => React.Element<*>,

--- a/src/views/CardStack.js
+++ b/src/views/CardStack.js
@@ -30,6 +30,7 @@ import type {
 
 import type {
   HeaderMode,
+  HeaderProps,
 } from './Header';
 
 import type { TransitionConfig } from './TransitionConfigs';
@@ -41,6 +42,7 @@ const NativeAnimatedModule = NativeModules && NativeModules.NativeAnimatedModule
 type Props = {
   screenProps?: {};
   headerMode: HeaderMode,
+  headerComponent?: ReactClass<HeaderProps>,
   mode: 'card' | 'modal',
   navigation: NavigationScreenProp<NavigationState, NavigationAction>,
   router: NavigationRouter,
@@ -61,6 +63,7 @@ type Props = {
 type DefaultProps = {
   mode: 'card' | 'modal',
   gesturesEnabled: boolean,
+  headerComponent: ReactClass<HeaderProps>,
 };
 
 class CardStack extends React.Component<DefaultProps, Props, void> {
@@ -86,6 +89,11 @@ class CardStack extends React.Component<DefaultProps, Props, void> {
      * is `screen` on Android and `float` on iOS.
      */
     headerMode: PropTypes.oneOf(['float', 'screen', 'none']),
+
+    /**
+     * Custom React component to be used as a header
+     */
+    headerComponent: PropTypes.func,
 
     /**
      * Style of the cards movement. Value could be `card` or `modal`.
@@ -138,6 +146,7 @@ class CardStack extends React.Component<DefaultProps, Props, void> {
   static defaultProps: DefaultProps = {
     mode: 'card',
     gesturesEnabled: Platform.OS === 'ios',
+    headerComponent: Header,
   };
 
   componentWillMount() {
@@ -186,13 +195,8 @@ class CardStack extends React.Component<DefaultProps, Props, void> {
     const navigation = this._getChildNavigation(props.scene);
     const header = this.props.router.getScreenConfig(navigation, 'header') || {};
 
-    let HeaderComponent = Header;
-    if (header.bar) {
-      HeaderComponent = header.bar;
-    }
-
     return (
-      <HeaderComponent
+      <this.props.headerComponent
         {...props}
         style={header.style}
         mode={headerMode}

--- a/src/views/CardStack.js
+++ b/src/views/CardStack.js
@@ -184,16 +184,17 @@ class CardStack extends React.Component<DefaultProps, Props, void> {
 
   _renderHeader(props: NavigationTransitionProps, headerMode: HeaderMode): ?React.Element<*> {
     const navigation = this._getChildNavigation(props.scene);
-    const header = this.props.router.getScreenConfig(navigation, 'header');
+    const header = this.props.router.getScreenConfig(navigation, 'header') || {};
 
     let HeaderComponent = Header;
-    if (header && header.bar) {
+    if (header.bar) {
       HeaderComponent = header.bar;
     }
 
     return (
       <HeaderComponent
         {...props}
+        style={header.style}
         mode={headerMode}
         onNavigateBack={() => this.props.navigation.goBack(null)}
         renderRightComponent={({ scene }) => {

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -39,7 +39,7 @@ type DefaultProps = {
   renderTitleComponent: SubViewRenderer,
 };
 
-type Props = NavigationSceneRendererProps & {
+export type HeaderProps = NavigationSceneRendererProps & {
   mode: HeaderMode,
   onNavigateBack: ?Function,
   renderLeftComponent: SubViewRenderer,
@@ -53,7 +53,7 @@ type SubViewName = 'left' | 'title' | 'right';
 const APPBAR_HEIGHT = Platform.OS === 'ios' ? 44 : 56;
 const STATUSBAR_HEIGHT = Platform.OS === 'ios' ? 20 : 0;
 
-class Header extends React.Component<DefaultProps, Props, *> {
+class Header extends React.Component<DefaultProps, HeaderProps, *> {
 
   static HEIGHT = APPBAR_HEIGHT + STATUSBAR_HEIGHT;
   static Title = HeaderTitle;
@@ -89,9 +89,9 @@ class Header extends React.Component<DefaultProps, Props, *> {
     style: PropTypes.any,
   };
 
-  props: Props;
+  props: HeaderProps;
 
-  shouldComponentUpdate(nextProps: Props, nextState: any): boolean {
+  shouldComponentUpdate(nextProps: HeaderProps, nextState: any): boolean {
     return ReactComponentWithPureRenderMixin.shouldComponentUpdate.call(
       this,
       nextProps,


### PR DESCRIPTION
Allows setting custom `style` property on a header to change e.g. backgroundColor. Fixes #18. Also fixes `headerComponent` by fixing an old property reference

**Test plan (required)**

Go to any example in playground and define `header.backgroundColor`. Reload.