### PR TITLE
Clarify Navigation Prop dispatch method

### DIFF
--- a/docs/guides/Screen-Navigation-Prop.md
+++ b/docs/guides/Screen-Navigation-Prop.md
@@ -110,13 +110,15 @@ The following actions are supported:
 ```js
 import { NavigationActions } from 'react-navigation'
 
-NavigationActions.navigate({
+const navigationAction = NavigationActions.navigate({
   routeName: 'Profile',
   params: {},
 
   // navigate can have a nested navigate action that will be run inside the child router
   action: NavigationActions.navigate({ routeName: 'SubProfileRoute'})
 })
+this.props.navigation.dispatch(navigationAction)
+
 ```
 
 
@@ -144,9 +146,11 @@ When dispatching `SetParams`, the router will produce a new state that has chang
 ```js
 import { NavigationActions } from 'react-navigation'
 
-NavigationActions.setParams({
+const setParamsAction = NavigationActions.setParams({
   params: {}, // these are the new params that will be merged into the existing route params
   // The key of the route that should get the new params
   key: 'screen-123',
 })
+this.props.navigation.dispatch(setParamsAction)
+
 ```


### PR DESCRIPTION
Doc was unclear what `NavigationActions` returned, before it looked like you can dispatch a navigation action simply by calling `NavigationActions.navigation({routeName: 'here'})`.

Looking at `NavigationActions.reset` it looks like the actual `dispatch` line was just missing in `NavigationActions.navigation` and `NavigationActions.setParams` examples.

#157 -> reset action doc was fixed but missed the other actions