### PR TITLE
Change <Header /> layout back to `absolute`

### DIFF
--- a/docs/guides/Redux-Integration.md
+++ b/docs/guides/Redux-Integration.md
@@ -5,6 +5,8 @@ To handle your app's navigation state in redux, you can pass your own `navigatio
 With redux, your app's state is defined by a reducer. Each navigation router effectively has a reducer, called `getStateForAction`. The following is a minimal example of how you might use navigators within a redux application:
 
 ```
+import { addNavigationHelpers } from 'react-navigation';
+
 const AppNavigator = StackNavigator(AppRouteConfigs);
 
 const navReducer = (state, action) => {

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -181,17 +181,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
     );
   }
 
-  _renderTitle(props: NavigationSceneRendererProps): ?React.Element<*> {
-    return this._renderSubView(
-      props,
-      'title',
-      this.props.renderTitleComponent,
-      this._renderTitleComponent,
-      HeaderStyleInterpolator.forCenter,
-    );
-  }
-
-  _renderRight(props: NavigationSceneRendererProps, options: *): ?React.Element<*> {
+  _renderTitle(props: NavigationSceneRendererProps, options: *): ?React.Element<*> {
     const style = {};
 
     if (Platform.OS === 'android') {
@@ -203,6 +193,16 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
       }
     }
 
+    return this._renderSubView(
+      { ...props, style },
+      'title',
+      this.props.renderTitleComponent,
+      this._renderTitleComponent,
+      HeaderStyleInterpolator.forCenter,
+    );
+  }
+
+  _renderRight(props: NavigationSceneRendererProps): ?React.Element<*> {
     return this._renderSubView(
       props,
       'right',
@@ -247,6 +247,10 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
       subView = defaultRenderer(subViewProps);
     }
 
+    if (subView === null) {
+      return null;
+    }
+
     const pointerEvents = offset !== 0 || isStale ? 'none' : 'box-none';
 
     return (
@@ -254,9 +258,9 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
         pointerEvents={pointerEvents}
         key={`${name}_${key}`}
         style={[
-          props.style,
           styles.item,
           styles[name],
+          props.style,
           styleInterpolator(props),
         ]}
       >
@@ -352,6 +356,9 @@ const styles = StyleSheet.create({
     right: TITLE_OFFSET,
     top: 0,
     position: 'absolute',
+    alignItems: Platform.OS === 'android'
+      ? 'flex-start'
+      : 'center',
   },
   left: {
     left: 0,

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -58,6 +58,7 @@ type HeaderState = {
 
 const APPBAR_HEIGHT = Platform.OS === 'ios' ? 44 : 56;
 const STATUSBAR_HEIGHT = Platform.OS === 'ios' ? 20 : 0;
+const TITLE_OFFSET = Platform.OS === 'ios' ? 70 : 40;
 
 class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
 
@@ -346,8 +347,8 @@ const styles = StyleSheet.create({
   },
   title: {
     bottom: 0,
-    left: 70,
-    right: 70,
+    left: TITLE_OFFSET,
+    right: TITLE_OFFSET,
     top: 0,
     position: 'absolute',
   },

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -307,7 +307,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
       appBar = scenesProps.map(this._renderHeader, this);
     } else {
       appBar = this._renderHeader({
-        ...this.props,
+        ...NavigationPropTypes.extractSceneRendererProps(this.props),
         position: new Animated.Value(this.props.scene.index),
         progress: new Animated.Value(0),
       });

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -155,20 +155,15 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
       state: props.scenes[props.scene.index - 1].route,
     });
     const backButtonTitle = this._getBackButtonTitle(previousNavigation);
-
-    const titleWidth = this.state.widths[props.key];
-    const availableWidth = titleWidth
-      ? (props.layout.initWidth - titleWidth) / 2
+    const width = this.state.widths[props.key]
+      ? (props.layout.initWidth - this.state.widths[props.key]) / 2
       : undefined;
-    console.log(titleWidth, props.layout.initWidth);
     return (
       <HeaderBackButton
         onPress={props.onNavigateBack}
         tintColor={tintColor}
         title={backButtonTitle}
-        style={availableWidth && {
-          width: availableWidth > 70 ? availableWidth : 70,
-        }}
+        width={width}
       />
     );
   };
@@ -351,8 +346,8 @@ const styles = StyleSheet.create({
   },
   title: {
     bottom: 0,
-    left: 40,
-    right: 40,
+    left: 70,
+    right: 70,
     top: 0,
     position: 'absolute',
   },

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -231,8 +231,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
       }
       : undefined;
 
-    const titleWidth = this.state.widths[key];
-    const availableWidth = (props.layout.initWidth - titleWidth) / 2;
+    const availableWidth = (props.layout.initWidth - this.state.widths[key]) / 2;
 
     return (
       <Animated.View

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -340,11 +340,11 @@ const styles = StyleSheet.create({
   },
   header: {
     flexDirection: 'row',
-    backgroundColor: 'transparent',
   },
   item: {
     justifyContent: 'center',
     alignItems: 'center',
+    backgroundColor: 'transparent',
   },
   title: {
     bottom: 0,

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -231,9 +231,8 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
       }
       : undefined;
 
-    const titleWidth = name === 'left' || name === 'right'
-      ? this.state.widths[key]
-      : undefined;
+    const titleWidth = this.state.widths[key];
+    const availableWidth = (props.layout.initWidth - titleWidth) / 2;
 
     return (
       <Animated.View
@@ -241,8 +240,8 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
         onLayout={onLayoutIOS}
         key={`${name}_${key}`}
         style={[
-          titleWidth && {
-            width: (props.layout.initWidth - titleWidth) / 2,
+          name !== 'title' && {
+            width: availableWidth > 70 ? availableWidth : 70,
           },
           styles.item,
           styles[name],
@@ -336,7 +335,9 @@ const styles = StyleSheet.create({
       flex: 1,
       alignItems: 'flex-start',
     }
-    : {},
+    : {
+      flex: 1,
+    },
   left: {
     alignItems: 'flex-start',
   },

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -254,6 +254,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
         pointerEvents={pointerEvents}
         key={`${name}_${key}`}
         style={[
+          props.style,
           styles.item,
           styles[name],
           styleInterpolator(props),

--- a/src/views/HeaderBackButton.js
+++ b/src/views/HeaderBackButton.js
@@ -10,7 +10,7 @@ import {
   StyleSheet,
 } from 'react-native';
 
-import type { LayoutEvent } from '../TypeDefinition';
+import type { LayoutEvent, Style } from '../TypeDefinition';
 
 import TouchableItem from './TouchableItem';
 
@@ -19,6 +19,7 @@ type Props = {
   title?: ?string,
   tintColor?: ?string,
   truncatedTitle?: ?string,
+  style?: ?Style,
 };
 
 type DefaultProps = {
@@ -37,6 +38,7 @@ class HeaderBackButton extends React.PureComponent<DefaultProps, Props, State> {
     title: PropTypes.string,
     tintColor: PropTypes.string,
     truncatedTitle: PropTypes.string,
+    style: PropTypes.object,
   };
 
   static defaultProps = {
@@ -67,7 +69,7 @@ class HeaderBackButton extends React.PureComponent<DefaultProps, Props, State> {
   };
 
   render() {
-    const { onPress, title, tintColor, truncatedTitle } = this.props;
+    const { onPress, style, title, tintColor, truncatedTitle } = this.props;
 
     const renderTruncated = this.state.containerWidth && this.state.initialTextWidth
       ? this.state.containerWidth < this.state.initialTextWidth
@@ -77,7 +79,7 @@ class HeaderBackButton extends React.PureComponent<DefaultProps, Props, State> {
       <TouchableItem
         delayPressIn={0}
         onPress={onPress}
-        style={styles.container}
+        style={[styles.container, style]}
         borderless
       >
         <View
@@ -112,7 +114,6 @@ const styles = StyleSheet.create({
   container: {
     alignItems: 'center',
     flexDirection: 'row',
-    backgroundColor: 'transparent',
   },
   title: {
     fontSize: 17,

--- a/src/views/HeaderBackButton.js
+++ b/src/views/HeaderBackButton.js
@@ -100,6 +100,7 @@ const styles = StyleSheet.create({
   container: {
     alignItems: 'center',
     flexDirection: 'row',
+    backgroundColor: 'transparent',
   },
   title: {
     fontSize: 17,

--- a/src/views/HeaderBackButton.js
+++ b/src/views/HeaderBackButton.js
@@ -10,7 +10,7 @@ import {
   StyleSheet,
 } from 'react-native';
 
-import type { LayoutEvent, Style } from '../TypeDefinition';
+import type { LayoutEvent } from '../TypeDefinition';
 
 import TouchableItem from './TouchableItem';
 

--- a/src/views/HeaderBackButton.js
+++ b/src/views/HeaderBackButton.js
@@ -19,7 +19,7 @@ type Props = {
   title?: ?string,
   tintColor?: ?string,
   truncatedTitle?: ?string,
-  style?: ?Style,
+  width?: ?number,
 };
 
 type DefaultProps = {
@@ -28,7 +28,6 @@ type DefaultProps = {
 };
 
 type State = {
-  containerWidth?: number,
   initialTextWidth?: number,
 };
 
@@ -38,7 +37,7 @@ class HeaderBackButton extends React.PureComponent<DefaultProps, Props, State> {
     title: PropTypes.string,
     tintColor: PropTypes.string,
     truncatedTitle: PropTypes.string,
-    style: PropTypes.object,
+    width: PropTypes.number,
   };
 
   static defaultProps = {
@@ -50,15 +49,6 @@ class HeaderBackButton extends React.PureComponent<DefaultProps, Props, State> {
 
   state = {};
 
-  _onContainerLayout = (e: LayoutEvent) => {
-    if (Platform.OS !== 'ios') {
-      return;
-    }
-    this.setState({
-      containerWidth: e.nativeEvent.layout.width,
-    });
-  };
-
   _onTextLayout = (e: LayoutEvent) => {
     if (this.state.initialTextWidth) {
       return;
@@ -69,23 +59,20 @@ class HeaderBackButton extends React.PureComponent<DefaultProps, Props, State> {
   };
 
   render() {
-    const { onPress, style, title, tintColor, truncatedTitle } = this.props;
+    const { onPress, width, title, tintColor, truncatedTitle } = this.props;
 
-    const renderTruncated = this.state.containerWidth && this.state.initialTextWidth
-      ? this.state.containerWidth < this.state.initialTextWidth
+    const renderTruncated = this.state.initialTextWidth && width
+      ? this.state.initialTextWidth > width
       : false;
 
     return (
       <TouchableItem
         delayPressIn={0}
         onPress={onPress}
-        style={[styles.container, style]}
+        style={styles.container}
         borderless
       >
-        <View
-          onLayout={this._onContainerLayout}
-          style={styles.container}
-        >
+        <View style={styles.container}>
           <Image
             style={[
               styles.icon,
@@ -96,7 +83,6 @@ class HeaderBackButton extends React.PureComponent<DefaultProps, Props, State> {
           />
           {Platform.OS === 'ios' && title && (
             <Text
-              ellipsizeMode="middle"
               onLayout={this._onTextLayout}
               style={[styles.title, { color: tintColor }]}
               numberOfLines={1}


### PR DESCRIPTION
This pull request fixes all issues regarding Header that were already filled in by:

1) Reverting previous `absolute` layout - turns `flex` looks nice and was easier to implement, but caused too many issues and it was impossible to keep it going forward
2) `onLayout` is async and it causes flickering as reported in issues - this PR makes sure absence of `onLayout` causes no issues. It does so by not touching layout at all. As soon as width of title is known, we only manipulate back button. No other parts are touched. Right and title stay as they used to be.
3) on iOS, title offset is `70`, whereas on `Android` 40 (as it used to be). This is because on iOS, by default we want to render `< Back` when title is too long. This is to make sure we end up with a well truncated title. Having `40` would cover part of `Back` string.

Fixes: #540 #539 #445