### PR TITLE
Send destructured screenProps to Component

### DIFF
--- a/src/views/SceneView.js
+++ b/src/views/SceneView.js
@@ -37,7 +37,7 @@ export default class SceneView extends PureComponent<void, Props, void> {
 
     return (
       <Component
-        screenProps={screenProps}
+        {...this.props.screenProps}
         navigation={navigation}
       />
     );


### PR DESCRIPTION
Hi!

I have used NavigationExperimeltal a lot with naviagation in Redux tree. I just started to migrate to this awesome library but one show stopper was this. I really dont understand why you are hiding the props sent down from my reducer function in an object called screenProps. My goal is to be able to navigate to normal components. Now when the props are inside the screenProps object i need to split up components into "go To"-able components and normal components => probably not what was intended.

Anyways i use a HOC function for now to solve this, let me know what you guys think and if i missed you something. Ill continue to test the lib if you guys get back to me with some small feedback. 

Let me know if you are interested in a minimalistic repo with this issue explained.

Please provide enough information so that others can review your pull request:

Explain the **motivation** for making this change. What existing problem does the pull request solve?

Prefer **small pull requests**. These are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise split it.

**Test plan (required)**

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

Make sure you test on both platforms if your change affects both platforms.

The code must pass tests and shouldn't add more Flow errors.

**Code formatting**

Look around. Match the style of the rest of the codebase.
