### PR TITLE
Fix glitches in Header when calling `replace` 

### DIFF
--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -52,7 +52,7 @@ type SubViewName = 'left' | 'title' | 'right';
 
 type HeaderState = {
   widths: {
-    [key: number]: number,
+    [key: string]: number,
   },
 };
 
@@ -225,14 +225,14 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
         this.setState({
           widths: {
             ...this.state.widths,
-            [index]: e.nativeEvent.layout.width,
+            [key]: e.nativeEvent.layout.width,
           },
         });
       }
       : undefined;
 
     const titleWidth = name === 'left' || name === 'right'
-      ? this.state.widths[index]
+      ? this.state.widths[key]
       : undefined;
 
     return (

--- a/src/views/Transitioner.js
+++ b/src/views/Transitioner.js
@@ -171,18 +171,15 @@ class Transitioner extends React.Component<*, Props, State> {
     const { timing } = transitionSpec;
     delete transitionSpec.timing;
 
-    const animations = [
-      timing(
-        progress,
-        {
-          ...transitionSpec,
-          toValue: 1,
-        },
-      ),
-    ];
-
-    if (indexHasChanged) {
-      animations.push(
+    const animations = indexHasChanged
+      ? [
+        timing(
+          progress,
+          {
+            ...transitionSpec,
+            toValue: 1,
+          },
+        ),
         timing(
           position,
           {
@@ -190,8 +187,9 @@ class Transitioner extends React.Component<*, Props, State> {
             toValue: nextProps.navigation.state.index,
           },
         ),
-      );
-    }
+      ]
+      : [];
+
     // update scenes and play the transition
     this._isTransitionRunning = true;
     this.setState(nextState, () => {


### PR DESCRIPTION
When having a StackNavigator with a route `A` and active index 0, calling `reset` action with a route `B` (leaving the same index) produces a series of glitches that this PR fixes.

Real use-case is when e.g. having a `Login` route and after clicking `Login` button, you want to replace it.

In order to fix those issues, I decided to change the following:

1) Transitioner shouldn't perform any animations when we do `reset` on the same index. Animations that rely on `index` will produce inaccurate effects as the index never changes, but the route does. What I experienced was e.g. after replacing a route, the title of a previous route stayed on screen for the duration of the animation, because `progress` was animating, but `position` wasn't. I cannot think of a use-case where it would be useful, but I might be wrong. 

2) We don't store computed layout for a title component under index, but unique scene key instead. That ensures even if we change the scene at the same index, it will work flawlessly and produce no races.

Before fix: https://drive.google.com/file/d/0B8qD3OEkGnJ9VDEtQ3JLMWU3RGc/view?usp=sharing
After fix: https://drive.google.com/file/d/0B8qD3OEkGnJ9aUFqLWhEWUhPQ2s/view?usp=sharing

Likely related: #295 
Likely related NavigationExperimental issue: https://github.com/facebook/react-native/issues/11114