### PR TITLE
Use back action instead of pushing initial route for empty deep link

### DIFF
--- a/examples/NavigationPlayground/js/App.js
+++ b/examples/NavigationPlayground/js/App.js
@@ -63,6 +63,18 @@ const ExampleRoutes = {
     screen: SimpleTabs,
     path: 'settings',
   },
+  LinkStackRootWithinTab: {
+    name: 'Link to stack root within tab',
+    description: 'Deep linking into a route in tab',
+    screen: StacksInTabs,
+    path: 'settings',
+  },
+  LinkStackSecondaryScreenWithinTab: {
+    name: 'Link to stack secondary screen within tab',
+    description: 'Deep linking into a route in a stack in a tab',
+    screen: StacksInTabs,
+    path: 'people/Jordan',
+  },
 };
 
 const MainScreen = ({ navigation }) => (

--- a/examples/NavigationPlayground/js/StacksInTabs.js
+++ b/examples/NavigationPlayground/js/StacksInTabs.js
@@ -71,14 +71,14 @@ const MySettingsScreen = ({ navigation }) => (
 const MainTab = StackNavigator({
   Home: {
     screen: MyHomeScreen,
-    path: '/',
+    path: '',
     navigationOptions: {
       title: () => 'Welcome',
     },
   },
   Profile: {
     screen: MyProfileScreen,
-    path: '/people/:name',
+    path: 'people/:name',
     navigationOptions: {
       title: ({ state }) => `${state.params.name}'s Profile!`,
     },
@@ -88,7 +88,7 @@ const MainTab = StackNavigator({
 const SettingsTab = StackNavigator({
   Settings: {
     screen: MySettingsScreen,
-    path: '/',
+    path: '',
     navigationOptions: {
       title: () => 'Settings',
     },
@@ -104,7 +104,7 @@ const SettingsTab = StackNavigator({
 const StacksInTabs = TabNavigator({
   MainTab: {
     screen: MainTab,
-    path: '/',
+    path: '',
     navigationOptions: {
       tabBar: () => ({
         label: 'Home',
@@ -120,7 +120,7 @@ const StacksInTabs = TabNavigator({
   },
   SettingsTab: {
     screen: SettingsTab,
-    path: '/settings',
+    path: 'settings',
     navigationOptions: {
       tabBar: () => ({
         label: 'Settings',

--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -238,10 +238,10 @@ export default (
 
     getActionForPathAndParams(pathToResolve: string): ?NavigationAction {
       // If the path is empty (null or empty string)
-      // just return the initial route action
+      // just return back to the initial route
       if (!pathToResolve) {
-        return NavigationActions.navigate({
-          routeName: initialRouteName,
+        return NavigationActions.back({
+          key: 'Init',
         });
       }
 

--- a/src/routers/__tests__/StackRouter-test.js
+++ b/src/routers/__tests__/StackRouter-test.js
@@ -528,7 +528,7 @@ describe('StackRouter', () => {
       },
     }, { initialRouteName: 'Bar' });
     const action = router.getActionForPathAndParams('');
-    expect(action).toEqual({ type: NavigationActions.NAVIGATE, routeName: 'Bar' });
+    expect(action).toEqual({ type: NavigationActions.BACK, key: 'Init' });
     let state = null;
     if (action) {
       state = router.getStateForAction(action);


### PR DESCRIPTION
**Summary**

This PR solves the following scenario: An app consists of a tab navigator with nested stack navigators, and desire to deep link to stack initial route (root of stack navigator within a tab).

Example:
- Tabs have paths: `hello`, `test`
- Stack within `hello` tab has an empty path (the root) and another tab, `world`.

Currently, the only way to navigate to the root via deep link is something like `app://hello/fake_url_here` so it hits the `null` case in `getActionForPathAndParams` ([source](https://github.com/react-community/react-navigation/blob/master/src/routers/StackRouter.js#L266))

This change makes it possible to navigate to the expected `app://hello`. Before, this url would have navigated to the stack tab, and then pushed an additional copy of the `initialRoute` onto the stack  ([source](https://github.com/react-community/react-navigation/blob/master/src/routers/StackRouter.js#L243)).

Other related changes:
- update paths to be consistent with `SimpleStack` (remove leading slashes)

**Test plan**

- Run test case covering this code, see that it passes with expected modifications.
- Run playground, test both new cases (`LinkStackRootWithinTab` tests this behavior exactly).
- Test locally in separate production app.
