### PR TITLE
Make it possible for a screen to set gesturesEnabled

### DIFF
--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -125,6 +125,7 @@ All `navigationOptions` for the `StackNavigator`:
   - `style` - Style object for the navigation bar
   - `titleStyle` - Style object for the title component
   - `tintColor` - Tint color for the header
+- `gesturesEnabled` - Whether you can use gestures to dismiss this screen. Defaults to true on iOS, false on Android
 
 ### Navigator Props
 

--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -125,7 +125,8 @@ All `navigationOptions` for the `StackNavigator`:
   - `style` - Style object for the navigation bar
   - `titleStyle` - Style object for the title component
   - `tintColor` - Tint color for the header
-- `gesturesEnabled` - Whether you can use gestures to dismiss this screen. Defaults to true on iOS, false on Android
+- `cardStack` - a config object for the card stack:
+  - `gesturesEnabled` - Whether you can use gestures to dismiss this screen. Defaults to true on iOS, false on Android
 
 ### Navigator Props
 

--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -185,6 +185,11 @@ export type NavigationScreenOptions = {
    * Options passed to the drawer for this screen.
    */
   drawer?: NavigationScreenOption<DrawerConfig>;
+  /**
+   * Whether you can use gestures to dismiss this screen.
+   * Defaults to true on iOS, false on Android.
+   */
+  gesturesEnabled?: bool,
 };
 
 export type NavigationScreenConfig = {

--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -167,6 +167,14 @@ export type DrawerConfig = {
   label?: string;
 };
 
+export type CardStackConfig = {
+  /**
+   * Whether you can use gestures to dismiss this screen.
+   * Defaults to true on iOS, false on Android.
+   */
+  gesturesEnabled?: bool;
+};
+
 export type NavigationScreenOptions = {
   /**
    * Title is rendered by certain navigators, e.g. the tab navigator,
@@ -186,10 +194,9 @@ export type NavigationScreenOptions = {
    */
   drawer?: NavigationScreenOption<DrawerConfig>;
   /**
-   * Whether you can use gestures to dismiss this screen.
-   * Defaults to true on iOS, false on Android.
+   * Options passed to the card stack for this screen.
    */
-  gesturesEnabled?: bool,
+  cardStack?: NavigationScreenOption<CardStackConfig>;
 };
 
 export type NavigationScreenConfig = {

--- a/src/views/CardStack.js
+++ b/src/views/CardStack.js
@@ -336,10 +336,9 @@ class CardStack extends Component<DefaultProps, Props, void> {
       'cardStack'
     ) || {};
     const gesturesEnabledConfig = cardStackConfig.gesturesEnabled;
-    const gesturesEnabled =
-      (gesturesEnabledConfig === true || gesturesEnabledConfig === false)
-        ? gesturesEnabledConfig
-        : Platform.OS === 'ios';
+    const gesturesEnabled = typeof gesturesEnabledConfig === 'boolean' ?
+      gesturesEnabledConfig :
+      Platform.OS === 'ios';
     if (gesturesEnabled) {
       let onNavigateBack = null;
       if (this.props.navigation.state.index !== 0) {

--- a/src/views/CardStack.js
+++ b/src/views/CardStack.js
@@ -331,10 +331,11 @@ class CardStack extends Component<DefaultProps, Props, void> {
 
     let panHandlers = null;
 
-    const gesturesEnabledConfig = this.props.router.getScreenConfig(
-      props.navigation,
-      'gesturesEnabled',
-    );
+    const cardStackConfig = this.props.router.getScreenConfig(
+      transitionProps.navigation,
+      'cardStack'
+    ) || {};
+    const gesturesEnabledConfig = cardStackConfig.gesturesEnabled;
     const gesturesEnabled =
       (gesturesEnabledConfig === true || gesturesEnabledConfig === false)
         ? gesturesEnabledConfig

--- a/src/views/CardStack.js
+++ b/src/views/CardStack.js
@@ -335,6 +335,9 @@ class CardStack extends Component<DefaultProps, Props, void> {
       props.navigation,
       'cardStack'
     ) || {};
+
+    // On iOS, the default behavior is to allow the user to pop a route by
+    // swiping the corresponding Card away. On Android this is off by default
     const gesturesEnabledConfig = cardStackConfig.gesturesEnabled;
     const gesturesEnabled = typeof gesturesEnabledConfig === 'boolean' ?
       gesturesEnabledConfig :

--- a/src/views/CardStack.js
+++ b/src/views/CardStack.js
@@ -52,11 +52,6 @@ type Props = {
   style: Style,
   gestureResponseDistance?: ?number,
   /**
-   * If true, enable navigating back by swiping (see CardStackPanResponder).
-   * TODO move this to TransitionConfig.
-   */
-  gesturesEnabled: ?boolean,
-  /**
    * Optional custom animation when transitioning between screens.
    */
   transitionConfig?: () => TransitionConfig,
@@ -64,7 +59,6 @@ type Props = {
 
 type DefaultProps = {
   mode: 'card' | 'modal',
-  gesturesEnabled: boolean,
   headerComponent: ReactClass<*>,
 };
 
@@ -117,11 +111,6 @@ class CardStack extends Component<DefaultProps, Props, void> {
     transitionConfig: PropTypes.func,
 
     /**
-     * Enable gestures. Default value is true on iOS, false on Android.
-     */
-    gesturesEnabled: PropTypes.bool,
-
-    /**
      * The navigation prop, including the state and the dispatcher for the back
      * action. The dispatcher must handle the back action
      * ({ type: NavigationActions.BACK }), and the navigation state has this shape:
@@ -149,7 +138,6 @@ class CardStack extends Component<DefaultProps, Props, void> {
 
   static defaultProps: DefaultProps = {
     mode: 'card',
-    gesturesEnabled: Platform.OS === 'ios',
     headerComponent: Header,
   };
 
@@ -343,7 +331,15 @@ class CardStack extends Component<DefaultProps, Props, void> {
 
     let panHandlers = null;
 
-    if (this.props.gesturesEnabled) {
+    const gesturesEnabledConfig = this.props.router.getScreenConfig(
+      props.navigation,
+      'gesturesEnabled',
+    );
+    const gesturesEnabled =
+      (gesturesEnabledConfig === true || gesturesEnabledConfig === false)
+        ? gesturesEnabledConfig
+        : Platform.OS === 'ios';
+    if (gesturesEnabled) {
       let onNavigateBack = null;
       if (this.props.navigation.state.index !== 0) {
         onNavigateBack = () => this.props.navigation.dispatch(

--- a/src/views/CardStack.js
+++ b/src/views/CardStack.js
@@ -332,7 +332,7 @@ class CardStack extends Component<DefaultProps, Props, void> {
     let panHandlers = null;
 
     const cardStackConfig = this.props.router.getScreenConfig(
-      transitionProps.navigation,
+      props.navigation,
       'cardStack'
     ) || {};
     const gesturesEnabledConfig = cardStackConfig.gesturesEnabled;


### PR DESCRIPTION
Context for the problem I was facing #383. A related `gesturesEnabled` PR with some additional context in #292.

In StackNavigator, sometimes it's useful to prevent somebody from dismissing a route. My use case is a log-in screen that I display as a modal above the rest of my app.

Test plan: I hooked this into my own app, and verified that I was able to set gesturesEnabled via navigation options. flow/jest pass