### PR TITLE
Add SetParams handling in TabRouter.js

### DIFF
--- a/src/routers/TabRouter.js
+++ b/src/routers/TabRouter.js
@@ -128,6 +128,24 @@ export default (
         }
         // console.log({navId: order.join('-'), action, order, lastIndex: state.index, index: activeTabIndex});
       }
+      if (action.type === 'SetParams') {
+        const lastRoute = state.routes.find(route => route.key === action.key);
+        if (lastRoute) {
+          const params = {
+            ...lastRoute.params,
+            ...action.params,
+          };
+          const routes = [...state.routes];
+          routes[state.routes.indexOf(lastRoute)] = {
+            ...lastRoute,
+            params,
+          };
+          return {
+            ...state,
+            routes,
+          };
+        }
+      }
       if (activeTabIndex !== state.index) {
         // console.log(`${order.join('-')}: Normal navigation`, {lastIndex: state.index, newIndex: activeTabIndex});
         return {

--- a/src/routers/TabRouter.js
+++ b/src/routers/TabRouter.js
@@ -128,7 +128,7 @@ export default (
         }
         // console.log({navId: order.join('-'), action, order, lastIndex: state.index, index: activeTabIndex});
       }
-      if (action.type === 'SetParams') {
+      if (action.type === NavigationActions.SET_PARAMS) {
         const lastRoute = state.routes.find(route => route.key === action.key);
         if (lastRoute) {
           const params = {

--- a/src/routers/__tests__/TabRouter-test.js
+++ b/src/routers/__tests__/TabRouter-test.js
@@ -81,16 +81,12 @@ describe('TabRouter', () => {
       Bar: {
         screen: () => <div />,
       },
-    }, {
-      initialRouteName: 'Bar',
     });
     const state2 = router.getStateForAction({
-      type: 'SetParams',
+      type: NavigationActions.SET_PARAMS,
       params: { name: 'Qux' },
       key: 'Foo',
     });
-
-    expect(state2 && state2.index).toEqual(1);
     expect(state2 && state2.routes[0].params).toEqual({ name: 'Qux' });
   });
 

--- a/src/routers/__tests__/TabRouter-test.js
+++ b/src/routers/__tests__/TabRouter-test.js
@@ -73,6 +73,28 @@ describe('TabRouter', () => {
     });
   });
 
+  test('Handles the SetParams action', () => {
+    const router = TabRouter({
+      Foo: {
+        screen: () => <div />,
+      },
+      Bar: {
+        screen: () => <div />,
+      },
+    }, {
+      initialRouteName: 'Bar',
+      initialRouteParams: { name: 'Zoo' },
+    });
+    const state = router.getStateForAction({ type: NavigationActions.INIT });
+    const state2 = router.getStateForAction({
+      type: NavigationActions.SET_PARAMS,
+      params: { name: 'Qux' },
+      key: 'Init',
+    }, state);
+    expect(state2 && state2.index).toEqual(0);
+    expect(state2 && state2.routes[0].params).toEqual({ name: 'Qux' });
+  });
+
   test('getStateForAction returns null when navigating to same tab', () => {
     const router = TabRouter({ Foo: BareLeafRouteConfig, Bar: BareLeafRouteConfig }, { initialRouteName: 'Bar' });
     const state = router.getStateForAction({ type: NavigationActions.INIT });

--- a/src/routers/__tests__/TabRouter-test.js
+++ b/src/routers/__tests__/TabRouter-test.js
@@ -83,15 +83,14 @@ describe('TabRouter', () => {
       },
     }, {
       initialRouteName: 'Bar',
-      initialRouteParams: { name: 'Zoo' },
     });
-    const state = router.getStateForAction({ type: NavigationActions.INIT });
     const state2 = router.getStateForAction({
-      type: NavigationActions.SET_PARAMS,
+      type: 'SetParams',
       params: { name: 'Qux' },
-      key: 'Init',
-    }, state);
-    expect(state2 && state2.index).toEqual(0);
+      key: 'Foo',
+    });
+
+    expect(state2 && state2.index).toEqual(1);
     expect(state2 && state2.routes[0].params).toEqual({ name: 'Qux' });
   });
 


### PR DESCRIPTION
Following on from #126 setParams in TabNavigator was not working. I believe this is because it is not handled in the getStateForAction function in TabRouter.js

The following code works with my changes
```js
import React from 'react';
import {
    AppRegistry,
    Text,
    View,
    Button,
    StyleSheet
} from 'react-native';
import { TabNavigator, TabView } from 'react-navigation';
import Ionicons from 'react-native-vector-icons/Ionicons';
import IconBadge from './IconBadge'

class Home extends React.Component {

    static navigationOptions = {
        tabBar: ({ state }) => ({
            label: 'Home',
            icon: ({ tintColor, focused }) =>
                <IconBadge
                MainElement={
                    <Ionicons
                    name={focused ? 'ios-home' : 'ios-home-outline'}
                    size={26}
                    style={{ color: tintColor }}
                    />
                }
                badgeNumber={typeof state.params === 'undefined' ? 0 : state.params.badgeCount}
                />,
        }),
    }

    render() {
        const {navigation} = this.props;

        return (
            <View>
                <Button
                    onPress={() => navigation.setParams({badgeCount : 1})}
                    title="Set Badge Number"
                />
            </View>
        );
    }
}

class Settings extends React.Component {
    static navigationOptions = {
        tabBar: {
            label: 'Settings'
        },
    }

    render() {
        const { navigate } = this.props.navigation;

        return (
            <Button
                onPress={() => this.props.navigation.goBack()}
                title="Go back"
            />
        );
    }
}

const MyApp = TabNavigator({
    Home: {
        screen: Home,
    },
    Settings: {
        screen: Settings,
    },
}, {
    ...TabNavigator.Presets.iOSBottomTabs,
    tabBarOptions: {
        activeTintColor: '#e91e63',
    },
});

AppRegistry.registerComponent('ReactNavigation', () => MyApp);
```
And fails without them. I'm presuming this is how you intended it to work, so please dismiss if I have misunderstood.