### PR TITLE
Reset specific StackRouter with key

### DIFF
--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -253,6 +253,7 @@ export type NavigationInitAction = {
 export type NavigationResetAction = {
   type: 'Navigation/RESET',
   index: number,
+  key?: string,
   actions: Array<NavigationNavigateAction>,
 };
 

--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -253,7 +253,7 @@ export type NavigationInitAction = {
 export type NavigationResetAction = {
   type: 'Navigation/RESET',
   index: number,
-  key?: string,
+  key?: ?string,
   actions: Array<NavigationNavigateAction>,
 };
 

--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -126,14 +126,14 @@ export default (
         };
         state = {
           index: 0,
-          key: 'Root',
           routes: [route],
         };
       }
 
       // Check if a child scene wants to handle the action
-      if(action.key !== 'Root') {
-        const childIndex = action.key ? StateUtils.indexOf(state, action.key) : state.index;
+      if(action.key !== null) {
+        const keyIndex = action.key ? StateUtils.indexOf(state, action.key) : -1
+        const childIndex = keyIndex >= 0 ? keyIndex : state.index;
         const childRoute = state.routes[childIndex];
         const childRouter = childRouters[childRoute.routeName];
         if (childRouter) {

--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -130,8 +130,8 @@ export default (
         };
       }
 
-      // Check if a child scene wants to handle the action
-      if(action.key !== null) {
+      // Check if a child scene wants to handle the action as long as it is not a reset to the root stack
+      if(action.type !== NavigationActions.RESET && action.key !== null) {
         const keyIndex = action.key ? StateUtils.indexOf(state, action.key) : -1
         const childIndex = keyIndex >= 0 ? keyIndex : state.index;
         const childRoute = state.routes[childIndex];

--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -131,7 +131,7 @@ export default (
       }
 
       // Check if a child scene wants to handle the action as long as it is not a reset to the root stack
-      if(action.type !== NavigationActions.RESET && action.key !== null) {
+      if(action.type !== NavigationActions.RESET || action.key !== null) {
         const keyIndex = action.key ? StateUtils.indexOf(state, action.key) : -1
         const childIndex = keyIndex >= 0 ? keyIndex : state.index;
         const childRoute = state.routes[childIndex];

--- a/src/routers/__tests__/StackRouter-test.js
+++ b/src/routers/__tests__/StackRouter-test.js
@@ -488,6 +488,7 @@ describe('StackRouter', () => {
     expect(state2 && state2.routes[0].routes[0].routeName).toEqual('baz');
   });
 
+
   test('Handles the navigate action with params and nested StackRouter', () => {
     const ChildNavigator = () => <div />;
     ChildNavigator.router = StackRouter({ Baz: { screen: () => <div /> } });

--- a/src/routers/__tests__/StackRouter-test.js
+++ b/src/routers/__tests__/StackRouter-test.js
@@ -488,6 +488,32 @@ describe('StackRouter', () => {
     expect(state2 && state2.routes[0].routes[0].routeName).toEqual('baz');
   });
 
+  test('Handles the reset action with a key', () => {
+    const ChildRouter = StackRouter({
+      baz: {
+        screen: () => <div />,
+      },
+    });
+
+    const ChildNavigator = () => <div />;
+    ChildNavigator.router = ChildRouter;
+
+    const router = StackRouter({
+      Foo: {
+        screen: ChildNavigator,
+      },
+      Bar: {
+        screen: () => <div />,
+      },
+    });
+    const state = router.getStateForAction({ type: NavigationActions.INIT });
+    const state2 = router.getStateForAction({ type: NavigationActions.NAVIGATE, routeName: 'Foo', action: { type: NavigationActions.NAVIGATE, routeName: 'baz' }}, state);
+    const state3 = router.getStateForAction({ type: NavigationActions.RESET, key: 'Init', actions: [{ type: NavigationActions.NAVIGATE, routeName: 'Foo' }], index: 0 }, state2);
+    const state4 = router.getStateForAction({ type: NavigationActions.RESET, key: null, actions: [{ type: NavigationActions.NAVIGATE, routeName: 'Bar' }], index: 0 }, state3);
+
+    expect(state4 && state4.index).toEqual(0);
+    expect(state4 && state4.routes[0].routeName).toEqual('Bar');
+  });
 
   test('Handles the navigate action with params and nested StackRouter', () => {
     const ChildNavigator = () => <div />;


### PR DESCRIPTION
**Motivation** 

There is no way to build a Login/Register flow without the ability to reset the router to the top-level nav state without hacky workarounds.

#691 #723 

By allowing a key to be passed along with a reset action, you can specify what level of state you want to reset to.

**Test plan (required)**

I added a test case that verifies the functionality.

I'm happy to add more test cases or documentation, if you find this PR useful.