### PR TITLE
Export Header component

### DIFF
--- a/src/react-navigation.js
+++ b/src/react-navigation.js
@@ -26,6 +26,7 @@ module.exports = {
   get CardStack() { return require('./views/CardStack').default; },
   get DrawerView() { return require('./views/Drawer/DrawerView').default; },
   get TabView() { return require('./views/TabView/TabView').default; },
+  get Header() { return require('./views/Header'); },
 
   // HOCs
   get withNavigation() { return require('./views/withNavigation').default; },


### PR DESCRIPTION
Hi,

This Pull Request allow the `Header` component to be imported as it was with `NavigationExperimental` 

```javascript
import { Header } from 'react-navigation';
```


See previous NavigationExperimental exports
https://github.com/facebook/react-native/blob/master/Libraries/NavigationExperimental/NavigationExperimental.js#L31

P.S: i know, the syntax is not the same as the others exports, because the Header component don't use `default` export.

If you have suggestion or remarks, please don't hesitate.

Thanks ;)

Kenny