### PR TITLE
Fixes several back button issues

### DIFF
--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -323,7 +323,6 @@ const styles = StyleSheet.create({
     left: 0,
     position: 'absolute',
     top: 0,
-    backgroundColor: 'red',
   },
   right: {
     bottom: 0,

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -119,16 +119,21 @@ class Header extends React.Component<void, HeaderProps, void> {
       return null;
     }
     const tintColor = this._getHeaderTintColor(props.navigation);
-    const previousNavigation = addNavigationHelpers({
-      ...props.navigation,
-      state: props.scenes[props.scene.index - 1].route,
-    });
-    const backButtonTitle = this._getHeaderTitle(previousNavigation);
+    // @todo(grabobu):
+    // We have implemented support for back button label (which works 100% fine),
+    // but when title is too long, it will overlap the <HeaderTitle />.
+    // We had to revert the PR implementing that because of Android issues,
+    // I will land it this week and re-enable that for next release.
+    //
+    // const previousNavigation = addNavigationHelpers({
+    //   ...props.navigation,
+    //   state: props.scenes[props.scene.index - 1].route,
+    // });
+    // const backButtonTitle = this._getHeaderTitle(previousNavigation);
     return (
       <HeaderBackButton
         onPress={props.onNavigateBack}
         tintColor={tintColor}
-        title={backButtonTitle}
       />
     );
   };
@@ -318,6 +323,7 @@ const styles = StyleSheet.create({
     left: 0,
     position: 'absolute',
     top: 0,
+    backgroundColor: 'red',
   },
   right: {
     bottom: 0,

--- a/src/views/HeaderBackButton.js
+++ b/src/views/HeaderBackButton.js
@@ -27,7 +27,11 @@ const HeaderBackButton = ({ onPress, title, tintColor }: Props) => (
   >
     <View style={styles.container}>
       <Image
-        style={[styles.button, { tintColor }]}
+        style={[
+          styles.icon,
+          title && styles.iconWithTitle,
+          { tintColor },
+        ]}
         source={require('./assets/back-icon.png')}
       />
       {Platform.OS === 'ios' && title && (
@@ -58,13 +62,16 @@ const styles = StyleSheet.create({
   },
   title: {
     fontSize: 17,
+    paddingRight: 10,
   },
-  button: Platform.OS === 'ios'
+  icon: Platform.OS === 'ios'
     ? {
-      height: 21,
-      width: 13,
-      margin: 10,
-      marginRight: 5,
+      height: 20,
+      width: 12,
+      marginLeft: 10,
+      marginRight: 22,
+      marginVertical: 12,
+      resizeMode: 'contain',
       transform: [{ scaleX: I18nManager.isRTL ? -1 : 1 }],
     }
     : {
@@ -74,6 +81,11 @@ const styles = StyleSheet.create({
       resizeMode: 'contain',
       transform: [{ scaleX: I18nManager.isRTL ? -1 : 1 }],
     },
+  iconWithTitle: Platform.OS === 'ios'
+    ? {
+      marginRight: 5,
+    }
+    : {},
 });
 
 export default HeaderBackButton;


### PR DESCRIPTION
There are few features/fixes included in this PR:

- Disable back button label as it's not read yet - it renders perfectly fine, but we haven't landed truncating yet, which is crucial for the production apps. I left it in master to iterate faster, but as @satya164 is planning to do the release, I have temporarily turned it off. I am also working on mimicking natural iOS animations as much as possible, hopefully this lands later this week.

- Fix layout issues on iOS. My changes introduced last week that were making an icon looking just like on a native app changed the size of container - the touchable area was no longer 44x44 as recommended by Apple, but 12x20 (size of an icon) + left margin of 10 points. This pull request fixes that by adjusting sizes.
<img width="394" alt="screen shot 2017-02-08 at 18 29 27" src="https://cloud.githubusercontent.com/assets/2464966/22749362/5248b466-ee2d-11e6-88c0-6d5365c0feaf.png">

- Add additional style for `icon with label` - this is the case for the future, as attached below. In this case, side margins are equal to 10.
<img width="393" alt="screen shot 2017-02-08 at 18 30 12" src="https://cloud.githubusercontent.com/assets/2464966/22749317/30e0ba6c-ee2d-11e6-8cb3-c082a1b9605b.png">
