### PR TITLE
Added nodes.js cross platform path separator in scripts/compile-docs.js

### DIFF
--- a/scripts/compile-docs.js
+++ b/scripts/compile-docs.js
@@ -1,3 +1,4 @@
+const path = require('path');
 var fs = require('fs');
 var join = require('path').join;
 
@@ -16,7 +17,7 @@ function crawl(location) {
 crawl('docs');
 
 var names = files.map(function(file) {
-  const nameWithExt = file.split('docs/')[1];
+  const nameWithExt = file.split('docs'+path.sep)[1];
   const name = nameWithExt.split('.md')[0];
   return name;
 });
@@ -24,7 +25,7 @@ var names = files.map(function(file) {
 var mdData = {};
 
 names.map(function(name) {
-  mdData[name] = fs.readFileSync('docs/'+name+'.md', {encoding: 'utf8'});
+  mdData[name] = fs.readFileSync('docs'+path.sep+name+'.md', {encoding: 'utf8'});
 });
 
-fs.writeFileSync('website/docs-dist.json', JSON.stringify(mdData));
+fs.writeFileSync('website'+path.sep+'docs-dist.json', JSON.stringify(mdData));


### PR DESCRIPTION
1. _Added nodes.js cross platform path separator in scripts/compile-docs.js_
2. _cross platform path separator_
3. _npm i_
4. _Only tested on Windows, but should work on Mac/Unix too._

