### PR TITLE
[FLOW] Fix missing "type" in flow import.

### DIFF
--- a/src/views/withNavigation.js
+++ b/src/views/withNavigation.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import hoistStatics from 'hoist-non-react-statics';
 
-import { ContextWithNavigation } from '../TypeDefinition';
+import type { ContextWithNavigation } from '../TypeDefinition';
 
 export default function withNavigation(Component: ReactClass<T>) {
   const componentWithNavigation = (props: T, { navigation }: ContextWithNavigation) => (


### PR DESCRIPTION
Fixes: Named import from module `../TypeDefinition` `ContextWithNavigation` is a type, but not a value. In order to import it, please use `import type`.

Please provide enough information so that others can review your pull request:
**Flow complains that we aren't using the import type syntax.**

Explain the **motivation** for making this change. What existing problem does the pull request solve?
**Flow requires import type syntax up until the current version (at least).**

**Test plan (required)**
Flowtype change - not tested as far as I can see.
