### PR TITLE
Fix style prop for header

### DIFF
--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -45,7 +45,6 @@ export type HeaderProps = NavigationSceneRendererProps & {
   renderTitleComponent: SubViewRenderer,
   tintColor: ?string,
   router: NavigationRouter,
-  style?: any,
 };
 
 type SubViewName = 'left' | 'title' | 'right';
@@ -230,7 +229,6 @@ class Header extends React.Component<void, HeaderProps, void> {
         style={[
           styles.item,
           styles[name],
-          props.style,
           styleInterpolator(props),
         ]}
       >


### PR DESCRIPTION
Fixes #189

When we introduced style for header, it got included with `NavigationSceneRendererProps` causing some glitches for title/left/right components.

It is wise to remove it as we do not use it at all anywhere and each of the components (left/right/title) have its own custom style (e.g. `titleStyle`)

Test plan:

Set #189 repro and compare fixed header with the one posted in the issue.

<img width="384" alt="screen shot 2017-02-09 at 09 44 04" src="https://cloud.githubusercontent.com/assets/2464966/22775583/a15ff58a-eeac-11e6-90d5-c2e4907880a8.png">
