### PR TITLE
truncatedBackTitle navigationOptions for StackNavigator

### DIFF
--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -121,7 +121,7 @@ All `navigationOptions` for the `StackNavigator`:
   - `visible` - Boolean toggle of header visibility. Only works when `headerMode` is `screen`.
   - `title` - String or React Element used by the header. Defaults to scene `title`
   - `backTitle` - Title string used by the back button on iOS or `null` to disable label. Defaults to scene `title`
-  - `truncatedBackTitle` - Title string used by the back button on iOS when there is not enough space. Default is `'Back'`
+  - `truncatedBackTitle` - Title string used by the back button on iOS when there is not enough space to display the previous screen's title. Default is `'Back'`
   - `right` - React Element to display on the right side of the header
   - `left` - React Element to display on the left side of the header
   - `style` - Style object for the header

--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -121,6 +121,7 @@ All `navigationOptions` for the `StackNavigator`:
   - `visible` - Boolean toggle of header visibility. Only works when `headerMode` is `screen`.
   - `title` - String or React Element used by the header. Defaults to scene `title`
   - `backTitle` - Title string used by the back button on iOS or `null` to disable label. Defaults to scene `title`
+  - `truncatedBackTitle` - Title string used by the back button on iOS when there is not enough space. Default is `'Back'`
   - `right` - React Element to display on the right side of the header
   - `left` - React Element to display on the left side of the header
   - `style` - Style object for the header

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -110,6 +110,14 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
     return undefined;
   }
 
+  _getHeaderTruncatedBackTitle(navigation: Navigation): ?string {
+    const header = this.props.router.getScreenConfig(navigation, 'header');
+    if (header && header.truncatedBackTitle) {
+      return header.truncatedBackTitle;
+    }
+    return undefined;
+  }
+
   _getHeaderTitleStyle(navigation: Navigation): Style {
     const header = this.props.router.getScreenConfig(navigation, 'header');
     if (header && header.titleStyle) {
@@ -151,6 +159,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
       return null;
     }
     const tintColor = this._getHeaderTintColor(props.navigation);
+    const truncatedBackTitle = this._getHeaderTruncatedBackTitle(props.navigation);
     const previousNavigation = addNavigationHelpers({
       ...props.navigation,
       state: props.scenes[props.scene.index - 1].route,
@@ -163,6 +172,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
       <HeaderBackButton
         onPress={props.onNavigateBack}
         tintColor={tintColor}
+        truncatedTitle={truncatedBackTitle}
         title={backButtonTitle}
         width={width}
       />


### PR DESCRIPTION
`truncatedBackTitle` `navigationOptions` for `StackNavigator`

This is to redefined the `'Back'` string default props on the `HeaderBackButton` component. But keeping the truncate behavior on iOS (that is impossible with the `backTitle` option).

It's necessary for translation.