### PR TITLE
pass navigation prop to TabBarComponent

### DIFF
--- a/src/views/TabView/TabView.js
+++ b/src/views/TabView/TabView.js
@@ -120,6 +120,7 @@ class TabView extends PureComponent<void, Props, void> {
       <TabBarComponent
         {...props}
         {...tabBarOptions}
+        navigation={this.props.navigation}
         getLabelText={this._getLabelText}
         renderIcon={this._renderIcon}
         animationEnabled={animationEnabled}


### PR DESCRIPTION
As the title says, in case we specify a custom TabBarComponent for a TabNavigator, `navigation` becomes available.

It is especially necessary if we have a TabNavigator nested in another navigator: a custom NavBar with a button to navigate outside of the tabs needs to `navigation.navigate(...)`