### PR TITLE
Don't allow transitioner to run two transitions at once (Fixes #160)

### DIFF
--- a/src/views/Transitioner.js
+++ b/src/views/Transitioner.js
@@ -95,6 +95,8 @@ class Transitioner extends React.Component<*, Props, State> {
     this._prevTransitionProps = null;
     this._transitionProps = buildTransitionProps(props, this.state);
     this._isMounted = false;
+    this._isTransitionRunning = false;
+    this._queuedTransition = null;
   }
 
   componentWillMount(): void {
@@ -121,6 +123,16 @@ class Transitioner extends React.Component<*, Props, State> {
       return;
     }
 
+    const indexHasChanged = nextProps.navigation.state.index !== this.props.navigation.state.index;
+    if (this._isTransitionRunning) {
+      this._queuedTransition = { nextProps, nextScenes, indexHasChanged };
+      return;
+    }
+
+    this._startTransition(nextProps, nextScenes, indexHasChanged);
+  }
+
+  _startTransition(nextProps: Props, nextScenes: Array<NavigationScene>, indexHasChanged: boolean) {
     const nextState = {
       ...this.state,
       scenes: nextScenes,
@@ -162,7 +174,7 @@ class Transitioner extends React.Component<*, Props, State> {
       ),
     ];
 
-    if (nextProps.navigation.state.index !== this.props.navigation.state.index) {
+    if (indexHasChanged) {
       animations.push(
         timing(
           position,
@@ -173,8 +185,8 @@ class Transitioner extends React.Component<*, Props, State> {
         ),
       );
     }
-
     // update scenes and play the transition
+    this._isTransitionRunning = true;
     this.setState(nextState, () => {
       nextProps.onTransitionStart && nextProps.onTransitionStart(
         this._transitionProps,
@@ -239,6 +251,16 @@ class Transitioner extends React.Component<*, Props, State> {
         this._transitionProps,
         prevTransitionProps,
       );
+      if (this._queuedTransition) {
+        this._startTransition(
+            this._queuedTransition.nextProps,
+            this._queuedTransition.nextScenes,
+            this._queuedTransition.indexHasChanged
+        );
+        this._queuedTransition = null;
+      } else {
+        this._isTransitionRunning = false;
+      }
     });
   }
 }


### PR DESCRIPTION
In order to set dynamic header buttons/titles, we need often need to do something like:

```javascript
componentDidMount () {
    const isDisabled = <someLogicUsingLocalState>;
    const params = {
            right: (
                <Button
                    onPress={() =>!isDisabled ? this.onSave() : null}
                >
                    <Text style={[styles.rightButtonTextStyle, isDisabled ? styles.disabledStyle : null]}>
                        Save
                    </Text>
                </Button>
            ),
        };
    this.props.navigation.setParams(params);
 }

// And our navigation options:

function getCurrentParams (state) {
    if (state.routes) {
        return getCurrentParams(state.routes[state.index]);
    }
    return state.params || {};
}

// ...some setup...

// main stack navigator navigationOptions
navigationOptions: {
    header: ({state}) => {
        // get the "deepest" current params.
        const currentParams = getCurrentParams(state);

        const left = currentParams.left;
        const right = currentParams.right;
        const style = currentParams.style;
        const tintColor = currentParams.tintColor;
        return { left, right, style, tintColor };
    }
 }
```

However, due to https://github.com/react-community/react-navigation/issues/160 this option doesn't work.  I believe the reason is that the quick firing of setParams causes Transitioner to try and run two transitions at the same time.  Specifically, _transitionProps gets updated mid-transition and  causes the app to get into a weird/unresponsive state.

This PR prevents Transitioner from queuing more than one transition at a time.  You can see the error by using https://github.com/react-community/react-navigation/compare/master...sportsaction:setParamsError and navigating to "Stack with Dynamic Header" in the NavigationPlayground example.  PR was tested using the same example/setup.

I'm still not super familiar with the codebase to let me know if this isn't the right track.