### PR TITLE
Add onNavigationStateChange

### DIFF
--- a/docs/api/navigators/Navigators.md
+++ b/docs/api/navigators/Navigators.md
@@ -48,6 +48,10 @@ When rendering one of the included navigators, the navigation prop is optional. 
 
 For the purpose of convenience, the built-in navigators have this ability because behind the scenes they use `createNavigationContainer`. Usually, navigators require a navigation prop in order to function.
 
+### `onNavigationStateChange`
+
+@todo
+
 ### `containerOptions`
 
 These options can be used to configure a navigator when it is used at the top level.

--- a/docs/api/navigators/Navigators.md
+++ b/docs/api/navigators/Navigators.md
@@ -48,9 +48,9 @@ When rendering one of the included navigators, the navigation prop is optional. 
 
 For the purpose of convenience, the built-in navigators have this ability because behind the scenes they use `createNavigationContainer`. Usually, navigators require a navigation prop in order to function.
 
-### `onNavigationStateChange`
+### `onNavigationStateChange(prevState, newState)`
 
-@todo
+Sometimes it is useful to know when navigation state managed by the top-level navigator changes. For this purpose, this function gets called every time with the previous state and the new state of the navigation.
 
 ### `containerOptions`
 

--- a/src/createNavigationContainer.js
+++ b/src/createNavigationContainer.js
@@ -145,6 +145,15 @@ export default function createNavigationContainer<T: *>(
       const nav = Component.router.getStateForAction(action, state.nav);
 
       if (nav && nav !== state.nav) {
+        if (console.group) {
+          console.group('Navigation Dispatch: ');
+          console.log('Action: ', action);
+          console.log('New State: ', nav);
+          console.log('Last State: ', state.nav);
+          console.groupEnd();
+        } else {
+          console.log('Navigation Dispatch: ', { action, newState: nav, lastState: state.nav });
+        }
         this.setState({ nav });
         return true;
       }

--- a/src/createNavigationContainer.js
+++ b/src/createNavigationContainer.js
@@ -30,7 +30,7 @@ export default function createNavigationContainer<T: *>(
 ) {
   type Props = {
     navigation: NavigationProp<T, NavigationAction>,
-    onNavigationStateChange?: (NavigationState) => void,
+    onNavigationStateChange?: (NavigationState, NavigationState) => void,
   };
 
   type State = {
@@ -116,6 +116,7 @@ export default function createNavigationContainer<T: *>(
         prevNavigationState !== navigationState
         && typeof this.props.onNavigationStateChange === 'function'
       ) {
+        // $FlowFixMe state is always defined, either this.state or props
         this.props.onNavigationStateChange(prevNavigationState, navigationState);
       }
     }


### PR DESCRIPTION
Sometimes it is useful to know when `navigation` did change, so that we can use e.g. Google Analytics to track page change.

This improves over past example that was hacking `componentDidUpdate` prototype.

Test plan:
add `onNavigationStateChange` prop and console log args. Should be called every dispatch with prev/next state.