### PR TITLE
[RFC] Remove confusing header.title API

### DIFF
--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -119,8 +119,8 @@ All `navigationOptions` for the `StackNavigator`:
 - `title` - a title (string) displayed in the header
 - `header` - a config object for the header bar:
   - `visible` - Boolean toggle of header visibility. Only works when `headerMode` is `screen`.
-  - `title` - Title string used by the navigation bar, or a custom React component
   - `backTitle` - Title string used by the back button or `null` to disable label. Defaults to `title` value by default
+  - `title` - Custom React Element to display in the middle of the header
   - `right` - Custom React Element to display on the right side of the header
   - `left` - Custom React Element to display on the left side of the header
   - `style` - Style object for the navigation bar

--- a/src/views/CardStack.js
+++ b/src/views/CardStack.js
@@ -223,13 +223,6 @@ class CardStack extends Component<DefaultProps, Props, void> {
         }}
         renderTitleComponent={(props: NavigationTransitionProps) => {
           const header = this.props.router.getScreenConfig(props.navigation, 'header') || {};
-          // When we return 'undefined' from 'renderXComponent', header treats them as not
-          // specified and default 'renderXComponent' functions are used. In case of 'title',
-          // we return 'undefined' in case of 'string' too because the default 'renderTitle'
-          // function in header handles them.
-          if (typeof header.title === 'string') {
-            return undefined;
-          }
           return header.title;
         }}
       />

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -83,14 +83,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
   };
 
   _getHeaderTitle(navigation: Navigation): ?string {
-    const header = this.props.router.getScreenConfig(navigation, 'header');
-    let title;
-    if (header && header.title) {
-      title = header.title;
-    } else {
-      title = this.props.router.getScreenConfig(navigation, 'title');
-    }
-    return typeof title === 'string' ? title : undefined;
+    return this.props.router.getScreenConfig(navigation, 'title');
   }
 
   _getBackButtonTitle(navigation: Navigation): ?string {


### PR DESCRIPTION
Currently, `header.title` can be either `string` or a `React.Element` to render in the middle of the header.

I believe that letting users specify `header.title`as a string introduces unnecessary confusion (already asked about differences [here](https://exponentjs.slack.com/archives/general/p1487650298022645)) as it's not clear how it's different from `title` property. Also, we don't use `header.title` strings anywhere in the docs.

The difference is conceptual, as `header.title` is a custom React.Element to be rendered in the middle of the header. The problem is that we implicitly wrap `strings` so that user can pass exactly same values he passes for `title`. W/o that implicit behavior, the difference would be: "Use `title` to render title of a scene, pass custom `header.title` component to e.g. achieve some more advanced interactions etc" 