### PR TITLE
Updated the reducer

### DIFF
--- a/docs/guides/Redux-Integration.md
+++ b/docs/guides/Redux-Integration.md
@@ -7,10 +7,13 @@ With redux, your app's state is defined by a reducer. Each navigation router eff
 ```
 const AppNavigator = StackNavigator(AppRouteConfigs);
 
+const navReducer = (state, action) => {
+  const newState = AppNavigator.router.getStateForAction(action, state);
+  return newState || state;
+};
+
 const appReducer = combineReducers({
-  nav: (state, action) => (
-    AppNavigator.router.getStateForAction(action, state)
-  ),
+  navReducer,
   ...
 });
 


### PR DESCRIPTION
When the drawer opens / close, the result of AppNavigator.router.getStateForAction(action, state); is null. So the nav state in the store is null which causes errors. This solves that.

Please provide enough information so that others can review your pull request:
