### PR TITLE
Pass through screenProps to nested navigators

### DIFF
--- a/docs/api/navigators/DrawerNavigator.md
+++ b/docs/api/navigators/DrawerNavigator.md
@@ -130,6 +130,6 @@ The navigator component created by `DrawerNavigator(...)` takes the following pr
  });
  
  <DrawerNav
-   screenProps={/* these will get passed to the screen components */}
+   screenProps={/* this prop will get passed to the screen components as this.props.screenProps */}
  />
  ```

--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -139,7 +139,7 @@ The navigator component created by `StackNavigator(...)` takes the following pro
  });
 
  <SomeStack
-   screenProps={/* these will get passed to the screen components */}
+   screenProps={/* this prop will get passed to the screen components as this.props.screenProps */}
  />
  ```
 

--- a/docs/api/navigators/TabNavigator.md
+++ b/docs/api/navigators/TabNavigator.md
@@ -162,7 +162,7 @@ The navigator component created by `TabNavigator(...)` takes the following props
  });
  
  <TabNav
-   screenProps={/* these will get passed to the screen components */}
+   screenProps={/* this prop will get passed to the screen components as this.props.screenProps */}
  />
  ```
  

--- a/src/views/SceneView.js
+++ b/src/views/SceneView.js
@@ -11,12 +11,12 @@ import type {
 
 type Props = {
   screenProps?: {};
+  hideScreenPropsWarning?: boolean;
   navigation: NavigationScreenProp<NavigationState, NavigationAction>;
   component: ReactClass<*>;
 };
 
 export default class SceneView extends PureComponent<void, Props, void> {
-
   static childContextTypes = {
     navigation: React.PropTypes.object.isRequired,
   };
@@ -29,8 +29,30 @@ export default class SceneView extends PureComponent<void, Props, void> {
     };
   }
 
+  componentWillMount() {
+    if (this.props.screenProps !== undefined && !this.props.hideScreenPropsWarning) {
+      console.warn(
+        'Behaviour of screenProps has changed from initial beta. ' +
+        'Components will now receive it as `this.props.screenProps` instead.\n' +
+        'Pass `hideScreenPropsWarning` to hide this warning.'
+      );
+    }
+  }
+
   render() {
-    const { screenProps, navigation, component: Component } = this.props;
-    return <Component {...screenProps} navigation={navigation} />;
+    const {
+      hideScreenPropsWarning,
+      screenProps,
+      navigation,
+      component: Component,
+    } = this.props;
+
+    return (
+      <Component
+        hideScreenPropsWarning={hideScreenPropsWarning}
+        screenProps={screenProps}
+        navigation={navigation}
+      />
+    );
   }
 }


### PR DESCRIPTION
This changes the behaviour of screenProps so that the props no longer get splatted.
Components will receive this as `this.props.screenProps`.
