### PR TITLE
Fix typo in docs for getComponentForRouteName

### DIFF
--- a/docs/api/routers/RoutersAPI.md
+++ b/docs/api/routers/RoutersAPI.md
@@ -51,7 +51,7 @@ Typically this should return a navigation state, with the following form:
 
 If the router has handled the action externally, or wants to swallow it without changing the navigation state, this function will return `null`.
 
-### `getComponentRouteName(routeName)`
+### `getComponentForRouteName(routeName)`
 
 Returns the child component or navigator for the given route name.
 
@@ -66,7 +66,7 @@ Say a router `getStateForAction` outputs a state like this:
 }
 ```
 
-Based on the routeNames in the state, the router is responsible for returning valid components when calling `router.getComponentRouteName('Foo')` or `router.getComponentRouteName('Bar')`.
+Based on the routeNames in the state, the router is responsible for returning valid components when calling `router.getComponentForRouteName('Foo')` or `router.getComponentForRouteName('Bar')`.
 
 ### `getComponentForState(state)`
 


### PR DESCRIPTION
Typo in docs: the right function name is `getComponentForRouteName`.