### PR TITLE
Fixed typo in HelloHybrid for ios

### DIFF
--- a/examples/HelloHybrid/HybridContainer.js
+++ b/examples/HelloHybrid/HybridContainer.js
@@ -107,7 +107,7 @@ const HybridContainer = (ReactScreens) => {
         const routeConfig = router && router.getScreenConfig({
           state: routes[index], dispatch: () => {}
         }, index, true);
-        title = (routeConfig && routeConfig.title) || route.routeName;
+        title = (routeConfig && routeConfig.title) || router.routeName;
       }
       HybridNavigationManager.setTitle(rootTag, title || name);
     }

--- a/examples/HelloHybrid/HybridContainer.js
+++ b/examples/HelloHybrid/HybridContainer.js
@@ -97,6 +97,7 @@ const HybridContainer = (ReactScreens) => {
     componentWillUpdate(props, state) {
       const { name, rootTag } = props;
       const ScreenView = ReactScreens[name];
+
       if (!ScreenView) {
         console.log('Experiencing an error! Fix me!')
       }
@@ -107,7 +108,7 @@ const HybridContainer = (ReactScreens) => {
         const routeConfig = router && router.getScreenConfig({
           state: routes[index], dispatch: () => {}
         }, index, true);
-        title = (routeConfig && routeConfig.title) || router.routeName;
+        title = (routeConfig && routeConfig.title) || state.navState.routeName;
       }
       HybridNavigationManager.setTitle(rootTag, title || name);
     }


### PR DESCRIPTION
So in HelloHybrid for ios there is a typo in `router` that cause **of undefined** exception