### PR TITLE
Option to add numberOfLines inside header in navigationOptions

### DIFF
--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -118,10 +118,19 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
     return undefined;
   }
 
+  _getHeaderTitleLines = (navigation: Navigation): number => {
+    const header = this.props.router.getScreenConfig(navigation, 'header');
+    if (header && header.numberOfLines) {
+      return header.numberOfLines;
+    }
+    return undefined;
+  }
+
   _renderTitleComponent = (props: SubViewProps) => {
     const titleStyle = this._getHeaderTitleStyle(props.navigation);
     const color = this._getHeaderTintColor(props.navigation);
     const title = this._getHeaderTitle(props.navigation);
+    const titleLines = this._getHeaderTitleLines(props.navigation);
 
     // On iOS, width of left/right components depends on the calculated
     // size of the title.
@@ -138,6 +147,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
 
     return (
       <HeaderTitle
+        numberOfLines={titleLines}
         onLayout={onLayoutIOS}
         style={[color ? { color } : null, titleStyle]}
       >

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -123,7 +123,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
     if (header && header.numberOfLines) {
       return header.numberOfLines;
     }
-    return undefined;
+    return 1;
   }
 
   _renderTitleComponent = (props: SubViewProps) => {

--- a/src/views/HeaderTitle.js
+++ b/src/views/HeaderTitle.js
@@ -15,10 +15,11 @@ import type {
 type Props = {
   tintColor?: ?string;
   style?: Style,
+  numberOfLines?: number
 };
 
-const HeaderTitle = ({ style, ...rest }: Props) => (
-  <Text numberOfLines={1} {...rest} style={[styles.title, style]} />
+const HeaderTitle = ({ style, numberOfLines, ...rest }: Props) => (
+  <Text numberOfLines={numberOfLines || 1} {...rest} style={[styles.title, style]} />
 );
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
#### Motivation

Inside my app I can't always know the title, and sometimes the title can be 4-5 words long. Since I don't want cropping in my header titles, i can make the size of the header and the font of the title change dynamically but I cant change the numberOfLines attribute.

This forces me to drop the font size very low if I want to fit a long title in one line. Enabling the option to manually set the numberOfLines gives me the ability to combine changing the header height, title fontSize and numberOfLines and make my header look and behave in a more flexible way.



#### Example

Here is an example of the default navigationOptions with long title:

![one-line](https://cloud.githubusercontent.com/assets/3890732/24197099/e91c3074-0f08-11e7-93c6-5306417c9dc5.png)

and the code:

```javascript
 static navigationOptions = {
	header : (options) => ({
		right: (<OKButton onPress={() => {}}/>),
		left: (<CancelButton onPress={() => options.state.params.onCloseModal()}/>),
		style: {
			backgroundColor : Colors.navigationBarColor
		},
		tintColor: Colors.defaultTextColor,
		titleStyle: {
			paddingLeft: 20
		}
	}),
	title : 'A Somewhat Long Title That Could Not Fit In One Line Without My Change'
}
```

and the same navigationOptions with numberOfLines option:

![three-line](https://cloud.githubusercontent.com/assets/3890732/24197117/0825dea2-0f09-11e7-8158-4ee05a1b1cd5.png)

and the code:

```javascript
 static navigationOptions = {
	header : (options) => ({
		right: (<OKButton onPress={() => {}}/>),
		left: (<CancelButton onPress={() => options.state.params.onCloseModal()}/>),
		style: {
			height: 100,
			backgroundColor : Colors.navigationBarColor
		},
		tintColor: Colors.defaultTextColor,
		numberOfLines: 3,  // <------------------------------------ THE CHANGE
		titleStyle: {
			paddingLeft: 20
		}
	}),
	title : 'A Somewhat Long Title That Now Sits In Three Lines Because Of My Change'
}
```