### PR TITLE
Pass through screenProps to nested navigators

### DIFF
--- a/examples/NavigationPlayground/js/App.js
+++ b/examples/NavigationPlayground/js/App.js
@@ -103,7 +103,13 @@ const AppNavigator = StackNavigator({
   mode: Platform.OS === 'ios' ? 'modal' : 'card',
 });
 
-export default () => <AppNavigator />;
+export default () => (
+  <AppNavigator
+    screenProps={{
+      exampleScreenProp: 'exampleScreenPropValue',
+    }}
+  />
+);
 
 const styles = StyleSheet.create({
   item: {

--- a/examples/NavigationPlayground/js/StacksInTabs.js
+++ b/examples/NavigationPlayground/js/StacksInTabs.js
@@ -15,9 +15,11 @@ import {
 import Ionicons from 'react-native-vector-icons/Ionicons';
 import SampleText from './SampleText';
 
-const MyNavScreen = ({ navigation, banner }) => (
+// exampleScreenProp passed through recursively from root AppNavigator
+const MyNavScreen = ({ navigation, banner, exampleScreenProp }) => (
   <ScrollView>
     <SampleText>{banner}</SampleText>
+    <SampleText>{exampleScreenProp}</SampleText>
     <Button
       onPress={() => navigation.navigate('Profile', { name: 'Jordan' })}
       title="Go to a profile screen"
@@ -37,34 +39,38 @@ const MyNavScreen = ({ navigation, banner }) => (
   </ScrollView>
 );
 
-const MyHomeScreen = ({ navigation }) => (
+const MyHomeScreen = ({ navigation, exampleScreenProp }) => (
   <MyNavScreen
     banner="Home Screen"
     navigation={navigation}
+    exampleScreenProp={exampleScreenProp}
   />
 );
 
-const MyProfileScreen = ({ navigation }) => (
+const MyProfileScreen = ({ navigation, exampleScreenProp }) => (
   <MyNavScreen
     banner={`${navigation.state.params.name}s Profile`}
     navigation={navigation}
+    exampleScreenProp={exampleScreenProp}
   />
 );
 MyProfileScreen.navigationOptions = {
   title: ({ state }) => `${state.params.name}'s Profile!`,
 };
 
-const MyNotificationsSettingsScreen = ({ navigation }) => (
+const MyNotificationsSettingsScreen = ({ navigation, exampleScreenProp }) => (
   <MyNavScreen
     banner="Notification Settings"
     navigation={navigation}
+    exampleScreenProp={exampleScreenProp}
   />
 );
 
-const MySettingsScreen = ({ navigation }) => (
+const MySettingsScreen = ({ navigation, exampleScreenProp }) => (
   <MyNavScreen
     banner="Settings"
     navigation={navigation}
+    exampleScreenProp={exampleScreenProp}
   />
 );
 

--- a/src/views/SceneView.js
+++ b/src/views/SceneView.js
@@ -19,6 +19,7 @@ export default class SceneView extends PureComponent<void, Props, void> {
 
   render() {
     const { screenProps, navigation, component: Component } = this.props;
-    return <Component {...screenProps} navigation={navigation} />;
+    // pass through screenProps as well for nested navigators
+    return <Component {...screenProps} screenProps={screenProps} navigation={navigation} />;
   }
 }


### PR DESCRIPTION
### Motivation

This formalizes passing `screenProps` to nested navigator screens by passing through the `screenProps` parameter to screen component in addition to pulling them out to props individually.

Prior to the change, this was accomplished by doing something like the following on the parent navigator, so that the `screenProps` would be available in nested navigator's screens:

```javascript
<AppNavigator
  screenProps={{
    exampleScreenProp: 'exampleScreenPropValue',
    screenProps: {
      exampleScreenProp: 'exampleScreenPropValue',
      // add additional levels for number of nested navigators
    },
  }}
/>
```

Open to suggestions, changes, etc. If accepted, a follow-up could change the behavior to only pass through the `screenProps` prop into screen component (along with `navigator`) instead of pulling them into separate params on the component (remove `{...screenProps}`).

### Test Plan

- Run `NavigationPlayground` example on both Android and iOS and verify that the `"exampleScreenPropValue"` is displayed on the nested navigator's screens.
- Integrate into own app and verify that the `screenProps` hack mentioned above can now be removed.