### PR TITLE
Replace usage of label with title prop for Buttons

### DIFF
--- a/docs/api/navigators/TabNavigator.md
+++ b/docs/api/navigators/TabNavigator.md
@@ -21,7 +21,7 @@ class MyHomeScreen extends React.Component {
     return (
       <Button
         onPress={() => this.props.navigation.navigate('Notifications')}
-        label="Go to notifications"
+        title="Go to notifications"
       />
     );
   }
@@ -44,7 +44,7 @@ class MyNotificationsScreen extends React.Component {
     return (
       <Button
         onPress={() => this.props.navigation.goBack()}
-        label="Go back home"
+        title="Go back home"
       />
     );
   }


### PR DESCRIPTION
This example doesn't compile locally for a few reasons:
1. I don't have the same file structure, so I don't have the images being used in my AwesomeProject (tutorial example used everywhere)
2. The Buttons are expecting a string-typed title prop

The second one seems like a bug to me, so I'm proposing we fix it. The first one seems like it's part of the context of the example, so it makes sense to leave it.

**Test plan (required)**

testinprod