### PR TITLE
Correct Redux example with addNavigationHelpers

### DIFF
--- a/docs/guides/Redux-Integration.md
+++ b/docs/guides/Redux-Integration.md
@@ -20,10 +20,10 @@ const appReducer = combineReducers({
 class AppWithNavigationState extends React.Component {
   render() {
     return (
-      <AppNavigator navigation={{
+      <AppNavigator navigation={addNavigationHelpers({
         dispatch: this.props.dispatch,
         state: this.props.nav,
-      }} />
+      })} />
     );
   }
 }


### PR DESCRIPTION
Correction for docs, addNavigationHelpers was missing, which if applied copy/paste style would lead to crashes
