### PR TITLE
[WIP] iOS header refinements

### DIFF
--- a/src/views/CardStack.js
+++ b/src/views/CardStack.js
@@ -224,22 +224,21 @@ class CardStack extends React.Component<DefaultProps, Props, void> {
           if (header && header.left) {
             return header.left;
           }
-          if (props.scene.index === 0 || !props.onNavigateBack) {
-            return null;
+          const { renderLeftComponent } = this.props.headerComponent.defaultProps || {};
+          if (typeof renderLeftComponent === 'function') {
+            return renderLeftComponent(props);
           }
-          const prevSceneTitle = this._getHeaderTitleForScene(props.scenes[props.index - 1]);
-          return (
-            <HeaderBackButton
-              onPress={props.onNavigateBack}
-              title={typeof prevSceneTitle === 'string' ? prevSceneTitle : undefined}
-            />
-          );
+          return null;
         }}
         renderRightComponent={({ scene }) => {
           const navigation = this._getChildNavigation(scene);
           const header = this.props.router.getScreenConfig(navigation, 'header');
           if (header && header.right) {
             return header.right;
+          }
+          const { renderRightComponent } = this.props.headerComponent.defaultProps || {};
+          if (typeof renderRightComponent === 'function') {
+            return renderRightComponent(props);
           }
           return null;
         }}

--- a/src/views/CardStack.js
+++ b/src/views/CardStack.js
@@ -231,7 +231,7 @@ class CardStack extends React.Component<DefaultProps, Props, void> {
           return (
             <HeaderBackButton
               onPress={props.onNavigateBack}
-              title={typeof prevSceneTitle === 'string' && prevSceneTitle}
+              title={typeof prevSceneTitle === 'string' ? prevSceneTitle : undefined}
             />
           );
         }}

--- a/src/views/HeaderBackButton.js
+++ b/src/views/HeaderBackButton.js
@@ -30,7 +30,9 @@ const HeaderBackButton = ({ onPress, title, tintColor }: Props) => (
       tintColor={tintColor}
     />
     {Platform.OS === 'ios' && (
-      <Text>{title}</Text>
+      <Text style={{ color: tintColor }}>
+        {title}
+      </Text>
     )}
   </TouchableItem>
 );
@@ -44,6 +46,7 @@ const styles = StyleSheet.create({
   container: {
     alignItems: 'center',
     justifyContent: 'center',
+    flexDirection: 'row',
   },
   button: {
     height: 24,

--- a/src/views/HeaderBackButton.js
+++ b/src/views/HeaderBackButton.js
@@ -29,7 +29,9 @@ const HeaderBackButton = ({ onPress, title, tintColor }: Props) => (
       source={require('./assets/back-icon.png')}
       tintColor={tintColor}
     />
-    <Text>{title}</Text>
+    {Platform.OS === 'ios' && (
+      <Text>{title}</Text>
+    )}
   </TouchableItem>
 );
 

--- a/src/views/HeaderBackButton.js
+++ b/src/views/HeaderBackButton.js
@@ -4,6 +4,7 @@ import React, { PropTypes } from 'react';
 import {
   I18nManager,
   Image,
+  Text,
   Platform,
   StyleSheet,
 } from 'react-native';
@@ -12,10 +13,11 @@ import TouchableItem from './TouchableItem';
 
 type Props = {
   onPress: Function,
+  title?: string,
   tintColor?: string;
 };
 
-const HeaderBackButton = ({ onPress, tintColor }: Props) => (
+const HeaderBackButton = ({ onPress, title, tintColor }: Props) => (
   <TouchableItem
     delayPressIn={0}
     onPress={onPress}
@@ -27,6 +29,7 @@ const HeaderBackButton = ({ onPress, tintColor }: Props) => (
       source={require('./assets/back-icon.png')}
       tintColor={tintColor}
     />
+    <Text>{title}</Text>
   </TouchableItem>
 );
 

--- a/src/views/HeaderBackButton.js
+++ b/src/views/HeaderBackButton.js
@@ -29,7 +29,7 @@ const HeaderBackButton = ({ onPress, title, tintColor }: Props) => (
       source={require('./assets/back-icon.png')}
       tintColor={tintColor}
     />
-    {Platform.OS === 'ios' && (
+    {Platform.OS === 'ios' && title && (
       <Text style={{ color: tintColor }}>
         {title}
       </Text>


### PR DESCRIPTION
Ideas welcome.

This pull request applies various visual tweaks to the header on iOS, most notably it adds support for `back button` label. 

By default, we will display a previous route title. I consider the logic done. The only part left is the styling itself, with a couple of todos as listed below.

Todo:
- [ ] Better visual fixes
- [ ] Fix header glitch

Will request reviews when ready. In the meantime feel free to chime in.