### PR TITLE
Add support for cardStyle prop

### DIFF
--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -84,6 +84,7 @@ Visual options:
   - `float` - Render a single header that stays at the top and animates as screens are changed. This is a common pattern on iOS.
   - `screen` - Each screen has a header attached to it and the header fades in and out together with the screen. This is a common pattern on Android.
   - `none` - No header will be rendered.
+- `cardStyle` - Use this prop to override or extend the default style for an individual card in stack.
 
 
 ### Screen Navigation Options

--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -249,6 +249,7 @@ export type NavigationStackViewConfig = {
   mode?: 'card' | 'modal',
   headerMode?: HeaderMode,
   headerComponent?: ReactClass<HeaderProps>,
+  cardStyle?: Object
 };
 
 export type NavigationStackRouterConfig = {
@@ -302,7 +303,7 @@ export type NavigationTabRouterConfig = {
   paths?: NavigationPathsConfig,
   navigationOptions?: NavigationScreenOptions,
   order?: Array<string>, // todo: type these as the real route names rather than 'string'
-  
+
   // Does the back button cause the router to switch to the initial tab
   backBehavior?: 'none' | 'initialRoute', // defaults `initialRoute`
 };

--- a/src/navigators/StackNavigator.js
+++ b/src/navigators/StackNavigator.js
@@ -27,6 +27,7 @@ export default (routeConfigMap: NavigationRouteConfigMap, stackConfig: StackNavi
     headerComponent,
     headerMode,
     mode,
+    cardStyle,
     navigationOptions,
   } = stackConfig;
   const stackRouterConfig = {
@@ -42,6 +43,7 @@ export default (routeConfigMap: NavigationRouteConfigMap, stackConfig: StackNavi
       headerComponent={headerComponent}
       headerMode={headerMode}
       mode={mode}
+      cardStyle={cardStyle}
     />
   )), containerOptions);
 };


### PR DESCRIPTION
Currently it is not possible to set the style for an individual card in the CardStack when using the default StackNavigator. My proposal is to add `cardStyle` option to `stackConfig`.