### PR TITLE
withCachedChildNavigation basically did not cache

### DIFF
--- a/src/withCachedChildNavigation.js
+++ b/src/withCachedChildNavigation.js
@@ -42,7 +42,9 @@ export default function withCachedChildNavigation<T: Props>(Comp: ReactClass<T>)
       navigation: NavigationScreenProp<NavigationState, NavigationAction>
     ) => {
       // Update props for each child route
-      this._childNavigationProps = {};
+      if (!this._childNavigationProps) {
+        this._childNavigationProps = {};
+      }
       navigation.state.routes.forEach((route: *) => {
         const childNavigation = this._childNavigationProps[route.key];
         if (childNavigation && childNavigation.state === route) {


### PR DESCRIPTION
Fixes #159. Any ideas on testing this welcome.

Also, I'm unsure if routes can change. If that is the case, we could add logic to clean out the cache of no-longer-used routes.