### PR TITLE
Minor fix in documentation in the "Screen Navigation Options" sample (state undefined)

### DIFF
--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -95,7 +95,7 @@ class ProfileScreen extends React.Component {
 
   static navigationOptions = {
 
-    title: `${state.params.name}'s Profile!`,
+    title: ({ state }) => `${state.params.name}'s Profile!`,
 
     header: ({ state, setParams }) => ({
       // Render a button on the right side of the header


### PR DESCRIPTION
The current code as it was, depended on the "state" param, but the title was being defined as a string template literal.