### PR TITLE
Add titleStyle header option

### DIFF
--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -121,6 +121,7 @@ All `navigationOptions` for the `StackNavigator`:
   - `right` - Custom React Element to display on the right side of the header
   - `left` - Custom React Element to display on the left side of the header
   - `style` - Style object for the navigation bar
+  - `titleStyle` - Style object for the title component
   - `tintColor` - Tint color for the header
 
 ### Navigator Props

--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -97,6 +97,8 @@ export type NavigationScreenOption<T> =
     router?: NavigationRouter) => T
   | T;
 
+export type Style = Object | number | false | void;
+
 export type HeaderConfig = {
   /**
    * Title string used by the navigation bar, or a custom component
@@ -121,7 +123,12 @@ export type HeaderConfig = {
   /**
    * Style passed into navigation bar container
    */
-  style?: Object,
+  style?: Style,
+
+  /**
+   * Style passed into navigation bar title
+   */
+  titleStyle?: Style,
 
   // // Style of title text
   // titleTextStyle?: $NavigationThunk<Object>,
@@ -254,7 +261,7 @@ export type NavigationStackViewConfig = {
   mode?: 'card' | 'modal',
   headerMode?: HeaderMode,
   headerComponent?: ReactClass<HeaderProps>,
-  cardStyle?: Object
+  cardStyle?: Style
 };
 
 export type NavigationStackRouterConfig = {

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -99,10 +99,19 @@ class Header extends React.Component<void, HeaderProps, void> {
     return undefined;
   }
 
+  _getHeaderTitleStyle(navigation: Navigation): ?object {
+    const header = this.props.router.getScreenConfig(navigation, 'header');
+    if (header && header.titleStyle) {
+      return header.titleStyle;
+    }
+    return undefined;
+  }
+
   _renderTitleComponent = (props: SubViewProps) => {
+    const titleStyle = this._getHeaderTitleStyle(props.navigation);
     const color = this._getHeaderTintColor(props.navigation);
     const title = this._getHeaderTitle(props.navigation);
-    return <HeaderTitle style={color && ({ color })}>{title}</HeaderTitle>;
+    return <HeaderTitle style={[color && { color }, titleStyle]}>{title}</HeaderTitle>;
   };
 
   _renderLeftComponent = (props: SubViewProps) => {


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

Explain the **motivation** for making this change. What existing problem does the pull request solve?

Changing the style of the individual title component required rolling your own title component for every screen.  This way developers can quickly add a single overriding style to their app, without having to define a new component for each case (ie still use the "string" version of the title option).

**Test plan (required)**

100% of current tests passing/flow results the same (122 errors).  No change to current examples.
