### PR TITLE
screen props warning removed

### DIFF
--- a/src/views/SceneView.js
+++ b/src/views/SceneView.js
@@ -15,8 +15,6 @@ type Props = {
   component: ReactClass<*>;
 };
 
-let screenPropsWarningShown = false;
-
 export default class SceneView extends PureComponent<void, Props, void> {
   static childContextTypes = {
     navigation: React.PropTypes.object.isRequired,
@@ -28,17 +26,6 @@ export default class SceneView extends PureComponent<void, Props, void> {
     return {
       navigation: this.props.navigation,
     };
-  }
-
-  componentWillMount() {
-    if (this.props.screenProps !== undefined && !screenPropsWarningShown) {
-      console.warn(
-        'Behaviour of screenProps has changed from initial beta. ' +
-        'Components will now receive it as `this.props.screenProps` instead.\n' +
-        'This warning will be removed in future.'
-      );
-      screenPropsWarningShown = true;
-    }
   }
 
   render() {


### PR DESCRIPTION
This warning has been around for a bit:
![image](https://cloud.githubusercontent.com/assets/997157/23589373/6029b090-0191-11e7-9157-c1d2b4690005.png)

It appears the docs have been updated for a while now.

@satya164 - straight forward removal.