### PR TITLE
remove workaround for screen shadow

### DIFF
--- a/src/views/CardStackStyleInterpolator.js
+++ b/src/views/CardStackStyleInterpolator.js
@@ -62,9 +62,7 @@ function forHorizontal(props: NavigationSceneRendererProps): Object {
   const index = scene.index;
   const inputRange = [index - 1, index, index + 0.99, index + 1];
 
-  // Add ~30px to the interpolated width screens width for horizontal movement. This allows
-  // the screen's shadow to go screen fully offscreen without abruptly dissapearing
-  const width = layout.initWidth + 30;
+  const width = layout.initWidth;
   const outputRange = I18nManager.isRTL ?
     ([-width, 0, 10, 10]: Array<number>) :
     ([width, 0, -10, -10]: Array<number>);


### PR DESCRIPTION
This depends on #828, see https://github.com/react-community/react-navigation/pull/828#issuecomment-290239321

@ericvicenti 