### PR TITLE
enable `showLabel` prop in `tabBarBottom`

### DIFF
--- a/docs/api/navigators/TabNavigator.md
+++ b/docs/api/navigators/TabNavigator.md
@@ -105,6 +105,7 @@ Several options get passed to the underlying router to modify navigation logic:
 - `activeBackgroundColor` - background color of the active tab
 - `inactiveTintColor` - label and icon color of the inactive tab
 - `inactiveBackgroundColor` - background color of the inactive tab
+- `showLabel` - whether to show label for tab, default is true
 - `style` - style object for the tab bar
 - `labelStyle` - style object for the tab label
 

--- a/src/views/TabView/TabBarBottom.js
+++ b/src/views/TabView/TabBarBottom.js
@@ -26,6 +26,7 @@ type DefaultProps = {
   activeBackgroundColor: string;
   inactiveTintColor: string;
   inactiveBackgroundColor: string;
+  showLabel: boolean;
 };
 
 type Props = {
@@ -38,6 +39,7 @@ type Props = {
   jumpToIndex: (index: number) => void;
   getLabelText: (scene: TabScene) => string;
   renderIcon: (scene: TabScene) => React.Element<*>;
+  showLabel: boolean;
   style: any;
   labelStyle?: any;
 };
@@ -50,6 +52,7 @@ export default class TabBarBottom extends PureComponent<DefaultProps, Props, voi
     activeBackgroundColor: 'transparent',
     inactiveTintColor: '#929292', // Default inactive tint color in iOS 10
     inactiveBackgroundColor: 'transparent',
+    showLabel: true,
   };
 
   props: Props;
@@ -61,7 +64,11 @@ export default class TabBarBottom extends PureComponent<DefaultProps, Props, voi
       activeTintColor,
       inactiveTintColor,
       labelStyle,
+      showLabel,
     } = this.props;
+    if (showLabel === false) {
+      return null;
+    }
     const { index } = scene;
     const { routes } = navigationState;
     // Prepend '-1', so there are always at least 2 items in inputRange


### PR DESCRIPTION
This PR adds the `showLabel` option to tabBarBottom for projects like mine that only want icons visible in the bottom tab bar.

It should be safe, since it is an exact copy/paste from `tabBarTop`. See https://github.com/react-community/react-navigation/blob/master/src/views/TabView/TabBarTop.js#L66

**Test plan (required)**
- All tests passed, though I don't know if any tests have been written to cover `TabBarBottom`

