### PR TITLE
Fix TabViewAnimated screenProps caveat

### DIFF
--- a/src/views/TabView/TabView.js
+++ b/src/views/TabView/TabView.js
@@ -201,6 +201,7 @@ class TabView extends PureComponent<void, Props, void> {
         renderPager={this._renderPager}
         configureTransition={configureTransition}
         onRequestChangeTab={this._handlePageChanged}
+        screenProps={this.props.screenProps}
       />
     );
   }


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:
Accordin do the react-native-tab-view, `TabViewAnimated` is a pure component, and as such, will not be rerendered unless it's props change.
This prevents rerenders when `screenProps` on `TabNavigator` change, and as such, is a major limitation when using `TabNavigator`.
The proposed solution is to pass the `screenProps` to the `TabViewAnimated`, even if does not use this in any way.
Any change to the `screenProps` of `TabNavigator` will trigger a rerender in `TabViewAnimated`.

Explain the **motivation** for making this change. What existing problem does the pull request solve?

Allows using `screenProps` with `TabNavigator`

Prefer **small pull requests**. These are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise split it.

**Test plan (required)**

Don't know how much this could be tested, since I've only added `screenProps={this.props.screenProps}` to the `TabViewAnimated` component.

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

Make sure you test on both platforms if your change affects both platforms.

The code must pass tests and shouldn't add more Flow errors.

**Code formatting**

Look around. Match the style of the rest of the codebase.
