### PR TITLE
[Docs] Link every heading automatically

### DIFF
--- a/website/src/App.css
+++ b/website/src/App.css
@@ -13,6 +13,13 @@ body, #root, html {
 .main-section a:hover {
   color: #6b52ae;
 }
+.md-header a:before {
+  display: block;
+  content: " ";
+  margin-top: -70px;
+  height: 70px;
+  visibility: hidden;
+}
 .md-header a,
 .md-header a:hover {
   color: inherit;

--- a/website/src/App.css
+++ b/website/src/App.css
@@ -13,16 +13,19 @@ body, #root, html {
 .main-section a:hover {
   color: #6b52ae;
 }
-.md-header a:before {
+.md-header:before {
   display: block;
   content: " ";
   margin-top: -70px;
   height: 70px;
   visibility: hidden;
 }
-.md-header a,
-.md-header a:hover {
-  color: inherit;
+.md-header a {
+  visibility: hidden;
+  display: inline-block;
+}
+.md-header:hover a {
+  visibility: visible;
 }
 .nextLink {
   float: right;

--- a/website/src/App.css
+++ b/website/src/App.css
@@ -13,6 +13,10 @@ body, #root, html {
 .main-section a:hover {
   color: #6b52ae;
 }
+.md-header a,
+.md-header a:hover {
+  color: inherit;
+}
 .nextLink {
   float: right;
 }

--- a/website/src/MDPage.js
+++ b/website/src/MDPage.js
@@ -62,7 +62,7 @@ const MDPage = ({navigation, docPath}) => (
         const Header = getHeadingForLevel(level);
         return (
           <Header id={id} className="md-header">
-            <a href={`#${id}`} title={children}>{children}</a>
+            {children} <a href={`#${id}`} title={children}>#</a>
           </Header>
         );
       },

--- a/website/src/MDPage.js
+++ b/website/src/MDPage.js
@@ -9,6 +9,26 @@ import CodeBlock from './CodeBlock';
 
 const safeString = s => slugify(s).replace(/\)/g, '-').replace(/\(/g, '-').replace(/^-/,'').replace(/-$/,'');
 
+const getHeadingForLevel = (level) => {
+  switch (level) {
+    case 2:
+      return 'h2';
+    case 3:
+      return 'h3';
+    case 4:
+      return 'h4';
+    case 5:
+      return 'h5';
+    case 6:
+      return 'h6';
+    case 7:
+      return 'h7';
+    default:
+    case 1:
+      return 'h1';
+  }
+};
+
 const MDPage = ({navigation, docPath}) => (
   <Markdown
     source={DocsMD[docPath]}
@@ -39,23 +59,12 @@ const MDPage = ({navigation, docPath}) => (
             return safeString(child.props.children);
           }
         }).join('-');
-        switch (level) {
-          case 2:
-            return <h2 id={id}>{children}</h2>;
-          case 3:
-            return <h3 id={id}>{children}</h3>;
-          case 4:
-            return <h4 id={id}>{children}</h4>;
-          case 5:
-            return <h5 id={id}>{children}</h5>;
-          case 6:
-            return <h6 id={id}>{children}</h6>;
-          case 7:
-            return <h7 id={id}>{children}</h7>;
-          default:
-          case 1:
-            return <h1 id={id}>{children}</h1>;
-        }
+        const Header = getHeadingForLevel(level);
+        return (
+          <Header id={id} className="md-header">
+            <a href={`#${id}`} title={children}>{children}</a>
+          </Header>
+        );
       },
       link: ({children, href}) => {
         if (href.indexOf('PhoneGraphic:') === 0) {


### PR DESCRIPTION
[docs] Fixes #434 

How it looks:
<img width="738" alt="screen shot 2017-02-23 at 16 36 07" src="https://cloud.githubusercontent.com/assets/2464966/23265894/797e761e-f9e6-11e6-81ab-5055b523f6dc.png">

With `:hover`
<img width="722" alt="screen shot 2017-02-23 at 16 36 11" src="https://cloud.githubusercontent.com/assets/2464966/23265901/80311cdc-f9e6-11e6-826f-889823d9dbe1.png">

URL:
<img width="393" alt="screen shot 2017-02-23 at 16 36 15" src="https://cloud.githubusercontent.com/assets/2464966/23265939/9bbfe122-f9e6-11e6-87c1-ddb2ab765a10.png">

Tested on Safari.

