### PR TITLE
Merge navigationOptions defined in component and routeConfigs

### DIFF
--- a/src/routers/createConfigGetter.js
+++ b/src/routers/createConfigGetter.js
@@ -66,6 +66,7 @@ export default (
             }
             return acc;
           }
+          return option;
         }
         return acc;
       },

--- a/src/routers/createConfigGetter.js
+++ b/src/routers/createConfigGetter.js
@@ -57,9 +57,15 @@ export default (
     ].reduce(
       (acc: *, options: NavigationScreenOptions) => {
         if (options && options[optionName] !== undefined) {
-          return typeof options[optionName] === 'function'
+          const option = typeof options[optionName] === 'function'
             ? options[optionName](navigation, acc)
             : options[optionName];
+          if (acc && typeof acc === 'object') {
+            for (var attr in option) {
+              acc[attr] = option[attr];
+            }
+            return acc;
+          }
         }
         return acc;
       },


### PR DESCRIPTION
`navigationOptions` can be defined in two places:

1. In `StackNavigator`

``` js
StackNavigator(RouteConfigs, {
  navigationOptions: {
    header: {
      style: { backgroundColor: '#ffffff' },
      titleStyle: { color: '#00ff00' },
    },
  },
});
```

2. In Component as a `static` property

``` js
class MainScreen extends React.Component {
  static navigationOptions = {
    title: 'Main',
    header: ({ state, setParams }) => ({
      // Render a button on the right side of the header
      right: (
        <Button
          title={'Edit'}
          onPress={() => setParams({ editing: state.params.editing ? false : true })}
        />
      ),
    }),
  };
  ...
```

It will be convenient to define some global properties (such as global header style) when implementing `StackNavigator` and leave by-screen customizations (like right button) in each component. However, the `header` object in `StackNavigator` will *replace* the `header` in the screen component. For example, the right button above (and those in all the other screen components) will be discarded. This PR will merge the two `header` defined in different place.