### PR TITLE
createNavigationContainer: cache previously used navigation

### DIFF
--- a/src/createNavigationContainer.js
+++ b/src/createNavigationContainer.js
@@ -148,10 +148,13 @@ const createNavigationContainer = (
     render() {
       let navigation = this.props.navigation;
       if (this._isStateful()) {
-        navigation = addNavigationHelpers({
-          dispatch: this.dispatch.bind(this),
-          state: this.state.nav,
-        });
+        if (!this._navigation || this._navigation.state !== this.state.nav) {
+            this._navigation = addNavigationHelpers({
+              dispatch: this.dispatch.bind(this),
+              state: this.state.nav,
+            });
+        }
+        navigation = this._navigation;
       }
       return (
         <Component


### PR DESCRIPTION
When your favorite navigation container is used with changing `screenProps`, each render results in the creation of a new `navigation` instance. Example:

```js
const MyNav = StackNavigator({...});
function App({changingProp}) {
    return <MyNav screenProps={{changingProp}} />;
}
```

Now, when you're having routes that don't really use those `screenProps` but do pass on `navigation` to otherwise pure components, those components get unnecessarily re-rendered.

This fix caches the last-built `navigation` property on the container HOC, and only updates it when the actual state changes -- similarly to how `withCachedChildNavigation` works.