### PR TITLE
remove ReactComponentWithPureRenderMixin

### DIFF
--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -9,8 +9,6 @@ import {
   View,
 } from 'react-native';
 
-import ReactComponentWithPureRenderMixin from 'react/lib/ReactComponentWithPureRenderMixin';
-
 import HeaderTitle from './HeaderTitle';
 import HeaderBackButton from './HeaderBackButton';
 import HeaderStyleInterpolator from './HeaderStyleInterpolator';


### PR DESCRIPTION
`ReactComponentWithPureRenderMixin` is useless in this file, and it has been removed from the core of latest `react`

build fails on master branch of `react-native` for this error @ericvicenti 