### PR TITLE
Fix low header bar on Android

### DIFF
--- a/src/views/CardStack.js
+++ b/src/views/CardStack.js
@@ -291,11 +291,13 @@ class CardStack extends Component<DefaultProps, Props, void> {
         isHeaderHidden ? null : this._renderHeader(props, headerMode);
       return (
         <View style={styles.container}>
-          <SceneView
-            screenProps={this.props.screenProps}
-            navigation={props.navigation}
-            component={SceneComponent}
-          />
+          <View style={{flex: 1}}>
+            <SceneView
+              screenProps={this.props.screenProps}
+              navigation={props.navigation}
+              component={SceneComponent}
+            />
+          </View>
           {maybeHeader}
         </View>
       );


### PR DESCRIPTION
Hello,

This PR adds a nested View around the content in CardStack so that the content expands and puts the header bar at the top of the screen on Android.

This issue seems like it was introduced in PR #436. My understanding is that the header bar is put after the screen content to change the rendering order and the `column-reverse` flex direction is used to make sure actual placement wouldn't change.

This problem only occurs when SceneView (in CardStack.js) is tightly wrapping whatever it contains. For example:
```
  render() {
    return <Text>Hello, sailer</Text>;
  }
```
will cause an issue whereas `TabNavigator` won't, for whatever reason.

Anyways it looks like this:

![screenshot from 2017-02-23 00-08-58](https://cloud.githubusercontent.com/assets/3858161/23245873/bee39628-f95d-11e6-9b5c-1f60ba567e43.png)

This issue is described in #432 and it was discovered that if the content is wrapped in an expanding View (with `style={{flex: 1}}`) it would look normal.

This PR adds the expanding View inside the CardStack so that the user doesn't have to.

Now the above code looks like this:

![screenshot from 2017-02-23 00-31-48](https://cloud.githubusercontent.com/assets/3858161/23246139/8fcca814-f95f-11e6-9aa9-e9db204ef6e2.png)


I don't really have the means to test on iOS so I've only tested on Android. Let me know if there is anything else I can do. Thanks for this excellent library, by the way!
