### PR TITLE
[WIP] Add an onChange callback prop to the navigationOptions.tabBar

### DIFF
--- a/docs/api/navigators/DrawerNavigator.md
+++ b/docs/api/navigators/DrawerNavigator.md
@@ -117,6 +117,34 @@ contentOptions: {
 }
 ```
 
+### Screen Navigation Options
+
+Usually you define static `navigationOptions` on your screen component. For example:
+
+```jsx
+class ProfileScreen extends React.Component {
+
+  static navigationOptions = {
+
+    title: ({ state }) => `${state.params.name}'s Profile!`,
+
+    drawer: {
+      icon: (
+        <Image src={require('./my-icon.png')} />
+      ),
+    },
+  };
+  ...
+```
+
+All `navigationOptions` for the `DrawerNavigator`:
+
+- `title` - a title (string) of the scene
+- `drawer` - a config object for the drawer:
+  - `label` - String, React Element or a function that given `{ focused: boolean, tintColor: string }` returns a React.Element, to display in drawer sidebar. When undefined, scene `title` is used
+  - `icon` - React Element or a function, that given `{ focused: boolean, tintColor: string }` returns a React.Element, to display in drawer sidebar
+
+
 ### Navigator Props
 
 The navigator component created by `DrawerNavigator(...)` takes the following props:

--- a/docs/api/navigators/Navigators.md
+++ b/docs/api/navigators/Navigators.md
@@ -48,6 +48,10 @@ When rendering one of the included navigators, the navigation prop is optional. 
 
 For the purpose of convenience, the built-in navigators have this ability because behind the scenes they use `createNavigationContainer`. Usually, navigators require a navigation prop in order to function.
 
+### `onNavigationStateChange(prevState, newState)`
+
+Sometimes it is useful to know when navigation state managed by the top-level navigator changes. For this purpose, this function gets called every time with the previous state and the new state of the navigation.
+
 ### `containerOptions`
 
 These options can be used to configure a navigator when it is used at the top level.

--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -116,14 +116,14 @@ class ProfileScreen extends React.Component {
 
 All `navigationOptions` for the `StackNavigator`:
 
-- `title` - a title (string) displayed in the header
+- `title` - a title (string) of the scene
 - `header` - a config object for the header bar:
   - `visible` - Boolean toggle of header visibility. Only works when `headerMode` is `screen`.
-  - `title` - Title string used by the navigation bar, or a custom React component
-  - `backTitle` - Title string used by the back button or `null` to disable label. Defaults to `title` value by default
-  - `right` - Custom React Element to display on the right side of the header
-  - `left` - Custom React Element to display on the left side of the header
-  - `style` - Style object for the navigation bar
+  - `title` - String or React Element used by the header. Defaults to scene `title`
+  - `backTitle` - Title string used by the back button on iOS or `null` to disable label. Defaults to scene `title`
+  - `right` - React Element to display on the right side of the header
+  - `left` - React Element to display on the left side of the header
+  - `style` - Style object for the header
   - `titleStyle` - Style object for the title component
   - `tintColor` - Tint color for the header
 - `cardStack` - a config object for the card stack:

--- a/docs/api/navigators/TabNavigator.md
+++ b/docs/api/navigators/TabNavigator.md
@@ -149,6 +149,34 @@ tabBarOptions: {
 }
 ```
 
+### Screen Navigation Options
+
+Usually you define static `navigationOptions` on your screen component. For example:
+
+```jsx
+class ProfileScreen extends React.Component {
+
+  static navigationOptions = {
+
+    title: ({ state }) => `${state.params.name}'s Profile!`,
+
+    tabBar: ({ state, setParams }) => ({
+      icon: (
+        <Image src={require('./my-icon.png')} />
+      ),
+    }),
+  };
+  ...
+```
+
+All `navigationOptions` for the `TabNavigator`:
+
+- `title` - a title (string) of the scene
+- `tabBar` - a config object for the tab bar:
+  - `visible` - Boolean toggle of tab bar visibility
+  - `icon` - React Element or a function that given `{ focused: boolean, tintColor: string }` returns a React.Element, to display in tab bar
+  - `label` - Title string of a tab displayed in the tab bar. When undefined, scene `title` is used. To hide, see `tabBarOptions.showLabel` in the previous section
+  
 ### Navigator Props
 
 The navigator component created by `TabNavigator(...)` takes the following props:

--- a/docs/guides/Screen-Nav-Options.md
+++ b/docs/guides/Screen-Nav-Options.md
@@ -97,26 +97,26 @@ The 2nd argument passed to the function are the default values for the `header` 
 
 ```js
 class TabScreen extends React.Component {
-
   static navigationOptions = {
     tabBar: ({ state }) => ({
       label: 'Tab Label',
       icon: ({ tintColor }) => (
         <Image
           source={require('./tab-icon.png')}
-          style={[styles.icon, {tintColor: tintColor}]}
+          style={[styles.icon, { tintColor: tintColor }]}
         />
       ),
-      visible: true
+      visible: true,
+      onChange: (route, prevRoute) => console.log(route, prevRoute),
     }),
   };
-
-};
+}
 ```
 
-- `label` - can be string or react component
-- `icon` - function that returns icon component
-- `visible` - true or false to show or hide the tab bar, if not set then defaults to true
+- `label` - label of the tab, can be a string or Component
+- `icon` - function that returns a Component for icon
+- `visible` - whether the tab should be displayed, defaults to true
+- `onChange` - a callback function that will be called when user moves to this tab
 
 ## Stack Navigation Options
 

--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -154,6 +154,17 @@ export type TabBarConfig = {
    * Label text used by the tab bar.
    */
   label?: string | React.Element<*>;
+  /**
+   * Whether the tab bar is visible.
+   */
+  visible?: boolean;
+  /**
+   * Callback when the tab has been changed with a press or a swipe.
+   */
+  onChange?: (
+    route: { index: number, routeName: string },
+    prevRoute: { index: number, routeName: string }
+  ) => any;
 };
 
 export type DrawerConfig = {

--- a/src/createNavigationContainer.js
+++ b/src/createNavigationContainer.js
@@ -30,6 +30,7 @@ export default function createNavigationContainer<T: *>(
 ) {
   type Props = {
     navigation: NavigationProp<T, NavigationAction>,
+    onNavigationStateChange?: (NavigationState, NavigationState) => void,
   };
 
   type State = {
@@ -103,6 +104,20 @@ export default function createNavigationContainer<T: *>(
             }
           }
         });
+      }
+    }
+
+    componentDidUpdate(prevProps: Props, prevState: State) {
+      const [prevNavigationState, navigationState] = this._isStateful()
+        ? [prevState.nav, this.state.nav]
+        : [prevProps.navigation.state, this.props.navigation.state];
+
+      if (
+        prevNavigationState !== navigationState
+        && typeof this.props.onNavigationStateChange === 'function'
+      ) {
+        // $FlowFixMe state is always defined, either this.state or props
+        this.props.onNavigationStateChange(prevNavigationState, navigationState);
       }
     }
 

--- a/src/routers/TabRouter.js
+++ b/src/routers/TabRouter.js
@@ -128,7 +128,7 @@ export default (
       }
       let didNavigate = false;
       if (action.type === NavigationActions.NAVIGATE) {
-        const navigateAction = ((action: *): NavigationNavigateAction);
+        const navigateAction: NavigationNavigateAction = action;
         didNavigate = !!order.find((tabId: string, i: number) => {
           if (tabId === navigateAction.routeName) {
             activeTabIndex = i;

--- a/src/views/Card.js
+++ b/src/views/Card.js
@@ -96,4 +96,4 @@ Card = createPointerEventsContainer(Card);
 Card.CardStackPanResponder = CardStackPanResponder;
 Card.CardStackStyleInterpolator = CardStackStyleInterpolator;
 
-module.exports = Card;
+export default Card;

--- a/src/views/Drawer/DrawerNavigatorItems.js
+++ b/src/views/Drawer/DrawerNavigatorItems.js
@@ -26,7 +26,7 @@ type Props = {
   activeBackgroundColor?: string;
   inactiveTintColor?: string;
   inactiveBackgroundColor?: string;
-  getLabelText: (scene: DrawerScene) => string;
+  getLabel: (scene: DrawerScene) => ?(React.Element<*> | string);
   renderIcon: (scene: DrawerScene) => ?React.Element<*>;
   style?: Style;
 };
@@ -40,7 +40,7 @@ const DrawerNavigatorItems = ({
   activeBackgroundColor,
   inactiveTintColor,
   inactiveBackgroundColor,
-  getLabelText,
+  getLabel,
   renderIcon,
   style,
 }: Props) => (
@@ -51,7 +51,7 @@ const DrawerNavigatorItems = ({
       const backgroundColor = focused ? activeBackgroundColor : inactiveBackgroundColor;
       const scene = { route, index, focused, tintColor: color };
       const icon = renderIcon(scene);
-      const label = getLabelText(scene);
+      const label = getLabel(scene);
       return (
         <TouchableItem
           key={route.key}
@@ -67,9 +67,14 @@ const DrawerNavigatorItems = ({
                 {icon}
               </View>
             ) : null}
-            <Text style={[styles.label, { color }]}>
-              {label}
-            </Text>
+            {typeof label === 'string'
+              ? (
+                <Text style={[styles.label, { color }]}>
+                  {label}
+                </Text>
+              )
+              : label
+            }
           </View>
         </TouchableItem>
       );

--- a/src/views/Drawer/DrawerSidebar.js
+++ b/src/views/Drawer/DrawerSidebar.js
@@ -11,7 +11,6 @@ import withCachedChildNavigation from '../../withCachedChildNavigation';
 
 import type {
   NavigationScreenProp,
-  NavigationState,
   NavigationRoute,
   NavigationAction,
   NavigationRouter,
@@ -47,10 +46,12 @@ class DrawerSidebar extends PureComponent<void, Props, void> {
     );
   }
 
-  _getLabelText = ({ route }: DrawerScene) => {
+  _getLabel = ({ focused, tintColor, route }: DrawerScene) => {
     const drawer = this._getScreenConfig(route.key, 'drawer');
-    if (drawer && typeof drawer.label === 'string') {
-      return drawer.label;
+    if (drawer && drawer.label) {
+      return typeof drawer.label === 'function'
+        ? drawer.label({ tintColor, focused })
+        : drawer.label;
     }
 
     const title = this._getScreenConfig(route.key, 'title');
@@ -64,10 +65,9 @@ class DrawerSidebar extends PureComponent<void, Props, void> {
   _renderIcon = ({ focused, tintColor, route }: DrawerScene) => {
     const drawer = this._getScreenConfig(route.key, 'drawer');
     if (drawer && drawer.icon) {
-      return drawer.icon({
-        tintColor,
-        focused,
-      });
+      return typeof drawer.icon === 'function'
+        ? drawer.icon({ tintColor, focused })
+        : drawer.icon;
     }
     return null;
   };
@@ -79,7 +79,7 @@ class DrawerSidebar extends PureComponent<void, Props, void> {
         <ContentComponent
           {...this.props.contentOptions}
           navigation={this.props.navigation}
-          getLabelText={this._getLabelText}
+          getLabel={this._getLabel}
           renderIcon={this._renderIcon}
         />
       </View>

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -52,7 +52,7 @@ type SubViewName = 'left' | 'title' | 'right';
 
 type HeaderState = {
   widths: {
-    [key: number]: number,
+    [key: string]: number,
   },
 };
 
@@ -225,14 +225,14 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
         this.setState({
           widths: {
             ...this.state.widths,
-            [index]: e.nativeEvent.layout.width,
+            [key]: e.nativeEvent.layout.width,
           },
         });
       }
       : undefined;
 
     const titleWidth = name === 'left' || name === 'right'
-      ? this.state.widths[index]
+      ? this.state.widths[key]
       : undefined;
 
     return (

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -345,4 +345,4 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = Header;
+export default Header;

--- a/src/views/TabView/TabBarBottom.js
+++ b/src/views/TabView/TabBarBottom.js
@@ -35,7 +35,7 @@ type Props = {
   position: Animated.Value;
   navigationState: NavigationState;
   jumpToIndex: (index: number) => void;
-  getLabelText: (scene: TabScene) => string;
+  getLabel: (scene: TabScene) => ?(React.Element<*> | string);
   renderIcon: (scene: TabScene) => React.Element<*>;
   showLabel: boolean;
   style?: Style;
@@ -80,7 +80,8 @@ export default class TabBarBottom extends PureComponent<DefaultProps, Props, voi
       inputRange,
       outputRange,
     });
-    const label = this.props.getLabelText(scene);
+
+    const label = this.props.getLabel(scene);
     if (typeof label === 'string') {
       return (
         <Animated.Text style={[styles.label, { color }, labelStyle]}>
@@ -88,6 +89,7 @@ export default class TabBarBottom extends PureComponent<DefaultProps, Props, voi
         </Animated.Text>
       );
     }
+
     return label;
   };
 

--- a/src/views/TabView/TabBarTop.js
+++ b/src/views/TabView/TabBarTop.js
@@ -34,7 +34,7 @@ type Props = {
   upperCaseLabel: boolean;
   position: Animated.Value;
   navigationState: NavigationState;
-  getLabelText: (scene: TabScene) => string;
+  getLabel: (scene: TabScene) => ?(React.Element<*> | string);
   renderIcon: (scene: TabScene) => React.Element<*>;
   labelStyle?: Style;
 };
@@ -75,7 +75,8 @@ export default class TabBarTop extends PureComponent<DefaultProps, Props, void> 
       inputRange,
       outputRange,
     });
-    const label = this.props.getLabelText(scene);
+
+    const label = this.props.getLabel(scene);
     if (typeof label === 'string') {
       return (
         <Animated.Text style={[styles.label, { color }, labelStyle]}>

--- a/src/views/TabView/TabView.js
+++ b/src/views/TabView/TabView.js
@@ -84,25 +84,38 @@ class TabView extends PureComponent<void, Props, void> {
     );
   };
 
-  _getLabelText = ({ route }: TabScene) => {
-    const tabBar = this.props.router.getScreenConfig(this.props.childNavigationProps[route.key], 'tabBar');
-    if (tabBar && typeof tabBar.label !== 'undefined') {
-      return tabBar.label;
+  _getLabel = ({ focused, route, tintColor }: TabScene) => {
+    const tabBar = this.props.router.getScreenConfig(
+      this.props.childNavigationProps[route.key],
+      'tabBar'
+    );
+
+    if (tabBar && tabBar.label) {
+      return typeof tabBar.label === 'function'
+        ? tabBar.label({ tintColor, focused })
+        : tabBar.label;
     }
-    const title = this.props.router.getScreenConfig(this.props.childNavigationProps[route.key], 'title');
+
+    const title = this.props.router.getScreenConfig(
+      this.props.childNavigationProps[route.key],
+      'title'
+    );
     if (typeof title === 'string') {
       return title;
     }
+
     return route.routeName;
   };
 
   _renderIcon = ({ focused, route, tintColor }: TabScene) => {
-    const tabBar = this.props.router.getScreenConfig(this.props.childNavigationProps[route.key], 'tabBar');
+    const tabBar = this.props.router.getScreenConfig(
+      this.props.childNavigationProps[route.key],
+      'tabBar'
+    );
     if (tabBar && tabBar.icon) {
-      return tabBar.icon({
-        tintColor,
-        focused,
-      });
+      return typeof tabBar.icon === 'function'
+        ? tabBar.icon({ tintColor, focused })
+        : tabBar.icon;
     }
     return null;
   };
@@ -121,7 +134,7 @@ class TabView extends PureComponent<void, Props, void> {
         {...props}
         {...tabBarOptions}
         navigation={this.props.navigation}
-        getLabelText={this._getLabelText}
+        getLabel={this._getLabel}
         renderIcon={this._renderIcon}
         animationEnabled={animationEnabled}
       />

--- a/src/views/TabView/TabView.js
+++ b/src/views/TabView/TabView.js
@@ -69,17 +69,20 @@ class TabView extends PureComponent<void, Props, void> {
 
   _handlePageChanged = (index: number) => {
     const { navigation, router, childNavigationProps } = this.props;
-    const { routeName, key } = navigation.state.routes[index];
-    navigation.navigate(routeName);
+    const nextRoute = navigation.state.routes[index];
+    navigation.navigate(nextRoute.routeName);
 
-    const tabBar = router.getScreenConfig(childNavigationProps[key], 'tabBar');
+    const tabBar = router.getScreenConfig(childNavigationProps[nextRoute.key], 'tabBar');
     if (tabBar && typeof tabBar.onChange === 'function') {
+      const prevIndex = navigation.state.index;
+      const prevRouteName = navigation.state.routes[prevIndex].routeName;
+
       tabBar.onChange({
         index,
-        routeName,
+        routeName: nextRoute.routeName,
       }, {
-        index: navigation.state.index,
-        routeName: navigation.state.routeName,
+        index: prevIndex,
+        routeName: prevRouteName,
       });
     }
   };

--- a/src/views/TabView/TabView.js
+++ b/src/views/TabView/TabView.js
@@ -68,9 +68,20 @@ class TabView extends PureComponent<void, Props, void> {
   props: Props;
 
   _handlePageChanged = (index: number) => {
-    const { navigation } = this.props;
-    navigation.navigate(
-      navigation.state.routes[index].routeName);
+    const { navigation, router, childNavigationProps } = this.props;
+    const { routeName, key } = navigation.state.routes[index];
+    navigation.navigate(routeName);
+
+    const tabBar = router.getScreenConfig(childNavigationProps[key], 'tabBar');
+    if (tabBar && typeof tabBar.onChange === 'function') {
+      tabBar.onChange({
+        index,
+        routeName,
+      }, {
+        index: navigation.state.index,
+        routeName: navigation.state.routeName,
+      });
+    }
   };
 
   _renderScene = ({ route }: any) => {

--- a/src/views/Transitioner.js
+++ b/src/views/Transitioner.js
@@ -171,18 +171,15 @@ class Transitioner extends React.Component<*, Props, State> {
     const { timing } = transitionSpec;
     delete transitionSpec.timing;
 
-    const animations = [
-      timing(
-        progress,
-        {
-          ...transitionSpec,
-          toValue: 1,
-        },
-      ),
-    ];
-
-    if (indexHasChanged) {
-      animations.push(
+    const animations = indexHasChanged
+      ? [
+        timing(
+          progress,
+          {
+            ...transitionSpec,
+            toValue: 1,
+          },
+        ),
         timing(
           position,
           {
@@ -190,8 +187,9 @@ class Transitioner extends React.Component<*, Props, State> {
             toValue: nextProps.navigation.state.index,
           },
         ),
-      );
-    }
+      ]
+      : [];
+
     // update scenes and play the transition
     this._isTransitionRunning = true;
     this.setState(nextState, () => {


### PR DESCRIPTION
Currently there is no proper way to know when a user moved to another tab. Existing methods to track such changes involve custom routers or Redux integration, both have their own downsides and are an overkill for such a simple task. 

There is also an undocumented *hack* to add `onTabPress` callback to `tabBarOptions` as follows:
```javascript
const MyTabs = TabNavigator({
    TabOne: {screen: TabOne},
    TabTwo: {screen: TabTwo},
    TabThree: {screen: TabThree},
}, {
    initialRouteName: 'TabOne',
    tabBarOptions: {
        onTabPress: route => console.log(route),
    },
});
```
It will be passed down to the [react-native-tab-view/TabBar.js](https://github.com/react-native-community/react-native-tab-view/blob/master/src/TabBar.js) and called on every tab press; not very practical either.

---

This PR is a proposal to add an `onChange` prop to the `navigationOptions.tabBar` that will be called on `onRequestChangeTab`, i.e. when one presses the tab header or swipes to a tab.

The change worked fine for me in a real app with the TabBarTop on Android and iOS. If you are OK with this change I will do more tests, fix flow issues and add related docs. Also I am not sure if `onChange` is a good name, but I couldn't find a better one for now.

Related issues: #347, #402, #198