### PR TITLE
Fix redux documentation

### DIFF
--- a/docs/guides/Redux-Integration.md
+++ b/docs/guides/Redux-Integration.md
@@ -13,7 +13,7 @@ const navReducer = (state, action) => {
 };
 
 const appReducer = combineReducers({
-  navReducer,
+  nav: navReducer,
   ...
 });
 


### PR DESCRIPTION
I think the navigation key for the redux store should be `nav` and not `navReducer`.