### PR TITLE
Implement `labelStyle` for `TabBarBottom`

### DIFF
--- a/docs/api/navigators/TabNavigator.md
+++ b/docs/api/navigators/TabNavigator.md
@@ -106,12 +106,16 @@ Several options get passed to the underlying router to modify navigation logic:
 - `inactiveTintColor` - label and icon color of the inactive tab
 - `inactiveBackgroundColor` - background color of the inactive tab
 - `style` - style object for the tab bar
+- `labelStyle` - style object for the tab label
 
 Example:
 
 ```js
 tabBarOptions: {
   activeTintColor: '#e91e63',
+  labelStyle: {
+    fontSize: 12,
+  },
   style: {
     backgroundColor: 'blue',
   }

--- a/docs/api/navigators/TabNavigator.md
+++ b/docs/api/navigators/TabNavigator.md
@@ -113,9 +113,7 @@ Example:
 ```js
 tabBarOptions: {
   activeTintColor: '#e91e63',
-  labelStyle: {
-    fontSize: 12,
-  },
+  labelStyle: { fontSize: 12 },
   style: {
     backgroundColor: 'blue',
   }

--- a/src/views/TabView/TabBarBottom.js
+++ b/src/views/TabView/TabBarBottom.js
@@ -39,7 +39,7 @@ type Props = {
   getLabelText: (scene: TabScene) => string;
   renderIcon: (scene: TabScene) => React.Element<*>;
   style: any;
-  labelStyle: any?;
+  labelStyle?: any;
 };
 
 export default class TabBarBottom extends PureComponent<DefaultProps, Props, void> {

--- a/src/views/TabView/TabBarBottom.js
+++ b/src/views/TabView/TabBarBottom.js
@@ -39,6 +39,7 @@ type Props = {
   getLabelText: (scene: TabScene) => string;
   renderIcon: (scene: TabScene) => React.Element<*>;
   style: any;
+  labelStyle: any?;
 };
 
 export default class TabBarBottom extends PureComponent<DefaultProps, Props, void> {
@@ -59,6 +60,7 @@ export default class TabBarBottom extends PureComponent<DefaultProps, Props, voi
       navigationState,
       activeTintColor,
       inactiveTintColor,
+      labelStyle,
     } = this.props;
     const { index } = scene;
     const { routes } = navigationState;
@@ -74,7 +76,7 @@ export default class TabBarBottom extends PureComponent<DefaultProps, Props, voi
     const label = this.props.getLabelText(scene);
     if (typeof label === 'string') {
       return (
-        <Animated.Text style={[styles.label, { color }]}>
+        <Animated.Text style={[styles.label, labelStyle, { color }]}>
           {label}
         </Animated.Text>
       );


### PR DESCRIPTION
This allows styling of the label component for `TabBarBottom` (analog to how it is already possible for  `TabBarTop`)