### PR TITLE
Fix 'setting the header title' example in the guides

### DIFF
--- a/docs/guides/Guide-Headers.md
+++ b/docs/guides/Guide-Headers.md
@@ -31,7 +31,7 @@ class ChatScreen extends React.Component {
     // title: 'Hello',
 
     // Or the title string may be a function of the navigation prop:
-    title: ({ navigation }) => `Chat with ${navigation.state.params.user}`
+    title: ({ state }) => `Chat with ${state.params.user}`
   };
   ...
 }


### PR DESCRIPTION
First of all, awesome library! 😸 

I was stepping through the guides, and noticed (what I believe to be) an error with one of the code samples. When [setting the header title](https://reactnavigation.org/docs/intro/headers), the current code gives the error `undefined is not an object (evaluating 'navigation.state')`.

To fix, I just changed it to stay inline with the other code examples, taking in `state` from the navigation param passed in and using that (`state.params.user`).
```js
title: ({ state }) => `Chat with ${state.params.user}`
```

It could also be done by taking in the navigation object, instead of using destructuring
```js
title: (navigation) => `Chat with ${navigation.state.params.user}`
```