### PR TITLE
Truncate long header title

### DIFF
--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -231,8 +231,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
       }
       : undefined;
 
-    const titleWidth = this.state.widths[key];
-    const availableWidth = (props.layout.initWidth - titleWidth) / 2;
+    const availableWidth = (props.layout.initWidth - this.state.widths[key]) / 2;
 
     return (
       <Animated.View

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -231,9 +231,8 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
       }
       : undefined;
 
-    const titleWidth = name === 'left' || name === 'right'
-      ? this.state.widths[key]
-      : undefined;
+    const titleWidth = this.state.widths[key];
+    const availableWidth = (props.layout.initWidth - titleWidth) / 2;
 
     return (
       <Animated.View
@@ -241,8 +240,8 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
         onLayout={onLayoutIOS}
         key={`${name}_${key}`}
         style={[
-          titleWidth && {
-            width: (props.layout.initWidth - titleWidth) / 2,
+          name !== 'title' && {
+            width: availableWidth > 70 ? availableWidth : 70,
           },
           styles.item,
           styles[name],
@@ -336,7 +335,9 @@ const styles = StyleSheet.create({
       flex: 1,
       alignItems: 'flex-start',
     }
-    : {},
+    : {
+      flex: 1,
+    },
   left: {
     alignItems: 'flex-start',
   },


### PR DESCRIPTION
Fix #540 

Added a minimum value that left/right can take on iOS so that it doesn't push left/right off the screen.

Waiting for the OP to check the PR on his own and see if it fixes the problem.

<img width="386" alt="screen shot 2017-03-02 at 13 07 42" src="https://cloud.githubusercontent.com/assets/2464966/23506575/50f898ec-ff49-11e6-8b7d-ac076880f43f.png">
