### PR TITLE
fixed initialRouteName documentation

### DIFF
--- a/docs/api/navigators/TabNavigator.md
+++ b/docs/api/navigators/TabNavigator.md
@@ -84,10 +84,10 @@ const MyApp = TabNavigator({
 
 Several options get passed to the underlying router to modify navigation logic:
 
-- `initialTab` - The routeName for the initial tab route when first loading
+- `initialRouteName` - The routeName for the initial tab route when first loading
 - `order` - Array of routeNames which defines the order of the tabs
 - `paths` - Provide a mapping of routeName to path config, which overrides the paths set in the routeConfigs.
-- `backBehavior` - Should the back button cause a tab switch to the initial tab? If yes, set to `initialTab`, otherwise `none`. Defaults to `initialTab` behavior.
+- `backBehavior` - Should the back button cause a tab switch to the initial tab? If yes, set to `initialRoute`, otherwise `none`. Defaults to `initialRoute` behavior.
 
 ### `tabBarOptions` for `TabBarBottom` (default tab bar on iOS)
 

--- a/docs/api/routers/TabRouter.md
+++ b/docs/api/routers/TabRouter.md
@@ -9,7 +9,7 @@ const MyApp = TabRouter({
   Home: { screen: HomeScreen },
   Settings: { screen: SettingsScreen },
 }, {
-  initialTab: 'Home',
+  initialRouteName: 'Home',
 })
 ```
 
@@ -46,10 +46,10 @@ Each item in the config may have the following:
 
 Config options that are also passed to the router.
 
-- `initialTab` - The routeName for the initial tab route when first loading
+- `initialRouteName` - The routeName for the initial tab route when first loading
 - `order` - Array of routeNames which defines the order of the tabs
 - `paths` - Provide a mapping of routeName to path config, which overrides the paths set in the routeConfigs.
-- `backBehavior` - Should the back button cause a tab switch to the initial tab? If yes, set to `initialTab`, otherwise `none`. Defaults to `initialTab` behavior.
+- `backBehavior` - Should the back button cause a tab switch to the initial tab? If yes, set to `initialRoute`, otherwise `none`. Defaults to `initialRoute` behavior.
 
 ### Supported Actions
 

--- a/examples/NavigationPlayground/js/CustomTabs.js
+++ b/examples/NavigationPlayground/js/CustomTabs.js
@@ -106,7 +106,7 @@ const CustomTabRouter = TabRouter({
   },
 }, {
   // Change this to start on a different tab
-  initialTab: 'Home',
+  initialRouteName: 'Home',
 });
 
 const CustomTabs = createNavigationContainer(createNavigator(CustomTabRouter)(CustomTabView));


### PR DESCRIPTION
This fixes https://github.com/react-community/react-navigation/issues/119 which is just a documentation issue. The documentation says that the property "initialTab" should be used for displaying an initial route in a TabRouter. The correct name for this property is "initialRouteName". Furthermore the correct value for the "backBehavior" property is "initialRoute" according to the source code of [TabRouter](https://github.com/react-community/react-navigation/blob/master/src/routers/TabRouter.js)