### PR TITLE
feat(header): allow hiding floating headers

### DIFF
--- a/src/views/CardStack.js
+++ b/src/views/CardStack.js
@@ -344,7 +344,9 @@ class CardStack extends Component<DefaultProps, Props, void> {
     let floatingHeader = null;
     const headerMode = this._getHeaderMode();
     if (headerMode === 'float') {
-      floatingHeader = this._renderHeader(props, headerMode);
+      const header = this.props.router.getScreenConfig(props.navigation, 'header') || {}; 
+      const isHiddenHeader = header && header.visible === false;
+      floatingHeader = isHiddenHeader ? null : this._renderHeader(props, headerMode);
     }
 
     const responder = PanResponder.create({


### PR DESCRIPTION
`header.visible` has only effect when `headerMode` is `screen`, this effectively makes it
unintuitive to use this prop. In addition, allowing floating headers to be hidden supports a
scenario when you would like to have a splash screen, then your main screen (with a Tabs navigator)
and subsequent non-tab screens being rendered with the floating header so it transitions properly
and in iOS' native style.