### PR TITLE
Fix null style warning in Header component

### DIFF
--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -336,7 +336,7 @@ const styles = StyleSheet.create({
       flex: 1,
       alignItems: 'flex-start',
     }
-    : null,
+    : {},
   left: {
     alignItems: 'flex-start',
   },


### PR DESCRIPTION
Fixes invalid style warning: #421

**Test plan**
Before Change: Open NavigationPlayground on iOS, open stack example, see warning.
After Change: No warning. Also verify no change on Android for stack example.
