### PR TITLE
apply params state change during navigate in TabRouter

### DIFF
--- a/src/routers/TabRouter.js
+++ b/src/routers/TabRouter.js
@@ -129,6 +129,10 @@ export default (
       }
       if (activeTabIndex !== state.index) {
         // console.log(`${order.join('-')}: Normal navigation`, {lastIndex: state.index, newIndex: activeTabIndex});
+        if ( action.params ) {
+          state = {...state, routes: [...state.routes]};
+          state.routes[activeTabIndex] = {...state.routes[activeTabIndex], params: action.params};
+        }
         return {
           ...state,
           index: activeTabIndex,


### PR DESCRIPTION
Related to Issue #80

`params` is not merged into state during the Navigation dispatch, so is unavailable to the Screen. I make no claim of understanding this code base, however, running through the nav transitions in the debugger led me to conclude that this is simply not handled. If it is handled then there is a documentation hole explaining how it is supposed to work, though I don't know what that would be.


**Test**

Object transition during action with params, attached  png

<img width="436" alt="navigate_params" src="https://cloud.githubusercontent.com/assets/1304838/22511004/19cb937c-e862-11e6-9238-102dbb50cc94.png">
