### PR TITLE
Don't render back button label just yet

### DIFF
--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -119,10 +119,11 @@ class Header extends React.Component<void, HeaderProps, void> {
       return null;
     }
     const tintColor = this._getHeaderTintColor(props.navigation);
-    const previousNavigation = addNavigationHelpers({
-      ...props.navigation,
-      state: props.scenes[props.scene.index - 1].route,
-    });
+// @todo(grabbou): Implement truncating back again, then uncomment
+//     const previousNavigation = addNavigationHelpers({
+//       ...props.navigation,
+//       state: props.scenes[props.scene.index - 1].route,
+//     });
 //  const backButtonTitle = this._getHeaderTitle(previousNavigation);
     return (
       <HeaderBackButton

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -123,12 +123,11 @@ class Header extends React.Component<void, HeaderProps, void> {
       ...props.navigation,
       state: props.scenes[props.scene.index - 1].route,
     });
-    const backButtonTitle = this._getHeaderTitle(previousNavigation);
+//  const backButtonTitle = this._getHeaderTitle(previousNavigation);
     return (
       <HeaderBackButton
         onPress={props.onNavigateBack}
         tintColor={tintColor}
-        title={backButtonTitle}
       />
     );
   };


### PR DESCRIPTION
The back button label works prefectly fine, however the PR that was implementing truncating of too long titles has been reverted due to issues on Android: https://github.com/react-community/react-navigation/pull/158

Since @satya164 is about to release a new version, please consider merging that one so that people don't end up having issues with back button being too long.

The fix I am working on is to land tomorrow latest, but this is in case one wants to release something in the meantime.
