### PR TITLE
Better back button label

### DIFF
--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -5,7 +5,6 @@ import React, { PropTypes } from 'react';
 import {
   Animated,
   Platform,
-  Dimensions,
   StyleSheet,
   View,
 } from 'react-native';
@@ -244,7 +243,7 @@ class Header extends React.Component<void, HeaderProps, HeaderState> {
         key={`${name}_${key}`}
         style={[
           width && {
-            width: (Dimensions.get('window').width - width) / 2,
+            width: (props.layout.initWidth - width) / 2,
           },
           styles.item,
           styles[name],

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -246,7 +246,7 @@ class Header extends React.Component<void, HeaderProps, void> {
   }
 
   render(): React.Element<*> {
-    let component = null;
+    let children = null;
 
     if (this.props.mode === 'float') {
       const scenesProps: Array<NavigationSceneRendererProps> = this.props.scenes
@@ -260,9 +260,9 @@ class Header extends React.Component<void, HeaderProps, void> {
           }),
         }));
 
-      component = scenesProps.map(this._renderHeader, this);
+      children = scenesProps.map(this._renderHeader, this);
     } else {
-      component = this._renderHeader({
+      children = this._renderHeader({
         ...this.props,
         position: new Animated.Value(this.props.scene.index),
         progress: new Animated.Value(0),
@@ -275,7 +275,7 @@ class Header extends React.Component<void, HeaderProps, void> {
     return (
       <Animated.View {...rest} style={[styles.container, style]}>
         <View style={styles.appBar}>
-          {component}
+          {children}
         </View>
       </Animated.View>
     );

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -160,20 +160,9 @@ class Header extends React.Component<void, HeaderProps, HeaderState> {
     );
   }
 
-  _renderTitle(props: NavigationSceneRendererProps, options: *): ?React.Element<*> {
-    const style = {};
-
-    if (Platform.OS === 'android') {
-      if (!options.hasLeftComponent) {
-        style.left = 0;
-      }
-      if (!options.hasRightComponent) {
-        style.right = 0;
-      }
-    }
-
+  _renderTitle(props: NavigationSceneRendererProps): ?React.Element<*> {
     return this._renderSubView(
-      { ...props, style },
+      props,
       'title',
       this.props.renderTitleComponent,
       this._renderTitleComponent,
@@ -271,10 +260,7 @@ class Header extends React.Component<void, HeaderProps, HeaderState> {
   _renderHeader(props: NavigationSceneRendererProps): React.Element<*> {
     const left = this._renderLeft(props);
     const right = this._renderRight(props);
-    const title = this._renderTitle(props, {
-      hasLeftComponent: !!left,
-      hasRightComponent: !!right,
-    });
+    const title = this._renderTitle(props);
 
     return (
       <View

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -225,53 +225,57 @@ class Header extends React.Component<void, HeaderProps, void> {
     );
   }
 
-  render(): React.Element<*> {
-    // eslint-disable-next-line no-unused-vars
-    const { scenes, scene, style, position, progress, ...rest } = this.props;
+  _renderHeader(props: NavigationSceneRendererProps): React.Element<*> {
+    const left = this._renderLeft(props);
+    const right = this._renderRight(props);
+    const title = this._renderTitle(props, {
+      hasLeftComponent: !!left,
+      hasRightComponent: !!right,
+    });
 
-    let leftComponents = null;
-    let titleComponents = null;
-    let rightComponents = null;
+    return (
+      <View
+        style={StyleSheet.absoluteFill}
+        key={`scene_${props.scene.key}`}
+      >
+        {title}
+        {left}
+        {right}
+      </View>
+    );
+  }
+
+  render(): React.Element<*> {
+    let component = null;
 
     if (this.props.mode === 'float') {
-      const scenesProps = (scenes.map((scene: NavigationScene, index: number) => {
-        const props = NavigationPropTypes.extractSceneRendererProps(this.props);
-        props.scene = scene;
-        props.index = index;
-        props.navigation = addNavigationHelpers({
-          ...this.props.navigation,
-          state: scene.route,
-        });
-        return props;
-      }): Array<NavigationSceneRendererProps>);
-      leftComponents = scenesProps.map(this._renderLeft, this);
-      rightComponents = scenesProps.map(this._renderRight, this);
-      titleComponents = scenesProps.map((props: *, i: number) =>
-        this._renderTitle(props, {
-          hasLeftComponent: leftComponents && !!leftComponents[i],
-          hasRightComponent: rightComponents && !!rightComponents[i],
-        })
-      );
+      const scenesProps: Array<NavigationSceneRendererProps> = this.props.scenes
+        .map((scene: NavigationScene, index: number) => ({
+          ...NavigationPropTypes.extractSceneRendererProps(this.props),
+          scene,
+          index,
+          navigation: addNavigationHelpers({
+            ...this.props.navigation,
+            state: scene.route,
+          }),
+        }));
+
+      component = scenesProps.map(this._renderHeader, this);
     } else {
-      const staticRendererProps = {
+      component = this._renderHeader({
         ...this.props,
-        position: new Animated.Value(scene.index),
+        position: new Animated.Value(this.props.scene.index),
         progress: new Animated.Value(0),
-      };
-      leftComponents = this._renderLeft(staticRendererProps);
-      rightComponents = this._renderRight(staticRendererProps);
-      titleComponents = this._renderTitle(staticRendererProps, {
-        hasLeftComponent: !!leftComponents,
-        hasRightComponent: !!rightComponents,
       });
     }
+
+    // eslint-disable-next-line no-unused-vars
+    const { scenes, scene, style, position, progress, ...rest } = this.props;
 
     return (
       <Animated.View {...rest} style={[styles.container, style]}>
         <View style={styles.appBar}>
-          {titleComponents}
-          {leftComponents}
-          {rightComponents}
+          {component}
         </View>
       </Animated.View>
     );
@@ -292,6 +296,7 @@ const styles = StyleSheet.create({
   },
   appBar: {
     height: APPBAR_HEIGHT,
+    position: 'relative',
   },
   item: {
     flexDirection: 'row',

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -50,7 +50,7 @@ type LayoutEvent = {
 
 type HeaderState = {
   widths: {
-    [key: string]: number,
+    [key: number]: number,
   },
 };
 
@@ -226,14 +226,14 @@ class Header extends React.Component<void, HeaderProps, HeaderState> {
         this.setState({
           widths: {
             ...this.state.widths,
-            [`${index}`]: e.nativeEvent.layout.width,
+            [index]: e.nativeEvent.layout.width,
           },
         });
       }
       : undefined;
 
     const width = name === 'left' || name === 'right'
-      ? this.state.widths[`${index}`]
+      ? this.state.widths[index]
       : undefined;
 
     return (

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -5,6 +5,7 @@ import React, { PropTypes } from 'react';
 import {
   Animated,
   Platform,
+  Dimensions,
   StyleSheet,
   View,
 } from 'react-native';
@@ -209,11 +210,22 @@ class Header extends React.Component<void, HeaderProps, void> {
     }
 
     const pointerEvents = offset !== 0 || isStale ? 'none' : 'box-none';
+
+    const layout = name === 'left' || name === 'right'
+      ? this._getSubViewLayout(props, 'title')
+      : undefined;
+
+    const layoutStyle = layout && layout.width
+      ? { width: (Dimensions.get('window').width - layout.width) / 2}
+      : {};
+
     return (
       <Animated.View
         pointerEvents={pointerEvents}
+        onLayout={(e) => this._cacheSubViewLayout(e.nativeEvent.layout, props, name)}
         key={`${name}_${key}`}
         style={[
+          layoutStyle,
           styles.item,
           styles[name],
           props.style,
@@ -223,6 +235,23 @@ class Header extends React.Component<void, HeaderProps, void> {
         {subView}
       </Animated.View>
     );
+  }
+
+  _cacheSubViewLayout(
+    layout: Object,
+    props: NavigationSceneRendererProps,
+    name: SubViewName
+  ): void {
+    this.setState({
+      [`${props.scene.key}_${name}`]: layout,
+    });
+  }
+
+  _getSubViewLayout(
+    props: NavigationSceneRendererProps,
+    name: SubViewName
+  ): ?Object {
+    return (this.state || {})[`${props.scene.key}_${name}`];
   }
 
   _renderHeader(props: NavigationSceneRendererProps): React.Element<*> {
@@ -235,11 +264,11 @@ class Header extends React.Component<void, HeaderProps, void> {
 
     return (
       <View
-        style={StyleSheet.absoluteFill}
+        style={[StyleSheet.absoluteFill, styles.header]}
         key={`scene_${props.scene.key}`}
       >
-        {title}
         {left}
+        {title}
         {right}
       </View>
     );
@@ -298,28 +327,22 @@ const styles = StyleSheet.create({
     height: APPBAR_HEIGHT,
     position: 'relative',
   },
+  header: {
+    flexDirection: 'row',
+  },
   item: {
     flexDirection: 'row',
     alignItems: 'center',
   },
   title: {
-    bottom: 0,
-    left: 40,
-    position: 'absolute',
-    right: 40,
-    top: 0,
+    flex: 1,
+    justifyContent: 'center',
   },
   left: {
-    bottom: 0,
-    left: 0,
-    position: 'absolute',
-    top: 0,
+    justifyContent: 'flex-start',
   },
   right: {
-    bottom: 0,
-    position: 'absolute',
-    right: 0,
-    top: 0,
+    justifyContent: 'flex-end',
   },
 });
 

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -275,7 +275,7 @@ class Header extends React.Component<void, HeaderProps, HeaderState> {
   }
 
   render(): React.Element<*> {
-    let children = null;
+    let children;
 
     if (this.props.mode === 'float') {
       const scenesProps: Array<NavigationSceneRendererProps> = this.props.scenes

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -338,9 +338,6 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
   },
-  left: {
-    justifyContent: 'flex-start',
-  },
   right: {
     justifyContent: 'flex-end',
   },

--- a/src/views/HeaderBackButton.js
+++ b/src/views/HeaderBackButton.js
@@ -57,7 +57,6 @@ HeaderBackButton.defaultProps = {
 const styles = StyleSheet.create({
   container: {
     alignItems: 'center',
-    justifyContent: 'center',
     flexDirection: 'row',
   },
   title: {

--- a/src/views/HeaderBackButton.js
+++ b/src/views/HeaderBackButton.js
@@ -31,7 +31,11 @@ const HeaderBackButton = ({ onPress, title, tintColor }: Props) => (
         source={require('./assets/back-icon.png')}
       />
       {Platform.OS === 'ios' && title && (
-        <Text style={[styles.title, { color: tintColor }]}>
+        <Text
+          ellipsizeMode="middle"
+          style={[styles.title, { color: tintColor }]}
+          numberOfLines={1}
+        >
           {title}
         </Text>
       )}

--- a/src/views/HeaderTitle.js
+++ b/src/views/HeaderTitle.js
@@ -24,6 +24,7 @@ const styles = StyleSheet.create({
     color: 'rgba(0, 0, 0, .9)',
     textAlign: Platform.OS === 'ios' ? 'center' : 'left',
     marginHorizontal: 16,
+    backgroundColor: 'transparent',
   },
 });
 


### PR DESCRIPTION
This pull request implements a better back button title for a back button on iOS. 

It changes the way components are rendered. Instead of rendering all left, title and right components separately with position `absolute`, it renders them within another View. That makes it possible to use layout, flex, and built-in truncating when width of the container is reached.

In order to achieve that, we listen to `onLayout` to get the real width.

**Todo**
Test on Android. Should have no changes. Will do later today, for now, waiting for review.

**Test plan**

Run on iOS, go to any view, push a screen, observe the header:
<img width="385" alt="screen shot 2017-02-02 at 10 56 27" src="https://cloud.githubusercontent.com/assets/2464966/22554273/d0fbc3ca-e95f-11e6-94ee-28fda0755265.png">
or go back and see smaller title:
<img width="399" alt="screen shot 2017-02-02 at 10 56 31" src="https://cloud.githubusercontent.com/assets/2464966/22554386/1f1e1cb0-e960-11e6-8e76-cb061f2f60e1.png">

