### PR TITLE
Accept tabBar label to be a function

### DIFF
--- a/src/views/TabView/TabBarBottom.js
+++ b/src/views/TabView/TabBarBottom.js
@@ -89,17 +89,8 @@ export default class TabBarBottom extends PureComponent<DefaultProps, Props, voi
         </Animated.Text>
       );
     }
-    
     if (typeof label === 'function') {
-      const st = [styles.label, { color: inactiveTintColor }, labelStyle];
-      const params = {
-        ...scene,
-        defaultStyles: StyleSheet.flatten(st)
-      };
-
-      return (
-        label(params)
-      )
+      return label(scene);
     }
 
     return label;

--- a/src/views/TabView/TabBarBottom.js
+++ b/src/views/TabView/TabBarBottom.js
@@ -89,6 +89,18 @@ export default class TabBarBottom extends PureComponent<DefaultProps, Props, voi
         </Animated.Text>
       );
     }
+    
+    if (typeof label === 'function') {
+      const st = [styles.label, { color: inactiveTintColor }, labelStyle];
+      const params = {
+        ...scene,
+        defaultStyles: StyleSheet.flatten(st)
+      };
+
+      return (
+        label(params)
+      )
+    }
 
     return label;
   };

--- a/src/views/TabView/TabBarTop.js
+++ b/src/views/TabView/TabBarTop.js
@@ -84,6 +84,9 @@ export default class TabBarTop extends PureComponent<DefaultProps, Props, void> 
         </Animated.Text>
       );
     }
+    if (typeof label === 'function') {
+      return label(scene);
+    }
 
     return label;
   };


### PR DESCRIPTION
It could be useful to dynamically change (`focused`) tabBar label default styles for certain tab(s).
This pull request is aim to discuss how to implement it properly. 

Usage example: 
```js
navigationOptions: {
  tabBar: {
    icon: ({ focused }) => <TabItem focused={focused} name="whatshot" activeColor="red" />,
    label: ({ focused, tintColor, defaultStyles }) => {
      return (<Text style={[defaultStyles, { color: focused ? 'red' : defaultStyles.color }]}>Profile</Text>);
    },
  }
},
```

Current implementation provided but without `Animated.Text` color specification  