### PR TITLE
Solves TabBarBottom item layout to match iOS UITabBar HIG

### DIFF
--- a/src/views/TabView/TabBarBottom.js
+++ b/src/views/TabView/TabBarBottom.js
@@ -166,7 +166,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#f4f4f4', // Default background color in iOS 10
   },
   tab: {
-    flexGrow: 1,
+    flex: 1,
     alignItems: 'stretch',
     justifyContent: 'flex-end',
   },


### PR DESCRIPTION
Instead of `flexGrow`, `TabBarBottom` should use `flex` in order to match iOS HIG for UITabBar. Otherwise, if labels with different length are set, the layout of the tab bar isn't consistent with what iOS users expect (tab highlighted with red border):

![screen shot 2017-02-27 at 11 23 27](https://cloud.githubusercontent.com/assets/289640/23364131/07103c5a-fcfe-11e6-8b7a-d7bc28ca3080.png)

After the change, this is how the tab bar looks:

<img width="429" alt="screen shot 2017-02-27 at 15 14 35" src="https://cloud.githubusercontent.com/assets/289640/23364470/7f652e76-fcff-11e6-9e84-8a0efa7d9c5d.png">

**Test plan (required)**

Tests pass and both Android and iOS `NavigationPlayground` example looks OK.

