### PR TITLE
Passes style from drawer navigator to view.

### DIFF
--- a/src/navigators/DrawerNavigator.js
+++ b/src/navigators/DrawerNavigator.js
@@ -45,6 +45,7 @@ const DrawerNavigator = (
     contentComponent,
     contentOptions,
     drawerPosition,
+    style,
     ...tabsConfig
   } = mergedConfig;
   const contentRouter = TabRouter(routeConfigs, tabsConfig);
@@ -63,6 +64,7 @@ const DrawerNavigator = (
   return createNavigationContainer(createNavigator(drawerRouter)((props: *) =>
     <DrawerView
       {...props}
+      style={style}
       drawerWidth={drawerWidth}
       contentComponent={contentComponent}
       contentOptions={contentOptions}


### PR DESCRIPTION
Thanks for building `react-navigation`!  Operation Tire-Kicking is going great!

This PR addresses an issue with the drawer contents.  It adds an additional style property that makes it's way down to DrawerSidebar.js from DrawerNavigator.js.

See the white area up top:

![image](https://cloud.githubusercontent.com/assets/68273/22467990/c520f68c-e794-11e6-90c5-4efcce419129.png)

It can now be targetted like so:

```js
DrawerNavigator(
  awesomeRoutes,
  { contentComponent: OmgGreen, style: { paddingTop: 0 } }
)
```

![image](https://cloud.githubusercontent.com/assets/68273/22468023/e5633d6a-e794-11e6-9c27-0dece9b657ba.png)

I considered calling this `drawerStyle` to be specific, but opted for `style`.  Also, much of this functionality was already in place (from the DrawerView down I didn't even have to touch).  Just seemed this was the missing piece.

If you're on-board with this change, I'll amend the docs & prop types (or flow thingies... or whatever you crazy kids are doing these days).

Thanks again.  Lovely API so far.
