### PR TITLE
Add getScreenConfig prop for DrawerNavigator contentComponent

### DIFF
--- a/src/views/Drawer/DrawerNavigatorItems.js
+++ b/src/views/Drawer/DrawerNavigatorItems.js
@@ -14,6 +14,7 @@ import type {
   NavigationState,
   NavigationRoute,
   NavigationAction,
+  NavigationRouter,
   Style,
 } from '../../TypeDefinition';
 import type {
@@ -29,6 +30,7 @@ type Props = {
   getLabel: (scene: DrawerScene) => ?(React.Element<*> | string);
   renderIcon: (scene: DrawerScene) => ?React.Element<*>;
   style?: Style;
+  router: NavigationRouter;
 };
 
 /**

--- a/src/views/Drawer/DrawerSidebar.js
+++ b/src/views/Drawer/DrawerSidebar.js
@@ -81,6 +81,7 @@ class DrawerSidebar extends PureComponent<void, Props, void> {
           navigation={this.props.navigation}
           getLabel={this._getLabel}
           renderIcon={this._renderIcon}
+          rotuer={this.props.router}
         />
       </View>
     );


### PR DESCRIPTION
The PR adds `getScreenConfig` property to the Drawer`s content component. 
If one needs to implement custom drawer menu (in place of `DrawerNavigatorItems`), he may want to also customize navigation options. The PR makes it possible.

*It is a PR-in-discussion, which may be altered or declined* (the related issue is here #478)