### PR TITLE
Support label as component in TabNavigator

### DIFF
--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -146,7 +146,7 @@ export type TabBarConfig = {
   /**
    * Label text used by the tab bar.
    */
-  label?: string;
+  label?: string | React.Element<*>;
 };
 
 export type DrawerConfig = {

--- a/src/views/TabView/TabBarBottom.js
+++ b/src/views/TabView/TabBarBottom.js
@@ -79,11 +79,7 @@ export default class TabBarBottom extends PureComponent<DefaultProps, Props, voi
         </Animated.Text>
       );
     }
-    return (
-      <Animated.View style={labelStyle}>
-        {label}
-      </Animated.View>
-    );
+    return label;
   };
 
   _renderIcon = (scene: TabScene) => {

--- a/src/views/TabView/TabBarBottom.js
+++ b/src/views/TabView/TabBarBottom.js
@@ -71,10 +71,18 @@ export default class TabBarBottom extends PureComponent<DefaultProps, Props, voi
       inputRange,
       outputRange,
     });
+    const label = this.props.getLabelText(scene);
+    if (typeof label === 'string') {
+      return (
+        <Animated.Text style={[styles.label, { color }]}>
+          {label}
+        </Animated.Text>
+      );
+    }
     return (
-      <Animated.Text style={[styles.label, { color }]}>
-        {this.props.getLabelText(scene)}
-      </Animated.Text>
+      <Animated.View style={labelStyle}>
+        {label}
+      </Animated.View>
     );
   };
 

--- a/src/views/TabView/TabBarTop.js
+++ b/src/views/TabView/TabBarTop.js
@@ -78,10 +78,17 @@ export default class TabBarTop extends PureComponent<DefaultProps, Props, void> 
       outputRange,
     });
     const label = this.props.getLabelText(scene);
+    if (typeof label === 'string') {
+      return (
+        <Animated.Text style={[styles.label, labelStyle, { color }]}>
+          {label}
+        </Animated.Text>
+      );
+    }
     return (
-      <Animated.Text style={[styles.label, labelStyle, { color }]}>
-        {upperCaseLabel && label ? label.toUpperCase() : label}
-      </Animated.Text>
+      <Animated.View style={labelStyle}>
+        {label}
+      </Animated.View>
     );
   };
 

--- a/src/views/TabView/TabBarTop.js
+++ b/src/views/TabView/TabBarTop.js
@@ -85,11 +85,8 @@ export default class TabBarTop extends PureComponent<DefaultProps, Props, void> 
         </Animated.Text>
       );
     }
-    return (
-      <Animated.View style={labelStyle}>
-        {label}
-      </Animated.View>
-    );
+
+    return label;
   };
 
   _renderIcon = (scene: TabScene) => {

--- a/src/views/TabView/TabView.js
+++ b/src/views/TabView/TabView.js
@@ -86,7 +86,7 @@ class TabView extends PureComponent<void, Props, void> {
 
   _getLabelText = ({ route }: TabScene) => {
     const tabBar = this.props.router.getScreenConfig(this.props.childNavigationProps[route.key], 'tabBar');
-    if (tabBar && tabBar.label) {
+    if (tabBar && typeof tabBar.label !== 'undefined') {
       return tabBar.label;
     } else {
       const title = this.props.router.getScreenConfig(this.props.childNavigationProps[route.key], 'title');

--- a/src/views/TabView/TabView.js
+++ b/src/views/TabView/TabView.js
@@ -86,7 +86,7 @@ class TabView extends PureComponent<void, Props, void> {
 
   _getLabelText = ({ route }: TabScene) => {
     const tabBar = this.props.router.getScreenConfig(this.props.childNavigationProps[route.key], 'tabBar');
-    if (tabBar && typeof tabBar.label === 'string') {
+    if (tabBar && tabBar.label) {
       return tabBar.label;
     } else {
       const title = this.props.router.getScreenConfig(this.props.childNavigationProps[route.key], 'title');


### PR DESCRIPTION
>Explain the **motivation** for making this change. What existing problem does the pull request solve?

The tabBar navigationOptions only allow a label to be a string. When an app requires more complex layout, the label needs to match, for example having multiline text. This change solves that by allowing a component to be passed through as the `label` component.

```
function A() {
  return <Text>Page</Text>;
}

function WithComponent() {
  return <Text>Page</Text>;
}

WithComponent.navigationOptions = {
  tabBar: {
    label: (
      <View>
        <Text>SAT</Text>
        <Text>28</Text>
      </View>
    )
  },
}

const Test = TabNavigator({
  A: { screen: WithComponent },
  B: { screen: A },
  C: { screen: A },
  D: { screen: A },
}, {
  tabBarOptions: {
    scrollEnabled: true,
    tabStyle: {
      width: 50,
      height: 50,
      padding: 0,
    }
  },
})
```

Output (example has more screens):

![image](https://cloud.githubusercontent.com/assets/842078/22501966/e4117304-e862-11e6-8bd5-64107873c5f9.png)

Any issues/changes let me know.

Cheers
