### PR TITLE
Fix back button tinting

### DIFF
--- a/src/views/HeaderBackButton.js
+++ b/src/views/HeaderBackButton.js
@@ -27,9 +27,8 @@ const HeaderBackButton = ({ onPress, title, tintColor }: Props) => (
   >
     <View style={styles.container}>
       <Image
-        style={styles.button}
+        style={[styles.button, { tintColor }]}
         source={require('./assets/back-icon.png')}
-        tintColor={tintColor}
       />
       {Platform.OS === 'ios' && title && (
         <Text style={[styles.title, { color: tintColor }]}>


### PR DESCRIPTION
Tinting was just added in #109. In a related issue [it was decided][1] that that the `tintColor` option should control back button tinting as well.

However `<Image>` takes `tintColor` [as a style][0] and not as a prop, so currently the option has no effect on the button’s colour.

Please let me know if any changes are required. Thanks!

[0]: https://facebook.github.io/react-native/releases/0.41/docs/image.html#style
[1]: https://github.com/react-community/react-navigation/issues/36#issuecomment-276294877