### PR TITLE
Custom header style interpolator

### DIFF
--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -105,7 +105,7 @@ Visual options:
   - `float` - Render a single header that stays at the top and animates as screens are changed. This is a common pattern on iOS.
   - `screen` - Each screen has a header attached to it and the header fades in and out together with the screen. This is a common pattern on Android.
   - `none` - No header will be rendered.
-- `headerStyleInterpolator` - Use this prop to override the default  Custom header style interpolator when transitioning
+- `headerStyleInterpolator` - Use this prop to override the default header style interpolator when transitioning
 - `cardStyle` - Use this prop to override or extend the default style for an individual card in stack.
 - `onTransitionStart` - Function to be invoked when the card transition animation is about to start.
 - `onTransitionEnd` - Function to be invoked once the card transition animation completes.

--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -68,6 +68,27 @@ StackNavigator({
 
 ### StackNavigatorConfig
 
+```js
+StackNavigator({
+  ...MyRoutes,
+}, {
+  initialRouteName: 'Profile',  
+  headerMode: 'float',
+  headerStyleInterpolator: {
+    forCenter: (props) {
+      const { position, scene } = props;
+      const { index } = scene;
+      return {
+        opacity: position.interpolate({
+          inputRange: [index - 1, index, index + 1],
+          outputRange: [0, 1, 0],
+        }),
+      };
+    },   
+  },
+});
+```
+
 Options for the router:
 
 - `initialRouteName` - Sets the default screen of the stack. Must match one of the keys in route configs.
@@ -84,7 +105,7 @@ Visual options:
   - `float` - Render a single header that stays at the top and animates as screens are changed. This is a common pattern on iOS.
   - `screen` - Each screen has a header attached to it and the header fades in and out together with the screen. This is a common pattern on Android.
   - `none` - No header will be rendered.
-- `headerStyleInterpolator` - Custom header style interpolator when transitioning
+- `headerStyleInterpolator` - Use this prop to override the default  Custom header style interpolator when transitioning
 - `cardStyle` - Use this prop to override or extend the default style for an individual card in stack.
 - `onTransitionStart` - Function to be invoked when the card transition animation is about to start.
 - `onTransitionEnd` - Function to be invoked once the card transition animation completes.

--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -84,6 +84,7 @@ Visual options:
   - `float` - Render a single header that stays at the top and animates as screens are changed. This is a common pattern on iOS.
   - `screen` - Each screen has a header attached to it and the header fades in and out together with the screen. This is a common pattern on Android.
   - `none` - No header will be rendered.
+- `headerStyleInterpolator` - Custom header style interpolator when transitioning
 - `cardStyle` - Use this prop to override or extend the default style for an individual card in stack.
 - `onTransitionStart` - Function to be invoked when the card transition animation is about to start.
 - `onTransitionEnd` - Function to be invoked once the card transition animation completes.

--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -11,6 +11,10 @@ import type {
   HeaderProps,
 } from './views/Header';
 
+import type {
+  HeaderStyleInterpolatorSpec,
+} from './views/HeaderStyleInterpolator';
+
 /**
  * NavigationState is a tree of routes for a single navigator, where each child
  * route may either be a NavigationScreenRoute or a NavigationRouterRoute.
@@ -274,6 +278,7 @@ export type NavigationStackViewConfig = {
   mode?: 'card' | 'modal',
   headerMode?: HeaderMode,
   headerComponent?: ReactClass<HeaderProps<*>>,
+  headerStyleInterpolator?: HeaderStyleInterpolatorSpec,
   cardStyle?: Style,
   onTransitionStart?: () => void,
   onTransitionEnd?: () => void

--- a/src/navigators/StackNavigator.js
+++ b/src/navigators/StackNavigator.js
@@ -26,6 +26,7 @@ export default (routeConfigMap: NavigationRouteConfigMap, stackConfig: StackNavi
     paths,
     headerComponent,
     headerMode,
+    headerStyleInterpolator,
     mode,
     cardStyle,
     onTransitionStart,
@@ -44,6 +45,7 @@ export default (routeConfigMap: NavigationRouteConfigMap, stackConfig: StackNavi
       {...props}
       headerComponent={headerComponent}
       headerMode={headerMode}
+      headerStyleInterpolator={headerStyleInterpolator}
       mode={mode}
       cardStyle={cardStyle}
       onTransitionStart={onTransitionStart}

--- a/src/views/CardStack.js
+++ b/src/views/CardStack.js
@@ -33,6 +33,10 @@ import type {
   HeaderMode,
 } from './Header';
 
+import type {
+  HeaderStyleInterpolatorSpec,
+} from './HeaderStyleInterpolator';
+
 import type { TransitionConfig } from './TransitionConfigs';
 
 import TransitionConfigs from './TransitionConfigs';
@@ -43,6 +47,7 @@ type Props = {
   screenProps?: {};
   headerMode: HeaderMode,
   headerComponent?: ReactClass<*>,
+  headerStyleInterpolator?: HeaderStyleInterpolatorSpec,
   mode: 'card' | 'modal',
   navigation: NavigationScreenProp<*, NavigationAction>,
   router: NavigationRouter,
@@ -96,6 +101,15 @@ class CardStack extends Component<DefaultProps, Props, void> {
      * Custom React component to be used as a header
      */
     headerComponent: PropTypes.func,
+
+    /**
+     * Custom header style interpolator when transitioning
+     */
+    headerStyleInterpolator: PropTypes.shape({
+      forLeft: PropTypes.func,
+      forCenter: PropTypes.func,
+      forRight: PropTypes.func,
+    }),
 
     /**
      * Style of the cards movement. Value could be `card` or `modal`.
@@ -204,6 +218,7 @@ class CardStack extends Component<DefaultProps, Props, void> {
         router={this.props.router}
         style={headerConfig.style}
         mode={headerMode}
+        styleInterpolator={this.props.headerStyleInterpolator}
         onNavigateBack={() => this.props.navigation.goBack(null)}
         renderLeftComponent={(props: NavigationTransitionProps) => {
           const header = this.props.router.getScreenConfig(props.navigation, 'header') || {};

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -28,6 +28,10 @@ import type {
   Style,
 } from '../TypeDefinition';
 
+import type {
+ HeaderStyleInterpolatorSpec,
+} from './HeaderStyleInterpolator';
+
 export type HeaderMode = 'float' | 'screen' | 'none';
 
 type SubViewProps = NavigationSceneRendererProps & {
@@ -37,6 +41,10 @@ type SubViewProps = NavigationSceneRendererProps & {
 type Navigation = NavigationScreenProp<*, NavigationAction>;
 
 type SubViewRenderer = (subViewProps: SubViewProps) => ?React.Element<any>;
+
+type DefaultProps = {
+  styleInterpolator: HeaderStyleInterpolatorSpec,
+};
 
 export type HeaderProps = NavigationSceneRendererProps & {
   mode: HeaderMode,
@@ -60,7 +68,7 @@ const APPBAR_HEIGHT = Platform.OS === 'ios' ? 44 : 56;
 const STATUSBAR_HEIGHT = Platform.OS === 'ios' ? 20 : 0;
 const TITLE_OFFSET = Platform.OS === 'ios' ? 70 : 40;
 
-class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
+class Header extends React.PureComponent<DefaultProps, HeaderProps, HeaderState> {
 
   static HEIGHT = APPBAR_HEIGHT + STATUSBAR_HEIGHT;
   static Title = HeaderTitle;
@@ -75,6 +83,15 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
     renderTitleComponent: PropTypes.func,
     router: PropTypes.object,
     style: PropTypes.any,
+    styleInterpolator: PropTypes.shape({
+      forLeft: PropTypes.func,
+      forCenter: PropTypes.func,
+      forRight: PropTypes.func,
+    }),
+  };
+
+  static defaultProps = {
+    styleInterpolator: HeaderStyleInterpolator,
   };
 
   props: HeaderProps;
@@ -177,7 +194,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
       'left',
       this.props.renderLeftComponent,
       this._renderLeftComponent,
-      HeaderStyleInterpolator.forLeft,
+      this.props.styleInterpolator.forLeft,
     );
   }
 
@@ -198,7 +215,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
       'title',
       this.props.renderTitleComponent,
       this._renderTitleComponent,
-      HeaderStyleInterpolator.forCenter,
+      this.props.styleInterpolator.forCenter,
     );
   }
 
@@ -208,7 +225,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
       'right',
       this.props.renderRightComponent,
       this._renderRightComponent,
-      HeaderStyleInterpolator.forRight,
+      this.props.styleInterpolator.forRight,
     );
   }
 

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -42,10 +42,6 @@ type Navigation = NavigationScreenProp<*, NavigationAction>;
 
 type SubViewRenderer = (subViewProps: SubViewProps) => ?React.Element<any>;
 
-type DefaultProps = {
-  styleInterpolator: HeaderStyleInterpolatorSpec,
-};
-
 export type HeaderProps = NavigationSceneRendererProps & {
   mode: HeaderMode,
   onNavigateBack?: () => void,
@@ -57,6 +53,7 @@ export type HeaderProps = NavigationSceneRendererProps & {
 };
 
 type SubViewName = 'left' | 'title' | 'right';
+type HeaderSubViewStyleInterpolatorName = 'Left' | 'Center' | 'Right';
 
 type HeaderState = {
   widths: {
@@ -68,7 +65,7 @@ const APPBAR_HEIGHT = Platform.OS === 'ios' ? 44 : 56;
 const STATUSBAR_HEIGHT = Platform.OS === 'ios' ? 20 : 0;
 const TITLE_OFFSET = Platform.OS === 'ios' ? 70 : 40;
 
-class Header extends React.PureComponent<DefaultProps, HeaderProps, HeaderState> {
+class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
 
   static HEIGHT = APPBAR_HEIGHT + STATUSBAR_HEIGHT;
   static Title = HeaderTitle;
@@ -88,10 +85,6 @@ class Header extends React.PureComponent<DefaultProps, HeaderProps, HeaderState>
       forCenter: PropTypes.func,
       forRight: PropTypes.func,
     }),
-  };
-
-  static defaultProps = {
-    styleInterpolator: HeaderStyleInterpolator,
   };
 
   props: HeaderProps;
@@ -133,6 +126,20 @@ class Header extends React.PureComponent<DefaultProps, HeaderProps, HeaderState>
       return header.titleStyle;
     }
     return undefined;
+  }
+
+  _getStyleInterpolator(
+    name: HeaderSubViewStyleInterpolatorName
+  ): NavigationStyleInterpolator {
+    const forSubView = `for${name}`;
+    const styleInterpolatorForSubview = (
+      this.props.styleInterpolator &&
+      this.props.styleInterpolator[forSubView]
+    );
+    if (!!styleInterpolatorForSubview) {
+      return styleInterpolatorForSubview;
+    }
+    return HeaderStyleInterpolator[forSubView];
   }
 
   _renderTitleComponent = (props: SubViewProps) => {
@@ -194,7 +201,7 @@ class Header extends React.PureComponent<DefaultProps, HeaderProps, HeaderState>
       'left',
       this.props.renderLeftComponent,
       this._renderLeftComponent,
-      this.props.styleInterpolator.forLeft,
+      this._getStyleInterpolator('Left'),
     );
   }
 
@@ -215,7 +222,7 @@ class Header extends React.PureComponent<DefaultProps, HeaderProps, HeaderState>
       'title',
       this.props.renderTitleComponent,
       this._renderTitleComponent,
-      this.props.styleInterpolator.forCenter,
+      this._getStyleInterpolator('Center'),
     );
   }
 
@@ -225,7 +232,7 @@ class Header extends React.PureComponent<DefaultProps, HeaderProps, HeaderState>
       'right',
       this.props.renderRightComponent,
       this._renderRightComponent,
-      this.props.styleInterpolator.forRight,
+      this._getStyleInterpolator('Right'),
     );
   }
 

--- a/src/views/HeaderStyleInterpolator.js
+++ b/src/views/HeaderStyleInterpolator.js
@@ -6,7 +6,14 @@ import {
 
 import type {
   NavigationSceneRendererProps,
+  NavigationStyleInterpolator,
 } from '../TypeDefinition';
+
+export type HeaderStyleInterpolatorSpec = {
+  forLeft: NavigationStyleInterpolator,
+  forCenter: NavigationStyleInterpolator,
+  forRight: NavigationStyleInterpolator,
+};
 
 /**
  * Utility that builds the style for the navigation header.


### PR DESCRIPTION
Currently we cannot configure header transition style so this PR is going to address this problem.

Developers can adding `headerStyleInterpolator` to `StackNavigatorConfig` to specify the header style interpolator
