### PR TITLE
Fix headerMode: `screen` position

### DIFF
--- a/src/views/CardStack.js
+++ b/src/views/CardStack.js
@@ -290,13 +290,13 @@ class CardStack extends Component<DefaultProps, Props, void> {
       const maybeHeader =
         isHeaderHidden ? null : this._renderHeader(props, headerMode);
       return (
-        <View style={{ flex: 1 }}>
-          {maybeHeader}
+        <View style={styles.container}>
           <SceneView
             screenProps={this.props.screenProps}
             navigation={props.navigation}
             component={SceneComponent}
           />
+          {maybeHeader}
         </View>
       );
     }


### PR DESCRIPTION
This fixes #414 

The issue is that with with `headerMode: 'screen'`, header shadows are covered by the `Card`, esp. when you set a background color on a Card. Also, as described in #414, when you set position to be absolute, in order to render e.g. semi-transparent header above the scene, this is not possible.

By being defined as the last element, we can now make interactions that in #414 were not possible before. No major changes were done, just applied the same style we do for `headerMode: float`. Thanks to that, they should be easier to maintain as they are now rendered exactly the same.