### PR TITLE
Add visible param to TabBar

### DIFF
--- a/docs/guides/Screen-Nav-Options.md
+++ b/docs/guides/Screen-Nav-Options.md
@@ -98,21 +98,26 @@ The 2nd argument passed to the function are the default values for the `header` 
 
 ```js
 class TabScreen extends React.Component {
+
   static navigationOptions = {
-    label: 'Tab Label',
-    icon: ({ tintColor }) => (
-      <Image
-        source={require('./tab-icon.png')}
-        style={[styles.icon, {tintColor: tintColor}]}
-      />
-    ),
-    visible: true
-  }
+    tabBar: ({ state }) => ({
+      label: 'Tab Label',
+      icon: ({ tintColor }) => (
+        <Image
+          source={require('./tab-icon.png')}
+          style={[styles.icon, {tintColor: tintColor}]}
+        />
+      ),
+      visible: true
+    }),
+  };
+
+};
 ```
 
 - `label` - can be string or react component
 - `icon` - function that returns icon component
-- `visible` - true or false to show or hide the tab bar
+- `visible` - true or false to show or hide the tab bar, if not set then defaults to true
 
 ## Stack Navigation Options
 

--- a/docs/guides/Screen-Nav-Options.md
+++ b/docs/guides/Screen-Nav-Options.md
@@ -96,7 +96,23 @@ The 2nd argument passed to the function are the default values for the `header` 
 
 ## Tab Navigation Options
 
-Coming Soon
+```js
+class TabScreen extends React.Component {
+  static navigationOptions = {
+    label: 'Tab Label',
+    icon: ({ tintColor }) => (
+      <Image
+        source={require('./tab-icon.png')}
+        style={[styles.icon, {tintColor: tintColor}]}
+      />
+    ),
+    visible: true
+  }
+```
+
+- `label` - can be string or react component
+- `icon` - function that returns icon component
+- `visible` - true or false to show or hide the tab bar
 
 ## Stack Navigation Options
 

--- a/src/views/TabView/TabView.js
+++ b/src/views/TabView/TabView.js
@@ -160,7 +160,7 @@ class TabView extends PureComponent<void, Props, void> {
     const { state } = this.props.navigation;
     const tabBar = this.props.router.getScreenConfig(this.props.childNavigationProps[state.routes[state.index].key], 'tabBar');
 
-    if ((tabBarComponent !== undefined) && (tabBar) && (tabBar.visible !== false)) {
+    if (tabBarComponent !== undefined && tabBar && tabBar.visible !== false) {
       if (tabBarPosition === 'bottom') {
         renderFooter = this._renderTabBar;
       } else {

--- a/src/views/TabView/TabView.js
+++ b/src/views/TabView/TabView.js
@@ -158,7 +158,7 @@ class TabView extends PureComponent<void, Props, void> {
     let renderFooter;
 
     const { state } = this.props.navigation;
-    const tabBar = this.props.router.getScreenConfig(this.props.childNavigationProps[state.routes[state.index].routeName], 'tabBar');
+    const tabBar = this.props.router.getScreenConfig(this.props.childNavigationProps[state.routes[state.index].key], 'tabBar');
 
     if ((typeof tabBarComponent !== 'undefined') && (tabBar.visible !== false)) {
       if (tabBarPosition === 'bottom') {

--- a/src/views/TabView/TabView.js
+++ b/src/views/TabView/TabView.js
@@ -160,7 +160,7 @@ class TabView extends PureComponent<void, Props, void> {
     const { state } = this.props.navigation;
     const tabBar = this.props.router.getScreenConfig(this.props.childNavigationProps[state.routes[state.index].key], 'tabBar');
 
-    if ((tabBarComponent !== 'undefined') && (tabBar) && (tabBar.visible !== false)) {
+    if ((tabBarComponent !== undefined) && (tabBar) && (tabBar.visible !== false)) {
       if (tabBarPosition === 'bottom') {
         renderFooter = this._renderTabBar;
       } else {

--- a/src/views/TabView/TabView.js
+++ b/src/views/TabView/TabView.js
@@ -160,7 +160,7 @@ class TabView extends PureComponent<void, Props, void> {
     const { state } = this.props.navigation;
     const tabBar = this.props.router.getScreenConfig(this.props.childNavigationProps[state.routes[state.index].key], 'tabBar');
 
-    if ((typeof tabBarComponent !== 'undefined') && (tabBar.visible !== false)) {
+    if ((tabBarComponent !== 'undefined') && (tabBar.visible !== false)) {
       if (tabBarPosition === 'bottom') {
         renderFooter = this._renderTabBar;
       } else {

--- a/src/views/TabView/TabView.js
+++ b/src/views/TabView/TabView.js
@@ -160,7 +160,7 @@ class TabView extends PureComponent<void, Props, void> {
     const { state } = this.props.navigation;
     const tabBar = this.props.router.getScreenConfig(this.props.childNavigationProps[state.routes[state.index].key], 'tabBar');
 
-    if ((tabBarComponent !== 'undefined') && (tabBar.visible !== false)) {
+    if ((tabBarComponent !== 'undefined') && (tabBar) && (tabBar.visible !== false)) {
       if (tabBarPosition === 'bottom') {
         renderFooter = this._renderTabBar;
       } else {

--- a/src/views/TabView/TabView.js
+++ b/src/views/TabView/TabView.js
@@ -157,7 +157,10 @@ class TabView extends PureComponent<void, Props, void> {
     let renderHeader;
     let renderFooter;
 
-    if (typeof tabBarComponent !== 'undefined') {
+    const { state } = this.props.navigation;
+    const tabBar = this.props.router.getScreenConfig(this.props.childNavigationProps[state.routes[state.index].routeName], 'tabBar');
+
+    if ((typeof tabBarComponent !== 'undefined') && (tabBar.visible !== false)) {
       if (tabBarPosition === 'bottom') {
         renderFooter = this._renderTabBar;
       } else {


### PR DESCRIPTION
This implements the ability to hide the tabBar by setting visible = false

It can be turned on in the navigationOptions
```
    static navigationOptions = {
        tabBar: ({ state }) => ({
            label: 'Messaging',
            visible: false,
        }),
    };
```
or accessed through SetParams (when #132 or similar functionality is implemented). See #136 for discussion.
