### PR TITLE
withCachedChildNavigation: set proper component name

### DIFF
--- a/src/withCachedChildNavigation.js
+++ b/src/withCachedChildNavigation.js
@@ -22,7 +22,7 @@ type Props = {
 export default function withCachedChildNavigation<T: Props>(Comp: ReactClass<T>): ReactClass<T> {
   return class extends PureComponent<void, T, void> {
 
-    static displayName = `withCachedChildNavigation(${Comp.displayName})`;
+    static displayName = `withCachedChildNavigation(${Comp.displayName || Comp.name})`;
 
     props: T;
 


### PR DESCRIPTION
When a component is wrapped with the withCachedChildNavigation, the component name was not always displayed. This fixes that which facilitates debugging.

When using debugger tools such as `react-native-debugger`, attempting to inspect the component tree shows various components as `withCachedChildNavigation(undefined)`. Closed inspection showed that this HOC relies only in `.displayName` of the wrapped component, which is not always set.

This change resolves that issue. Tested locally.