### PR TITLE
Fixes TabBar upperCaseLabel option

### DIFF
--- a/src/views/TabView/TabBarTop.js
+++ b/src/views/TabView/TabBarTop.js
@@ -81,7 +81,7 @@ export default class TabBarTop extends PureComponent<DefaultProps, Props, void> 
     if (typeof label === 'string') {
       return (
         <Animated.Text style={[styles.label, { color }, labelStyle]}>
-          {label}
+          {upperCaseLabel ? label.toUpperCase() : label}
         </Animated.Text>
       );
     }


### PR DESCRIPTION
The TabBar has a upperCaseLabel option, default as true on android but the labels were never uppercased. 

This uppercases them in the render method.