### PR TITLE
Fix issue where initialRouteParams were not set

### DIFF
--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -50,7 +50,7 @@ export default (
   });
 
   const {
-    initialRouteParams = {},
+    initialRouteParams,
   } = stackConfig;
 
   const initialRouteName = stackConfig.initialRouteName || routeNames[0];
@@ -113,9 +113,10 @@ export default (
             params: initialRouteParams,
           }));
         }
-        const params = (route.params || action.params) && {
+        const params = (route.params || action.params || initialRouteParams) && {
           ...(route.params || {}),
           ...(action.params || {}),
+          ...(initialRouteParams || {}),
         };
         route = {
           ...route,

--- a/src/routers/__tests__/StackRouter-test.js
+++ b/src/routers/__tests__/StackRouter-test.js
@@ -384,6 +384,26 @@ describe('StackRouter', () => {
     });
   });
 
+  test('Initial route params appear in nav state', () => {
+    const FooScreen = () => <div />;
+    const router = StackRouter({
+      Foo: {
+        screen: FooScreen,
+      },
+    }, { initialRouteName: 'Bar', initialRouteParams: { foo: 'bar' } });
+    const state = router.getStateForAction({ type: NavigationActions.INIT });
+    expect(state).toEqual({
+      index: 0,
+      routes: [
+        {
+          key: 'Init',
+          routeName: 'Bar',
+          params: { foo: 'bar' },
+        },
+      ],
+    });
+  });
+
   test('Action params appear in nav state', () => {
     const FooScreen = () => <div />;
     const BarScreen = () => <div />;


### PR DESCRIPTION
Currently initialRouteParams option has no effect when using StackRouter.