### PR TITLE
Add `showIcon` to `tabBarOptions` so that icons can be hidden on iOS

### DIFF
--- a/src/views/TabView/TabBarBottom.js
+++ b/src/views/TabView/TabBarBottom.js
@@ -145,7 +145,7 @@ export default class TabBarBottom extends PureComponent<DefaultProps, Props, voi
           const justifyContent = this.props.showIcon ? 'flex-end' : 'center';
           return (
             <TouchableWithoutFeedback key={route.key} onPress={() => jumpToIndex(index)}>
-              <Animated.View style={[styles.tab, { backgroundColor }, { justifyContent }]}>
+              <Animated.View style={[styles.tab, { backgroundColor, justifyContent }]}>
                 {this._renderIcon(scene)}
                 {this._renderLabel(scene)}
               </Animated.View>

--- a/src/views/TabView/TabBarBottom.js
+++ b/src/views/TabView/TabBarBottom.js
@@ -42,6 +42,7 @@ type Props = {
   showLabel: boolean;
   style: any;
   labelStyle?: any;
+  showIcon: boolean;
 };
 
 export default class TabBarBottom extends PureComponent<DefaultProps, Props, void> {
@@ -53,6 +54,7 @@ export default class TabBarBottom extends PureComponent<DefaultProps, Props, voi
     inactiveTintColor: '#929292', // Default inactive tint color in iOS 10
     inactiveBackgroundColor: 'transparent',
     showLabel: true,
+    showIcon: true,
   };
 
   props: Props;
@@ -98,7 +100,11 @@ export default class TabBarBottom extends PureComponent<DefaultProps, Props, voi
       activeTintColor,
       inactiveTintColor,
       renderIcon,
+      showIcon,
     } = this.props;
+    if (showIcon === false) {
+      return null;
+    }
     return (
       <TabBarIcon
         position={position}
@@ -136,9 +142,10 @@ export default class TabBarBottom extends PureComponent<DefaultProps, Props, voi
             inputRange,
             outputRange,
           });
+          const justifyContent = this.props.showIcon ? 'flex-end' : 'center';
           return (
             <TouchableWithoutFeedback key={route.key} onPress={() => jumpToIndex(index)}>
-              <Animated.View style={[styles.tab, { backgroundColor }]}>
+              <Animated.View style={[styles.tab, { backgroundColor }, { justifyContent }]}>
                 {this._renderIcon(scene)}
                 {this._renderLabel(scene)}
               </Animated.View>


### PR DESCRIPTION
See sample and use case [here](https://cl.ly/2h0O1M3o0i0k).