### PR TITLE
Make header component containers' styles configurable

### DIFF
--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -125,6 +125,10 @@ All `navigationOptions` for the `StackNavigator`:
   - `left` - React Element to display on the left side of the header
   - `style` - Style object for the header
   - `titleStyle` - Style object for the title component
+  - `componentStyle` - a config object for styling header components
+    - `title` - Style object for the title component
+    - `left` - Style object for the left component
+    - `right` - Style object for the right component
   - `tintColor` - Tint color for the header
 - `cardStack` - a config object for the card stack:
   - `gesturesEnabled` - Whether you can use gestures to dismiss this screen. Defaults to true on iOS, false on Android

--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -124,7 +124,6 @@ All `navigationOptions` for the `StackNavigator`:
   - `right` - React Element to display on the right side of the header
   - `left` - React Element to display on the left side of the header
   - `style` - Style object for the header
-  - `titleStyle` - Style object for the title component
   - `componentStyle` - a config object for styling header components
     - `title` - Style object for the title component
     - `left` - Style object for the left component

--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -130,6 +130,16 @@ export type HeaderConfig = {
    */
   titleStyle?: Style,
 
+
+  /**
+   * Styles passed into navigation bar components
+   */
+  componentStyle?: {
+    left?: Style,
+    title?: Style,
+    right?: Style,
+  },
+
   // // Style of title text
   // titleTextStyle?: $NavigationThunk<Object>,
   // // Tint color of navigation bar contents

--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -126,12 +126,6 @@ export type HeaderConfig = {
   style?: Style,
 
   /**
-   * Style passed into navigation bar title
-   */
-  titleStyle?: Style,
-
-
-  /**
    * Styles passed into navigation bar components
    */
   componentStyle?: {

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -118,6 +118,14 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
     return undefined;
   }
 
+  _getHeaderComponentStyle(navigation: Navigation, name: SubViewName): Style {
+    const header = this.props.router.getScreenConfig(navigation, 'header');
+    if (header && header.componentStyle && header.componentStyle[name]) {
+      return header.componentStyle[name];
+    }
+    return undefined;
+  }
+
   _renderTitleComponent = (props: SubViewProps) => {
     const titleStyle = this._getHeaderTitleStyle(props.navigation);
     const color = this._getHeaderTintColor(props.navigation);
@@ -253,6 +261,11 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
 
     const pointerEvents = offset !== 0 || isStale ? 'none' : 'box-none';
 
+    const componentStyle = this._getHeaderComponentStyle(
+      props.navigation,
+      name
+    );
+
     return (
       <Animated.View
         pointerEvents={pointerEvents}
@@ -261,6 +274,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
           styles.item,
           styles[name],
           props.style,
+          componentStyle,
           styleInterpolator(props),
         ]}
       >

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -110,14 +110,6 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
     return undefined;
   }
 
-  _getHeaderTitleStyle(navigation: Navigation): Style {
-    const header = this.props.router.getScreenConfig(navigation, 'header');
-    if (header && header.titleStyle) {
-      return header.titleStyle;
-    }
-    return undefined;
-  }
-
   _getHeaderComponentStyle(navigation: Navigation, name: SubViewName): Style {
     const header = this.props.router.getScreenConfig(navigation, 'header');
     if (header && header.componentStyle && header.componentStyle[name]) {
@@ -127,7 +119,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
   }
 
   _renderTitleComponent = (props: SubViewProps) => {
-    const titleStyle = this._getHeaderTitleStyle(props.navigation);
+    const titleStyle = this._getHeaderComponentStyle(props.navigation, 'title');
     const color = this._getHeaderTintColor(props.navigation);
     const title = this._getHeaderTitle(props.navigation);
 


### PR DESCRIPTION
In beta 6, header components' styles are absolute positioned and I hate the fact that title component has left/right offset so I make the style configurable to override the default style

Since we now have a way to set component styles, I also deprecated the `titleStyle`

Demo:

```js
const MyHomeScreen = ({ navigation }) => (
  <MyNavScreen
    banner="Home Screen"
    navigation={navigation}
  />
);
MyHomeScreen.navigationOptions = {
  title: 'Welcome',
  header: () => ({
    componentStyle: {
      title: {
        backgroundColor: 'red',
        left: 0,
        right: 0,
      },
    },
  }),
};
```
![screen shot 2017-03-10 at 11 13 53 pm](https://cloud.githubusercontent.com/assets/10144357/23800432/555b1528-05e7-11e7-93a4-bf72204963c8.png)

```js
const MyProfileScreen = ({ navigation }) => (
  <MyNavScreen
    banner={
      `${navigation.state.params.mode === 'edit' ? 'Now Editing ' : ''
      }${navigation.state.params.name}'s Profile`
    }
    navigation={navigation}
  />
);
MyProfileScreen.navigationOptions = {
  header: ({ state, setParams }) => ({
    title: `${state.params.name}'s Profile!`,
    // Render a button on the right side of the header.
    // When pressed switches the screen to edit mode.
    right: (
      <Button
        title={state.params.mode === 'edit' ? 'Done' : 'Edit'}
        onPress={() => setParams({ mode: state.params.mode === 'edit' ? '' : 'edit' })}
      />
    ),
    componentStyle: {
      title: {
        backgroundColor: 'red',
        left: 0,
        right: 0,
      },
      left: {
        backgroundColor: 'blue',
      },
      right: {
        backgroundColor: 'yellow',
      },
    },
  }),
};
```

![screen shot 2017-03-10 at 11 13 59 pm](https://cloud.githubusercontent.com/assets/10144357/23800443/61216cae-05e7-11e7-89fa-befb6a1d9e53.png)

```js
const MyProfileScreen = ({ navigation }) => (
  <MyNavScreen
    banner={
      `${navigation.state.params.mode === 'edit' ? 'Now Editing ' : ''
      }${navigation.state.params.name}'s Profile`
    }
    navigation={navigation}
  />
);
MyProfileScreen.navigationOptions = {
  header: ({ state, setParams }) => ({
    title: `${state.params.name}'s Profile!`,
    // Render a button on the right side of the header.
    // When pressed switches the screen to edit mode.
    right: (
      <Button
        title={state.params.mode === 'edit' ? 'Done' : 'Edit'}
        onPress={() => setParams({ mode: state.params.mode === 'edit' ? '' : 'edit' })}
      />
    ),
    componentStyle: {
      title: {
        backgroundColor: 'red',
        left: 0,
        right: 0,
      },
      right: {
        backgroundColor: 'yellow',
      },
    },
  }),
};
```
![screen shot 2017-03-10 at 11 15 42 pm](https://cloud.githubusercontent.com/assets/10144357/23800494/8bdabf86-05e7-11e7-912c-bd8ab0e9220e.png)
