### PR TITLE
Drawer custom item

### DIFF
--- a/examples/NavigationPlayground/js/App.js
+++ b/examples/NavigationPlayground/js/App.js
@@ -15,6 +15,7 @@ import { StackNavigator } from 'react-navigation';
 import Banner from './Banner';
 import CustomTabs from './CustomTabs';
 import Drawer from './Drawer';
+import CustomDrawer from './CustomDrawer';
 import ModalStack from './ModalStack';
 import StacksInTabs from './StacksInTabs';
 import SimpleStack from './SimpleStack';
@@ -35,6 +36,11 @@ const ExampleRoutes = {
     name: 'Drawer Example',
     description: 'Android-style drawer navigation',
     screen: Drawer,
+  },
+  CustomDrawer: {
+    name: 'Custom Drawer',
+    description: 'Custom drawer',
+    screen: CustomDrawer,
   },
   CustomTabs: {
     name: 'Custom Tabs',

--- a/examples/NavigationPlayground/js/CustomDrawer.js
+++ b/examples/NavigationPlayground/js/CustomDrawer.js
@@ -1,0 +1,83 @@
+/**
+ * @flow
+ */
+
+import React from 'react';
+import { Button, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { DrawerNavigator } from 'react-navigation';
+import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
+import SampleText from './SampleText';
+
+const MyNavScreen = ({ navigation, banner }) => (
+  <ScrollView style={styles.container}>
+    <SampleText>{banner}</SampleText>
+    <Button onPress={() => navigation.navigate('DrawerOpen')} title="Open drawer" />
+    <Button onPress={() => navigation.goBack(null)} title="Go back" />
+  </ScrollView>
+);
+
+const InboxScreen = ({ navigation }) => <MyNavScreen banner={'Inbox Screen'} navigation={navigation} />;
+InboxScreen.navigationOptions = {
+  drawer: {
+    label: 'Inbox',
+    item: ({ focused, label }) => (
+      <View style={[styles.itemContainer, focused && styles.itemFocused]}>
+        <MaterialIcons name="move-to-inbox" size={24} style={styles.icon} />
+        <Text style={[styles.label]}>{label}</Text>
+      </View>
+    ),
+  },
+};
+
+const DraftsScreen = ({ navigation }) => <MyNavScreen banner={'Drafts Screen'} navigation={navigation} />;
+DraftsScreen.navigationOptions = {
+  drawer: {
+    label: 'Drafts',
+    item: ({ focused, label }) => (
+      <View style={[styles.itemContainer, focused && styles.itemFocused]}>
+        <MaterialIcons name="drafts" size={24} style={styles.icon} />
+        <Text style={[styles.label]}>{label}</Text>
+      </View>
+    ),
+  },
+};
+
+const DrawerExample = DrawerNavigator(
+  {
+    Inbox: {
+      path: '/',
+      screen: InboxScreen,
+    },
+    Drafts: {
+      path: '/sent',
+      screen: DraftsScreen,
+    },
+  },
+  {
+    initialRouteName: 'Inbox',
+  },
+);
+
+const styles = StyleSheet.create({
+  itemContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderLeftWidth: 5,
+    borderColor: 'transparent',
+    height: 44,
+  },
+  itemFocused: {
+    borderColor: '#F44336',
+  },
+  icon: {
+    marginHorizontal: 16,
+    width: 24,
+    alignItems: 'center',
+  },
+  label: {
+    fontWeight: 'bold',
+    margin: 16,
+  },
+});
+
+export default DrawerExample;

--- a/src/views/Drawer/DrawerNavigatorItems.js
+++ b/src/views/Drawer/DrawerNavigatorItems.js
@@ -28,10 +28,11 @@ type Props = {
   inactiveBackgroundColor?: string;
   getLabelText: (scene: DrawerScene) => string;
   renderIcon: (scene: DrawerScene) => ?React.Element<*>;
+  renderItem: (scene: DrawerScene) => ?React.Element<*>;
   style?: Style;
 };
 
-/**
+/** 
  * Component that renders the navigation list in the drawer.
  */
 const DrawerNavigatorItems = ({
@@ -42,6 +43,7 @@ const DrawerNavigatorItems = ({
   inactiveBackgroundColor,
   getLabelText,
   renderIcon,
+  renderItem,
   style,
 }: Props) => (
   <View style={[styles.container, style]}>
@@ -51,6 +53,7 @@ const DrawerNavigatorItems = ({
       const backgroundColor = focused ? activeBackgroundColor : inactiveBackgroundColor;
       const scene = { route, index, focused, tintColor: color };
       const icon = renderIcon(scene);
+      const item = renderItem(scene);
       const label = getLabelText(scene);
       return (
         <TouchableItem
@@ -61,16 +64,18 @@ const DrawerNavigatorItems = ({
           }}
           delayPressIn={0}
         >
-          <View style={[styles.item, { backgroundColor }]}>
-            {icon ? (
-              <View style={[styles.icon, focused ? null : styles.inactiveIcon]}>
-                {icon}
-              </View>
-            ) : null}
-            <Text style={[styles.label, { color }]}>
-              {label}
-            </Text>
-          </View>
+          {item ||
+          (<View style={[styles.item, { backgroundColor }]}>
+              {icon ? (
+                <View style={[styles.icon, focused ? null : styles.inactiveIcon]}>
+                  {icon}
+                </View>
+              ) : null}
+              <Text style={[styles.label, { color }]}>
+                {label}
+              </Text>
+            </View>
+          )}
         </TouchableItem>
       );
     })}
@@ -101,7 +106,7 @@ const styles = StyleSheet.create({
   item: {
     flexDirection: 'row',
     alignItems: 'center',
-  },
+  },  
   icon: {
     marginHorizontal: 16,
     width: 24,

--- a/src/views/Drawer/DrawerSidebar.js
+++ b/src/views/Drawer/DrawerSidebar.js
@@ -72,9 +72,10 @@ class DrawerSidebar extends PureComponent<void, Props, void> {
     return null;
   };
 
-  _renderItem = ({ focused, route }: DrawerScene) => {
+  _renderItem = (scene: DrawerScene) => {
+    const { focused, route } = scene;
     const drawer = this._getScreenConfig(route.key, 'drawer');
-    const label = this._getLabelText({ route });
+    const label = this._getLabelText(scene);
     if (drawer && drawer.item) {
       return drawer.item({
         focused,

--- a/src/views/Drawer/DrawerSidebar.js
+++ b/src/views/Drawer/DrawerSidebar.js
@@ -11,11 +11,11 @@ import withCachedChildNavigation from '../../withCachedChildNavigation';
 
 import type {
   NavigationScreenProp,
-  NavigationState,
-  NavigationRoute,
-  NavigationAction,
-  NavigationRouter,
-  Style,
+    NavigationState,
+    NavigationRoute,
+    NavigationAction,
+    NavigationRouter,
+    Style,
 } from '../../TypeDefinition';
 
 import type {
@@ -29,8 +29,8 @@ type Props = {
   navigation: Navigation,
   childNavigationProps: { [key: string]: Navigation },
   contentComponent: ReactClass<*>,
-  contentOptions?: {},
-  style?: Style;
+    contentOptions?: {},
+    style?: Style;
 };
 
 /**
@@ -72,6 +72,18 @@ class DrawerSidebar extends PureComponent<void, Props, void> {
     return null;
   };
 
+  _renderItem = ({ focused, route }: DrawerScene) => {
+    const drawer = this._getScreenConfig(route.key, 'drawer');
+    const label = this._getLabelText({ route });
+    if (drawer && drawer.item) {
+      return drawer.item({
+        focused,
+        label,
+      });
+    }
+    return null;
+  };
+
   render() {
     const ContentComponent = this.props.contentComponent;
     return (
@@ -81,6 +93,7 @@ class DrawerSidebar extends PureComponent<void, Props, void> {
           navigation={this.props.navigation}
           getLabelText={this._getLabelText}
           renderIcon={this._renderIcon}
+          renderItem={this._renderItem}
         />
       </View>
     );


### PR DESCRIPTION
**Motivation**

We want to render a custom item on DrawerNavigator but without the constraints that `renderIcon` has so we open this issue: https://github.com/react-community/react-navigation/issues/416
So we'd added an option called `item` under the navigationOptions on the DrawerNavigator to render a custom component.

**Test plan (required)**
We added an example under `examples/NavigationPlayground`.
[Run the native playground](https://reactnavigation.org/docs/guides/contributors) and go to the Custom Drawer item

<img width="695" alt="screen shot 2017-02-23 at 4 19 25 pm" src="https://cloud.githubusercontent.com/assets/2475912/23275094/ec7d8964-f9e3-11e6-9cf9-5e6e070fa1ad.png">

--------------------

<img width="692" alt="screen shot 2017-02-23 at 4 19 34 pm" src="https://cloud.githubusercontent.com/assets/2475912/23275095/f04c0912-f9e3-11e6-845c-f0fe49f68ad5.png">

--------------------

**Inbox item focused:**

<img width="592" alt="screen shot 2017-02-23 at 4 22 21 pm" src="https://cloud.githubusercontent.com/assets/2475912/23275195/4f975f02-f9e4-11e6-9352-bd43a12a8ae8.png">

**Drafts items focused:**

<img width="590" alt="screen shot 2017-02-23 at 4 22 34 pm" src="https://cloud.githubusercontent.com/assets/2475912/23275207/63cc4e74-f9e4-11e6-81d4-7e87f29300ff.png">

**Code formatting**
We use the same code formatting that the project has. It's different only on the example on `examples/NavigationPlayground/js/CustomDrawer.js`