### PR TITLE
Update react-native-tab-view

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "hoist-non-react-statics": "^1.2.0",
     "path-to-regexp": "^1.7.0",
     "react-native-drawer-layout": "^1.1.0",
-    "react-native-tab-view": "^0.0.55"
+    "react-native-tab-view": "^0.0.56"
   },
   "jest": {
     "notify": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3864,9 +3864,9 @@ react-native-drawer-layout@^1.1.0:
     autobind-decorator "^1.3.2"
     react-native-dismiss-keyboard "1.0.0"
 
-react-native-tab-view@^0.0.55:
-  version "0.0.55"
-  resolved "https://registry.yarnpkg.com/react-native-tab-view/-/react-native-tab-view-0.0.55.tgz#6e82c50f916b46e0a5af2f9748e6aca36d58f7ad"
+react-native-tab-view@^0.0.56:
+  version "0.0.56"
+  resolved "https://registry.yarnpkg.com/react-native-tab-view/-/react-native-tab-view-0.0.56.tgz#7417a1f6502deef49abf58ba76a1cde213abbbf1"
 
 react-native-vector-icons@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Fixes #209 

Diff: https://github.com/react-native-community/react-native-tab-view/compare/v0.0.55...v0.0.56
Release notes: https://github.com/react-native-community/react-native-tab-view/releases/tag/v0.0.56

Basically some fixes, accessibility support and added some tests.

Tested this on the playground app in simulator.