### PR TITLE
Navigator which is not front is reacting to action by back processing…

### DIFF
--- a/src/addNavigationHelpers.js
+++ b/src/addNavigationHelpers.js
@@ -15,9 +15,16 @@ import NavigationActions from './NavigationActions';
 export default function<S: *> (navigation: NavigationProp<S, NavigationAction>) {
   return {
     ...navigation,
-    goBack: (key?: ?string): boolean => navigation.dispatch(NavigationActions.back({
-      key: key === undefined ? navigation.state.key : key,
-    })),
+    goBack: (key?: ?string): boolean => {
+      if (key === undefined || key == null) {
+        const index = navigation.state.index
+        const route = navigation.state.routes[index]
+        key = route.key
+      }
+      return navigation.dispatch(NavigationActions.back({
+        key: key,
+      }))
+    },
     navigate: (
       routeName: string,
       params?: NavigationParams,

--- a/src/addNavigationHelpers.js
+++ b/src/addNavigationHelpers.js
@@ -16,11 +16,15 @@ export default function<S: *> (navigation: NavigationProp<S, NavigationAction>) 
   return {
     ...navigation,
     goBack: (key?: ?string): boolean => {
-      if (key === undefined || key == null) {
+      if (key === undefined) {
+        key = navigation.state.key
+      }
+      else if (key == null && 'index' in navigation.state && 'routes' in navigation.state) {
         const index = navigation.state.index
         const route = navigation.state.routes[index]
         key = route.key
       }
+      
       return navigation.dispatch(NavigationActions.back({
         key: key,
       }))


### PR DESCRIPTION
… when using multiple navigators.

If you multiplex this with "Stack -> Stack" and you tap the "Back" button on the navigation bar, I want you to operate only on the front Stack which is displaying the navigation bar originally , It solves the problem that "Back" is executed for all Stacks.

```
Stack 0
    TopScene
    Stack 1
       Page 0
       Page 1 <- This is displayed
```

If you create a navigation in the above state and tap the displayed Back button, you can check the difference in behavior.