### PR TITLE
React Native Buttons use title, not label.

### DIFF
--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -15,7 +15,7 @@ class MyHomeScreen extends React.Component {
     return (
       <Button
         onPress={() => this.props.navigation.navigate('Profile', {name: 'Lucy'})}
-        label="Go to Lucy's profile"
+        title="Go to Lucy's profile"
       />
     );
   }


### PR DESCRIPTION
When going through the example code on this page, I got an error and noticed that the docs used **label** instead of **title**. This pull is to fix this in the example code so it actually runs.