### PR TITLE
correction of a few documentation typo

### DIFF
--- a/docs/api/routers/Routers.md
+++ b/docs/api/routers/Routers.md
@@ -105,8 +105,8 @@ const MyApp = StackNavigator({
 }, {
   initialRouteName: 'Home',
 })
-MyApp.router = {
-  ...MyApp.router,
+const previousGetActionForPathAndParams = MyApp.router.getActionForPathAndParams
+Object.assign(MyApp.router, {
   getActionForPathAndParams(path, params) {
     if (
       path === 'my/custom/path' &&
@@ -124,7 +124,7 @@ MyApp.router = {
       });
       return null;
     }
-    return MyApp.router.getStateForAction(action, state);
+    return previousGetActionForPathAndParams(path, params);
   },
 };
 ```

--- a/docs/api/routers/RoutersAPI.md
+++ b/docs/api/routers/RoutersAPI.md
@@ -4,7 +4,7 @@ You can make your own router by building an object with the following functions:
 
 ```js
 const MyRouter = {
-  getStateForAction: (action) => ({}),
+  getStateForAction: (action, state) => ({}),
   getActionForPathAndParams: (path, params) => null,
   getPathAndParamsForState: (state) => null,
   getComponentForState: (state) => MyScreen,
@@ -51,7 +51,7 @@ Typically this should return a navigation state, with the following form:
 
 If the router has handled the action externally, or wants to swallow it without changing the navigation state, this function will return `null`.
 
-### `getComponentRouteName(routeName)`
+### `getComponentForRouteName(routeName)`
 
 Returns the child component or navigator for the given route name.
 


### PR DESCRIPTION
Hi,

Some typos on docs (So I think).

The less obvious is on https://reactnavigation.org/docs/routers/ : 
The sample says that we can override methodes. But I think it is not true, at least on StackNavigator.
On StackNavigator, the router is a constant (https://github.com/react-community/react-navigation/blob/master/src/navigators/StackNavigator.js).
What worked for me is to use 
Object.assign(MyApp.router, { ...}) 
to keep the same instance but change properties.

Also, to override, we need keep a ref on previous methid because we can't call MyApp.router.getStateForAction(action, state) : I think it will result in an infinite loop.