### PR TITLE
Add `screenProps` example and fix various wordings

### DIFF
--- a/docs/api/navigators/DrawerNavigator.md
+++ b/docs/api/navigators/DrawerNavigator.md
@@ -79,7 +79,12 @@ this.props.navigation.navigate('DrawerClose'); // close drawer
 DrawerNavigator(RouteConfigs, DrawerNavigatorConfig)
 ```
 
-### Drawer Navigator Options
+### RouteConfigs
+
+The route configs object is a mapping from route name to a route config, which tells the navigator what to present for that route, see [example](https://github.com/coodoo/react-navigation/blob/master/docs/api/navigators/StackNavigator.md#routeconfigs) from `StackNavigator`.
+
+
+### DrawerNavigatorConfig
 
 - `drawerWidth` - Width of the drawer
 - `drawerPosition` - Options are `left` or `right`. Default is `left` position.
@@ -101,7 +106,7 @@ Several options get passed to the underlying router to modify navigation logic:
 - `inactiveBackgroundColor` - background color of the inactive label
 - `style` - style object for the content section
 
-Example:
+#### Example:
 
 ```js
 contentOptions: {
@@ -112,10 +117,19 @@ contentOptions: {
 }
 ```
 
-
 ### Navigator Props
 
-The navigator component created by `DrawerNavigator(...)` takes the following props,
+The navigator component created by `DrawerNavigator(...)` takes the following props:
 
-- `screenProps` - Props to pass to each child screen
+- `screenProps` - Pass down extra options to child screens, for example:
 
+
+ ```jsx
+ const DrawerNav = DrawerNavigator({
+   // config
+ });
+ 
+ <DrawerNav
+   screenProps={/* these will get passed to the screen components */}
+ />
+ ```

--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -50,13 +50,13 @@ StackNavigator({
 
     // `ProfileScreen` is a React component that will be the main content of the screen.
     screen: ProfileScreen,
-    // When `ProfileScreen` is loaded by the StackNavigator, it will be given a navigation prop.
+    // When `ProfileScreen` is loaded by the StackNavigator, it will be given a `navigation` prop.
 
     // Optional: When deep linking or using react-navigation in a web app, this path is used:
     path: 'people/:username',
     // The action and route params are extracted from the path.
 
-    // Optional: Override the navigation options for the screen
+    // Optional: Override the `navigationOptions` for the screen
     navigationOptions: {
       title: ({state}) => `${state.params.username}'s Profile'`,
     },
@@ -86,7 +86,7 @@ Visual options:
   - `none` - No header will be rendered.
 
 
-### Screen Navigation Options
+### Screen `navigationOptions`
 
 Usually you define static `navigationOptions` on your screen component. For example:
 
@@ -121,13 +121,24 @@ All `navigationOptions` for the `StackNavigator`:
   - `left` - Custom React Element to display on the left side of the header
   - `style` - Style object for the navigation bar
 
-### Examples
-
-See the examples [SimpleStack.js](https://github.com/react-community/react-navigation/tree/master/examples/NavigationPlayground/js/SimpleStack.js) and [ModalStack.js](https://github.com/react-community/react-navigation/tree/master/examples/NavigationPlayground/js/ModalStack.js) which you can run locally as part of the [NavigationPlayground](https://github.com/react-community/react-navigation/tree/master/examples/NavigationPlayground) app.
-
-
 ### Navigator Props
 
 The navigator component created by `StackNavigator(...)` takes the following props,
 
 - `screenProps` - Props to pass to each child screen
+
+Use `screenProps` to pass down extra options to child screens. For example: 
+
+```jsx
+const SomeStack = StackNavigator({
+  // config
+});
+
+<SomeStack
+  screenProps={/* these will get passed to the screen components */}
+/>
+```
+
+### Examples
+
+See the examples [SimpleStack.js](https://github.com/react-community/react-navigation/tree/master/examples/NavigationPlayground/js/SimpleStack.js) and [ModalStack.js](https://github.com/react-community/react-navigation/tree/master/examples/NavigationPlayground/js/ModalStack.js) which you can run locally as part of the [NavigationPlayground](https://github.com/react-community/react-navigation/tree/master/examples/NavigationPlayground) app.

--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -86,7 +86,7 @@ Visual options:
   - `none` - No header will be rendered.
 
 
-### Screen `navigationOptions`
+### Screen Navigation Options
 
 Usually you define static `navigationOptions` on your screen component. For example:
 
@@ -125,20 +125,19 @@ All `navigationOptions` for the `StackNavigator`:
 
 The navigator component created by `StackNavigator(...)` takes the following props,
 
-- `screenProps` - Props to pass to each child screen
+- `screenProps` - Pass down extra options to child screens, for example:
 
-Use `screenProps` to pass down extra options to child screens. For example: 
 
-```jsx
-const SomeStack = StackNavigator({
-  // config
-});
-
-<SomeStack
-  screenProps={/* these will get passed to the screen components */}
-/>
-```
-
+ ```jsx
+ const SomeStack = StackNavigator({
+   // config
+ });
+ 
+ <SomeStack
+   screenProps={/* these will get passed to the screen components */}
+ />
+ ```
+ 
 ### Examples
 
 See the examples [SimpleStack.js](https://github.com/react-community/react-navigation/tree/master/examples/NavigationPlayground/js/SimpleStack.js) and [ModalStack.js](https://github.com/react-community/react-navigation/tree/master/examples/NavigationPlayground/js/ModalStack.js) which you can run locally as part of the [NavigationPlayground](https://github.com/react-community/react-navigation/tree/master/examples/NavigationPlayground) app.

--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -123,7 +123,7 @@ All `navigationOptions` for the `StackNavigator`:
 
 ### Navigator Props
 
-The navigator component created by `StackNavigator(...)` takes the following props,
+The navigator component created by `StackNavigator(...)` takes the following props:
 
 - `screenProps` - Pass down extra options to child screens, for example:
 

--- a/docs/api/navigators/TabNavigator.md
+++ b/docs/api/navigators/TabNavigator.md
@@ -71,7 +71,17 @@ const MyApp = TabNavigator({
 });
 ```
 
-### Tab Navigator Options
+## API Definition
+
+```js
+TabNavigator(RouteConfigs, TabNavigatorConfig)
+```
+
+### RouteConfigs
+
+The route configs object is a mapping from route name to a route config, which tells the navigator what to present for that route, see [example](https://github.com/coodoo/react-navigation/blob/master/docs/api/navigators/StackNavigator.md#routeconfigs) from `StackNavigator`.
+
+### TabNavigatorConfig
 
 - `tabBarComponent` - component to use as the tab bar, e.g. `TabView.TabBarBottom`
 (this is the default on iOS), `TabView.TabBarTop`
@@ -138,6 +148,18 @@ tabBarOptions: {
 
 ### Navigator Props
 
-The navigator component created by `TabNavigator(...)` takes the following props,
+The navigator component created by `TabNavigator(...)` takes the following props:
 
-- `screenProps` - Props to pass to each child screen
+- `screenProps` - Pass down extra options to child screens, for example:
+
+
+ ```jsx
+ const TabNav = TabNavigator({
+   // config
+ });
+ 
+ <TabNav
+   screenProps={/* these will get passed to the screen components */}
+ />
+ ```
+ 


### PR DESCRIPTION

Added `screenProps` example and fixed various wordings issues, if everything looks good I will start updating other `navigator` docs so they are in alignment.