### PR TITLE
Header: Use static properties `Title` and `BackButton`

### DIFF
--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -111,7 +111,7 @@ class Header extends React.Component<void, HeaderProps, void> {
     const titleStyle = this._getHeaderTitleStyle(props.navigation);
     const color = this._getHeaderTintColor(props.navigation);
     const title = this._getHeaderTitle(props.navigation);
-    return <HeaderTitle style={[color ? { color } : null, titleStyle]}>{title}</HeaderTitle>;
+    return <Header.Title style={[color ? { color } : null, titleStyle]}>{title}</Header.Title>;
   };
 
   _renderLeftComponent = (props: SubViewProps): ?React.Element<HeaderBackButton> => {
@@ -121,7 +121,7 @@ class Header extends React.Component<void, HeaderProps, void> {
     const tintColor = this._getHeaderTintColor(props.navigation);
     // @todo(grabobu):
     // We have implemented support for back button label (which works 100% fine),
-    // but when title is too long, it will overlap the <HeaderTitle />.
+    // but when title is too long, it will overlap the <Header.Title />.
     // We had to revert the PR implementing that because of Android issues,
     // I will land it this week and re-enable that for next release.
     //
@@ -131,7 +131,7 @@ class Header extends React.Component<void, HeaderProps, void> {
     // });
     // const backButtonTitle = this._getHeaderTitle(previousNavigation);
     return (
-      <HeaderBackButton
+      <Header.BackButton
         onPress={props.onNavigateBack}
         tintColor={tintColor}
       />


### PR DESCRIPTION
...instead of imported `HeaderTitle` and `HeaderBackButton`

**Motivation**

Allow overriding the HeaderTitle and HeaderBackButton component easily.
The header API already exposes these properties but does not use them to render the underlying components title and back button.


**Test**

Tested with the navigation playground project:

Added the following to `SimpleStack.js`:

```diff
diff --git a/examples/NavigationPlayground/js/SimpleStack.js b/examples/NavigationPlayground/js/SimpleStack.js
index 3a0a3d7..d85c48e 100644
--- a/examples/NavigationPlayground/js/SimpleStack.js
+++ b/examples/NavigationPlayground/js/SimpleStack.js
@@ -9,9 +9,14 @@ import {
 } from 'react-native';
 import {
   StackNavigator,
+  CardStack,
 } from 'react-navigation';
 import SampleText from './SampleText';

+CardStack.Header.BackButton = ({ onPress }) => (
+  <Button title="Back" onPress={onPress}/>
+);
+
 const MyNavScreen = ({ navigation, banner }) => (
   <ScrollView>
     <SampleText>{banner}</SampleText>
```

produces the following experience:

| iOS | Android |
|-----|--------|
| ![ios mov](https://cloud.githubusercontent.com/assets/309515/22990236/60cadd58-f36d-11e6-9057-cc679c0a654c.gif) | ![android mov](https://cloud.githubusercontent.com/assets/309515/22990228/57f36880-f36d-11e6-9ffe-d38ca6866fd6.gif) |
