### PR TITLE
Make TabNavigator code example formatting consistent

### DIFF
--- a/docs/api/navigators/TabNavigator.md
+++ b/docs/api/navigators/TabNavigator.md
@@ -114,10 +114,12 @@ Example:
 ```js
 tabBarOptions: {
   activeTintColor: '#e91e63',
-  labelStyle: { fontSize: 12 },
+  labelStyle: {
+    fontSize: 12,
+  },
   style: {
     backgroundColor: 'blue',
-  }
+  },
 }
 ```
 
@@ -145,7 +147,7 @@ tabBarOptions: {
   },
   style: {
     backgroundColor: 'blue',
-  }
+  },
 }
 ```
 

--- a/docs/api/routers/StackRouter.md
+++ b/docs/api/routers/StackRouter.md
@@ -16,7 +16,7 @@ const MyApp = StackRouter({
 
 ### RouteConfig
 
-A basic stack router have a route config. Here is an example configuration:
+A basic stack router expects a route config object. Here is an example configuration:
 
 ```js
 const MyApp = StackRouter({ // This is the RouteConfig:


### PR DESCRIPTION
Just making the formatting consistent between examples in the docs