### PR TITLE
Adds documentation about forking and syncing repo

### DIFF
--- a/docs/guides/Contributors.md
+++ b/docs/guides/Contributors.md
@@ -86,4 +86,5 @@ Simple bug fixes are welcomed in pull requests! Please check for duplicate PRs b
 
 #### Make sure to sync up with the state of upstream before submitting a PR:
 
-- `git rebase upstream/master`
+- `git fetch upstream/master`
+- `git rebase upstream/master master`

--- a/docs/guides/Contributors.md
+++ b/docs/guides/Contributors.md
@@ -6,11 +6,11 @@ React navigation was initially developed on macOS 10.12, with node 7+, and react
 
 ## Development
 
-### 0. Fork and install
+### 0. Fork the repo
 
-Fork [`react-navigation`](https://github.com/react-community/react-navigation) on GitHub
+- Fork [`react-navigation`](https://github.com/react-community/react-navigation) on GitHub
 
-_next:_
+- Run these commands in the terminal:
 
 ```
 git clone https://github.com/<USERNAME>/react-navigation.git`
@@ -86,6 +86,4 @@ Simple bug fixes are welcomed in pull requests! Please check for duplicate PRs b
 
 #### Make sure to sync up with the state of upstream before submitting a PR:
 
-- `git fetch upstream`
-- `git checkout master`
-- `git merge upstream/master`
+- `git rebase upstream/master`

--- a/docs/guides/Contributors.md
+++ b/docs/guides/Contributors.md
@@ -6,13 +6,19 @@ React navigation was initially developed on macOS 10.12, with node 7+, and react
 
 ## Development
 
-### 0. Basic Install
+### 0. Fork and install
+
+Fork [`react-navigation`](https://github.com/react-community/react-navigation) on GitHub
+
+_next:_
 
 ```
-git clone git@github.com:react-community/react-navigation.git
+git clone https://github.com/<USERNAME>/react-navigation.git`
 cd react-navigation
+git remote add upstream https://github.com/react-community/react-navigation.git
 npm install
 ```
+
 
 ### 1. Run the native playground
 
@@ -77,3 +83,9 @@ Before embarking on any major changes, please file an issue describing the sugge
 ### Minor Bugfixes
 
 Simple bug fixes are welcomed in pull requests! Please check for duplicate PRs before posting.
+
+#### Make sure to sync up with the state of upstream before submitting a PR:
+
+- `git fetch upstream`
+- `git checkout master`
+- `git merge upstream/master`


### PR DESCRIPTION
This improves the contributors guide by discussing the contribution workflow. Can't PR by just cloning main repo so I describe forking it and keeping in sync with upstream