### PR TITLE
Bring back better `header.bar`

### DIFF
--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -118,7 +118,7 @@ All `navigationOptions` for the `StackNavigator`:
 
 - `title` - a title (string) of the scene
 - `header` - a config object for the header bar:
-  - `visible` - Boolean toggle of header visibility. Only works when `headerMode` is `screen`.
+  - `bar` - React Element to display as a header or `null` to hide it. Only works when `headerMode` is `screen`
   - `title` - String or React Element used by the header. Defaults to scene `title`
   - `backTitle` - Title string used by the back button on iOS or `null` to disable label. Defaults to scene `title`
   - `right` - React Element to display on the right side of the header

--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -118,7 +118,7 @@ All `navigationOptions` for the `StackNavigator`:
 
 - `title` - a title (string) of the scene
 - `header` - a config object for the header bar:
-  - `bar` - React Element to display as a header or `null` to hide it. Only works when `headerMode` is `screen`
+  - `bar` - React Element or a function that given `HeaderProps` returns a React Element, to display as a header. Only works when `headerMode` is `screen`. Setting to `null` hides header.
   - `title` - String or React Element used by the header. Defaults to scene `title`
   - `backTitle` - Title string used by the back button on iOS or `null` to disable label. Defaults to scene `title`
   - `right` - React Element to display on the right side of the header

--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -118,7 +118,7 @@ All `navigationOptions` for the `StackNavigator`:
 
 - `title` - a title (string) of the scene
 - `header` - a config object for the header bar:
-  - `bar` - React Element or a function that given `HeaderProps` returns a React Element, to display as a header. Only works when `headerMode` is `screen`. Setting to `null` hides header.
+  - `bar` - React Element or a function that given `HeaderProps` returns a React Element, to display as a header. Setting to `null` hides header.
   - `title` - String or React Element used by the header. Defaults to scene `title`
   - `backTitle` - Title string used by the back button on iOS or `null` to disable label. Defaults to scene `title`
   - `right` - React Element to display on the right side of the header

--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -133,10 +133,7 @@ export type HeaderConfig = {
   /**
    * React element to display as a header
    */
-  bar?: React.Element<*>
-    | (
-      transitionProps: NavigationTransitionProps & { router: NavigationRouter }
-    ) => React.Element<*>,
+  bar?: React.Element<*> | HeaderProps => ReactElement<*>
 
   // // Style of title text
   // titleTextStyle?: $NavigationThunk<Object>,
@@ -281,7 +278,6 @@ export type NavigationContainerConfig = {
 export type NavigationStackViewConfig = {
   mode?: 'card' | 'modal',
   headerMode?: HeaderMode,
-  headerComponent?: ReactClass<HeaderProps<*>>,
   cardStyle?: Style,
   onTransitionStart?: () => void,
   onTransitionEnd?: () => void

--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -133,7 +133,10 @@ export type HeaderConfig = {
   /**
    * React element to display as a header
    */
-  bar?: React.Element<*>,
+  bar?: React.Element<*>
+    | (
+      transitionProps: NavigationTransitionProps & { router: NavigationRouter }
+    ) => React.Element<*>,
 
   // // Style of title text
   // titleTextStyle?: $NavigationThunk<Object>,
@@ -177,7 +180,7 @@ export type CardStackConfig = {
    * Whether you can use gestures to dismiss this screen.
    * Defaults to true on iOS, false on Android.
    */
-  gesturesEnabled?: bool;
+  gesturesEnabled?: boolean;
 };
 
 export type NavigationScreenOptions = {

--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -130,6 +130,11 @@ export type HeaderConfig = {
    */
   titleStyle?: Style,
 
+  /**
+   * React element to display as a header
+   */
+  bar?: React.Element<*>,
+
   // // Style of title text
   // titleTextStyle?: $NavigationThunk<Object>,
   // // Tint color of navigation bar contents

--- a/src/navigators/StackNavigator.js
+++ b/src/navigators/StackNavigator.js
@@ -24,7 +24,6 @@ export default (routeConfigMap: NavigationRouteConfigMap, stackConfig: StackNavi
     initialRouteName,
     initialRouteParams,
     paths,
-    headerComponent,
     headerMode,
     mode,
     cardStyle,
@@ -42,7 +41,6 @@ export default (routeConfigMap: NavigationRouteConfigMap, stackConfig: StackNavi
   return createNavigationContainer(createNavigator(router)(props => (
     <CardStack
       {...props}
-      headerComponent={headerComponent}
       headerMode={headerMode}
       mode={mode}
       cardStyle={cardStyle}

--- a/src/views/CardStack.js
+++ b/src/views/CardStack.js
@@ -45,7 +45,6 @@ const NativeAnimatedModule = NativeModules && NativeModules.NativeAnimatedModule
 type Props = {
   screenProps?: {};
   headerMode: HeaderMode,
-  headerComponent?: ReactClass<*>,
   mode: 'card' | 'modal',
   navigation: NavigationScreenProp<*, NavigationAction>,
   router: NavigationRouter,
@@ -62,7 +61,6 @@ type Props = {
 
 type DefaultProps = {
   mode: 'card' | 'modal',
-  headerComponent: ReactClass<*>,
 };
 
 class CardStack extends Component<DefaultProps, Props, void> {
@@ -90,11 +88,6 @@ class CardStack extends Component<DefaultProps, Props, void> {
      * is `screen` on Android and `float` on iOS.
      */
     headerMode: PropTypes.oneOf(['float', 'screen', 'none']),
-
-    /**
-     * Custom React component to be used as a header
-     */
-    headerComponent: PropTypes.func,
 
     /**
      * Style of the cards movement. Value could be `card` or `modal`.
@@ -141,7 +134,6 @@ class CardStack extends Component<DefaultProps, Props, void> {
 
   static defaultProps: DefaultProps = {
     mode: 'card',
-    headerComponent: Header,
   };
 
   componentWillMount() {
@@ -211,7 +203,7 @@ class CardStack extends Component<DefaultProps, Props, void> {
     }
 
     return (
-      <this.props.headerComponent
+      <Header
         {...transitionProps}
         router={this.props.router}
         style={headerConfig.style}

--- a/src/views/CardStack.js
+++ b/src/views/CardStack.js
@@ -202,7 +202,12 @@ class CardStack extends Component<DefaultProps, Props, void> {
         headerMode === 'screen',
         'header.bar is only supported with headerMode: screen',
       );
-      return headerConfig.bar;
+      return typeof headerConfig.bar === 'function'
+        ? headerConfig.bar({
+          ...transitionProps,
+          router: this.props.router,
+        })
+        : headerConfig.bar;
     }
 
     return (

--- a/src/views/CardStack.js
+++ b/src/views/CardStack.js
@@ -187,7 +187,10 @@ class CardStack extends Component<DefaultProps, Props, void> {
       'header'
     ) || {};
 
-    if (headerConfig.bar === null || typeof headerConfig.bar !== 'function') {
+    if (
+      headerConfig.bar === null
+      || (headerConfig.bar && typeof headerConfig.bar !== 'function')
+    ) {
       return headerConfig.bar;
     }
 

--- a/src/views/CardStack.js
+++ b/src/views/CardStack.js
@@ -195,7 +195,7 @@ class CardStack extends Component<DefaultProps, Props, void> {
       return headerConfig.bar;
     }
 
-    const renderHeader = headerConfig.bar || ((props: HeaderProps) => <Header {...props} />);
+    const renderHeader = headerConfig.bar || ((props: *) => <Header {...props} />);
 
     return renderHeader({
       ...transitionProps,

--- a/src/views/CardStack.js
+++ b/src/views/CardStack.js
@@ -189,26 +189,19 @@ class CardStack extends Component<DefaultProps, Props, void> {
       'header'
     ) || {};
 
-    if (typeof headerConfig.bar !== 'undefined') {
-      invariant(
-        headerMode === 'screen',
-        'header.bar is only supported with headerMode: screen',
-      );
-      return typeof headerConfig.bar === 'function'
-        ? headerConfig.bar({
-          ...transitionProps,
-          router: this.props.router,
-        })
-        : headerConfig.bar;
+    if (headerConfig.bar === null || typeof headerConfig.bar !== 'function') {
+      return headerConfig.bar;
     }
 
+    const HeaderComponent = headerConfig.bar || Header;
+
     return (
-      <Header
+      <HeaderComponent
         {...transitionProps}
         router={this.props.router}
         style={headerConfig.style}
         mode={headerMode}
-        onNavigateBack={() => this.props.navigation.goBack(null)}
+        onNavigateBack={() => { this.props.navigation.goBack(null); }}
         renderLeftComponent={(props: NavigationTransitionProps) => {
           const header = this.props.router.getScreenConfig(props.navigation, 'header') || {};
           return header.left;

--- a/src/views/CardStack.js
+++ b/src/views/CardStack.js
@@ -26,6 +26,7 @@ import type {
   NavigationSceneRendererProps,
   NavigationTransitionProps,
   NavigationRouter,
+  HeaderConfig,
   Style,
 } from '../TypeDefinition';
 
@@ -189,10 +190,18 @@ class CardStack extends Component<DefaultProps, Props, void> {
     transitionProps: NavigationTransitionProps,
     headerMode: HeaderMode
   ): ?React.Element<*> {
-    const headerConfig = this.props.router.getScreenConfig(
+    const headerConfig: HeaderConfig = this.props.router.getScreenConfig(
       transitionProps.navigation,
       'header'
     ) || {};
+
+    if (typeof headerConfig.bar !== 'undefined') {
+      if (headerMode === 'screen') {
+        return headerConfig.bar;
+      } else {
+        console.warn('header.bar is only supported with headerMode: screen. Ignoring');
+      }
+    }
 
     return (
       <this.props.headerComponent
@@ -283,22 +292,18 @@ class CardStack extends Component<DefaultProps, Props, void> {
     SceneComponent: ReactClass<*>,
     props: NavigationSceneRendererProps,
   ): React.Element<*> {
-    const header = this.props.router.getScreenConfig(props.navigation, 'header');
     const headerMode = this._getHeaderMode();
     if (headerMode === 'screen') {
-      const isHeaderHidden = header && header.visible === false;
-      const maybeHeader =
-        isHeaderHidden ? null : this._renderHeader(props, headerMode);
       return (
         <View style={styles.container}>
-          <View style={{flex: 1}}>
+          <View style={{ flex: 1 }}>
             <SceneView
               screenProps={this.props.screenProps}
               navigation={props.navigation}
               component={SceneComponent}
             />
           </View>
-          {maybeHeader}
+          {this._renderHeader(props, headerMode)}
         </View>
       );
     }

--- a/src/views/CardStack.js
+++ b/src/views/CardStack.js
@@ -32,6 +32,7 @@ import type {
 
 import type {
   HeaderMode,
+  HeaderProps,
 } from './Header';
 
 import type { TransitionConfig } from './TransitionConfigs';
@@ -188,42 +189,42 @@ class CardStack extends Component<DefaultProps, Props, void> {
     ) || {};
 
     if (
-      headerConfig.bar === null
-      || (headerConfig.bar && typeof headerConfig.bar !== 'function')
+      typeof headerConfig.bar !== 'undefined'
+      && typeof headerConfig.bar !== 'function'
     ) {
       return headerConfig.bar;
     }
 
-    const HeaderComponent = headerConfig.bar || Header;
+    const renderHeader = headerConfig.bar || ((props: HeaderProps) => <Header {...props} />);
 
-    return (
-      <HeaderComponent
-        {...transitionProps}
-        router={this.props.router}
-        style={headerConfig.style}
-        mode={headerMode}
-        onNavigateBack={() => { this.props.navigation.goBack(null); }}
-        renderLeftComponent={(props: NavigationTransitionProps) => {
-          const header = this.props.router.getScreenConfig(props.navigation, 'header') || {};
-          return header.left;
-        }}
-        renderRightComponent={(props: NavigationTransitionProps) => {
-          const header = this.props.router.getScreenConfig(props.navigation, 'header') || {};
-          return header.right;
-        }}
-        renderTitleComponent={(props: NavigationTransitionProps) => {
-          const header = this.props.router.getScreenConfig(props.navigation, 'header') || {};
-          // When we return 'undefined' from 'renderXComponent', header treats them as not
-          // specified and default 'renderXComponent' functions are used. In case of 'title',
-          // we return 'undefined' in case of 'string' too because the default 'renderTitle'
-          // function in header handles them.
-          if (typeof header.title === 'string') {
-            return undefined;
-          }
-          return header.title;
-        }}
-      />
-    );
+    return renderHeader({
+      ...transitionProps,
+      router: this.props.router,
+      style: headerConfig.style,
+      mode: headerMode,
+      onNavigateBack: () => {
+        this.props.navigation.goBack(null);
+      },
+      renderLeftComponent: (props: NavigationTransitionProps) => {
+        const header = this.props.router.getScreenConfig(props.navigation, 'header') || {};
+        return header.left;
+      },
+      renderRightComponent: (props: NavigationTransitionProps) => {
+        const header = this.props.router.getScreenConfig(props.navigation, 'header') || {};
+        return header.left;
+      },
+      renderTitleComponent: (props: NavigationTransitionProps) => {
+        const header = this.props.router.getScreenConfig(props.navigation, 'header') || {};
+        // When we return 'undefined' from 'renderXComponent', header treats them as not
+        // specified and default 'renderXComponent' functions are used. In case of 'title',
+        // we return 'undefined' in case of 'string' too because the default 'renderTitle'
+        // function in header handles them.
+        if (typeof header.title === 'string') {
+          return undefined;
+        }
+        return header.title;
+      },
+    });
   }
 
   _render(props: NavigationTransitionProps): React.Element<*> {

--- a/src/views/CardStack.js
+++ b/src/views/CardStack.js
@@ -8,8 +8,6 @@ import {
   View,
 } from 'react-native';
 
-import invariant from 'fbjs/lib/invariant';
-
 import Transitioner from './Transitioner';
 import Card from './Card';
 import CardStackStyleInterpolator from './CardStackStyleInterpolator';

--- a/src/views/CardStack.js
+++ b/src/views/CardStack.js
@@ -8,6 +8,8 @@ import {
   View,
 } from 'react-native';
 
+import invariant from 'fbjs/lib/invariant';
+
 import Transitioner from './Transitioner';
 import Card from './Card';
 import CardStackStyleInterpolator from './CardStackStyleInterpolator';
@@ -196,11 +198,11 @@ class CardStack extends Component<DefaultProps, Props, void> {
     ) || {};
 
     if (typeof headerConfig.bar !== 'undefined') {
-      if (headerMode === 'screen') {
-        return headerConfig.bar;
-      } else {
-        console.warn('header.bar is only supported with headerMode: screen. Ignoring');
-      }
+      invariant(
+        headerMode === 'screen',
+        'header.bar is only supported with headerMode: screen',
+      );
+      return headerConfig.bar;
     }
 
     return (
@@ -296,7 +298,7 @@ class CardStack extends Component<DefaultProps, Props, void> {
     if (headerMode === 'screen') {
       return (
         <View style={styles.container}>
-          <View style={{ flex: 1 }}>
+          <View style={styles.scene}>
             <SceneView
               screenProps={this.props.screenProps}
               navigation={props.navigation}
@@ -390,6 +392,9 @@ const styles = StyleSheet.create({
     flexDirection: 'column-reverse',
   },
   scenes: {
+    flex: 1,
+  },
+  scene: {
     flex: 1,
   },
 });


### PR DESCRIPTION
Fixes #570
Fixes #100 
Fixes #53

Brings back `header.bar` instead of `headerComponent`. Removes `header.visible`. Use `null` value to hide it for a specific screen.

Works for `headerMode: float` (with a small glitch we can tackle in next PR).

Tested the following:
```js
const SimpleStack = StackNavigator({}, {
  navigationOptions: {
    header: {
      bar: CardStack.Header,
    },
  },
});
```
no-issues, that's the default effect.

Another case:
```js
navigationOptions: {
    header: {
      bar: null,
    },
  },
```
on per screen basis.