### PR TITLE
Query string parsing capabilities for deep linking

### DIFF
--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -245,7 +245,9 @@ export default (
         });
       }
 
-      // Attempt to match `pathToResolve` with a route in this router's
+      const [pathNameToResolve, queryString] = pathToResolve.split('?');
+
+      // Attempt to match `pathNameToResolve` with a route in this router's
       // routeConfigs
       let matchedRouteName;
       let pathMatch;
@@ -254,7 +256,7 @@ export default (
       for (const routeName in paths) {
         /* $FlowFixMe */
         const { re, keys } = paths[routeName];
-        pathMatch = re.exec(pathToResolve);
+        pathMatch = re.exec(pathNameToResolve);
         if (pathMatch && pathMatch.length) {
           pathMatchKeys = keys;
           matchedRouteName = routeName;
@@ -279,6 +281,18 @@ export default (
         );
       }
 
+      // reduce the items of the query string. any query params may
+      // be overridden by path params
+      const queryParams = (queryString || '').split('&').reduce((result: *, item: string) => {
+        if (item !== '') {
+          const nextResult = result || {};
+          const [key, value] = item.split('=');
+          nextResult[key] = value;
+          return nextResult;
+        }
+        return result;
+      }, null);
+
       // reduce the matched pieces of the path into the params
       // of the route. `params` is null if there are no params.
       /* $FlowFixMe */
@@ -291,7 +305,8 @@ export default (
         const paramName = key.name;
         nextResult[paramName] = matchResult;
         return nextResult;
-      }, null);
+      }, queryParams);
+
 
       return NavigationActions.navigate({
         routeName: matchedRouteName,

--- a/src/routers/__tests__/StackRouter-test.js
+++ b/src/routers/__tests__/StackRouter-test.js
@@ -186,12 +186,13 @@ describe('StackRouter', () => {
   });
 
   test('Parses paths with a query', () => {
-    expect(TestStackRouter.getActionForPathAndParams('people/foo?code=test')).toEqual({
+    expect(TestStackRouter.getActionForPathAndParams('people/foo?code=test&foo=bar')).toEqual({
       type: NavigationActions.NAVIGATE,
       routeName: 'person',
       params: {
         id: 'foo',
         code: 'test',
+        foo: 'bar',
       },
     });
   });

--- a/src/routers/__tests__/StackRouter-test.js
+++ b/src/routers/__tests__/StackRouter-test.js
@@ -185,6 +185,17 @@ describe('StackRouter', () => {
     });
   });
 
+  test('Parses paths with a query', () => {
+    expect(TestStackRouter.getActionForPathAndParams('people/foo?code=test')).toEqual({
+      type: NavigationActions.NAVIGATE,
+      routeName: 'person',
+      params: {
+        id: 'foo',
+        code: 'test',
+      },
+    });
+  });
+
 
   test('Correctly parses a path without arguments into an action chain', () => {
     const uri = 'auth/login';

--- a/src/routers/__tests__/StackRouter-test.js
+++ b/src/routers/__tests__/StackRouter-test.js
@@ -197,6 +197,17 @@ describe('StackRouter', () => {
     });
   });
 
+  test('Parses paths with an empty query value', () => {
+    expect(TestStackRouter.getActionForPathAndParams('people/foo?code=&foo=bar')).toEqual({
+      type: NavigationActions.NAVIGATE,
+      routeName: 'person',
+      params: {
+        id: 'foo',
+        code: '',
+        foo: 'bar',
+      },
+    });
+  });
 
   test('Correctly parses a path without arguments into an action chain', () => {
     const uri = 'auth/login';


### PR DESCRIPTION
This PR adds query string parsing capabilities. The items of the query string will be added to the `params` object of a navigation action. When there are same-named params in the query and the path, the params from the path will override the ones from the query.

**Motivation**
In my app I needed this capability, because I have a deep link `/redeem_key?key=<key>&name=<name>`. As with query params in the web, the ordering shouldn't be significant.

**Test plan (required)**
I added a test case that verifies the functionality. There are no UI changes and it shouldn't affect any platform-specific code.

I'm happy to add more test cases or documentation, if you find this PR useful.
