### PR TITLE
fix naming consistency in DrawerNavigator

### DIFF
--- a/docs/api/navigators/DrawerNavigator.md
+++ b/docs/api/navigators/DrawerNavigator.md
@@ -88,20 +88,20 @@ The route configs object is a mapping from route name to a route config, which t
 
 - `drawerWidth` - Width of the drawer
 - `drawerPosition` - Options are `left` or `right`. Default is `left` position.
-- `contentComponent` - Component used to render the content of the drawer, for example, navigation items. Receives the `navigation` prop for the drawer. Defaults to `DrawerView.Items`. For more information, see below.
-- `contentOptions` - Configure the drawer content, see below.
+- `drawerComponent` - Component used to render the content of the drawer, for example, navigation items. Receives the `navigation` prop for the drawer. Defaults to `DrawerView.Items`. For more information, see below.
+- `drawerOptions` - Configure the drawer content, see below.
 
 #### Example:
 
 Default the `DrawerView` isn't scrollable.
-To achieve a scrollable `View`, you have to use the `contentComponent` to customize the container, 
+To achieve a scrollable `View`, you have to use the `drawerComponent` to customize the container, 
 as you can see in the example below.
 
 ```js
 {
   drawerWidth: 200,
   drawerPosition: 'right',
-  contentComponent: props => <ScrollView><DrawerView.Items {...props} /></ScrollView>
+  drawerComponent: props => <ScrollView><DrawerView.Items {...props} /></ScrollView>
 }
 ```
 
@@ -112,12 +112,12 @@ Several options get passed to the underlying router to modify navigation logic:
 - `paths` - Provide a mapping of routeName to path config, which overrides the paths set in the routeConfigs.
 - `backBehavior` - Should the back button cause switch to the initial route? If yes, set to `initialRoute`, otherwise `none`. Defaults to `initialRoute` behavior.
 
-### Providing a custom `contentComponent`
+### Providing a custom `drawerComponent`
 
 You can easily override the default component used by `react-navigation`:
 
 ```js
-const CustomDrawerContentComponent = (props) => (
+const CustomDrawerDrawerComponent = (props) => (
   <View style={style.container}>
     <DrawerView.Items {...props} />
   </View>
@@ -130,7 +130,7 @@ const styles = StyleSheet.create({
 });
 ```
 
-### `contentOptions` for `DrawerView.Items`
+### `drawerOptions` for `DrawerView.Items`
 
 - `activeTintColor` - label and icon color of the active label
 - `activeBackgroundColor` - background color of the active label
@@ -142,7 +142,7 @@ const styles = StyleSheet.create({
 #### Example:
 
 ```js
-contentOptions: {
+drawerOptions: {
   activeTintColor: '#e91e63',
   style: {
     marginVertical: 0,

--- a/examples/NavigationPlayground/js/Drawer.js
+++ b/examples/NavigationPlayground/js/Drawer.js
@@ -79,7 +79,7 @@ const DrawerExample = DrawerNavigator({
   },
 }, {
   initialRouteName: 'Drafts',
-  contentOptions: {
+  drawerOptions: {
     activeTintColor: '#e91e63',
   },
 });

--- a/src/navigators/DrawerNavigator.js
+++ b/src/navigators/DrawerNavigator.js
@@ -30,7 +30,7 @@ const DefaultDrawerConfig = {
    * https://material.io/guidelines/patterns/navigation-drawer.html
    */
   drawerWidth: Dimensions.get('window').width - (Platform.OS === 'android' ? 56 : 64),
-  contentComponent: DrawerView.Items,
+  drawerComponent: DrawerView.Items,
   drawerPosition: 'left',
 };
 
@@ -42,8 +42,8 @@ const DrawerNavigator = (
   const {
     containerConfig,
     drawerWidth,
-    contentComponent,
-    contentOptions,
+    drawerComponent,
+    drawerOptions,
     drawerPosition,
     ...tabsConfig
   } = mergedConfig;
@@ -64,8 +64,8 @@ const DrawerNavigator = (
     <DrawerView
       {...props}
       drawerWidth={drawerWidth}
-      contentComponent={contentComponent}
-      contentOptions={contentOptions}
+      drawerComponent={drawerComponent}
+      drawerOptions={drawerOptions}
       drawerPosition={drawerPosition}
     />
   ), containerConfig);

--- a/src/views/Drawer/DrawerSidebar.js
+++ b/src/views/Drawer/DrawerSidebar.js
@@ -27,8 +27,8 @@ type Props = {
   router: NavigationRouter,
   navigation: Navigation,
   childNavigationProps: { [key: string]: Navigation },
-  contentComponent: ReactClass<*>,
-  contentOptions?: {},
+  drawerComponent: ReactClass<*>,
+  drawerOptions?: {},
   style?: Style;
 };
 
@@ -73,11 +73,11 @@ class DrawerSidebar extends PureComponent<void, Props, void> {
   };
 
   render() {
-    const ContentComponent = this.props.contentComponent;
+    const DrawerComponent = this.props.drawerComponent;
     return (
       <View style={[styles.container, this.props.style]}>
-        <ContentComponent
-          {...this.props.contentOptions}
+        <DrawerComponent
+          {...this.props.drawerOptions}
           navigation={this.props.navigation}
           getLabel={this._getLabel}
           renderIcon={this._renderIcon}

--- a/src/views/Drawer/DrawerView.js
+++ b/src/views/Drawer/DrawerView.js
@@ -26,8 +26,8 @@ export type DrawerScene = {
 export type DrawerViewConfig = {
   drawerWidth: number,
   drawerPosition: 'left' | 'right',
-  contentComponent: ReactClass<*>,
-  contentOptions?: {},
+  drawerComponent: ReactClass<*>,
+  drawerOptions?: {},
   style?: Style;
 };
 
@@ -104,8 +104,8 @@ export default class DrawerView<T: *> extends PureComponent<void, Props, void> {
     <DrawerSidebar
       navigation={this._screenNavigationProp}
       router={this.props.router}
-      contentComponent={this.props.contentComponent}
-      contentOptions={this.props.contentOptions}
+      drawerComponent={this.props.drawerComponent}
+      drawerOptions={this.props.drawerOptions}
       style={this.props.style}
     />
   );


### PR DESCRIPTION
Rename configuration parameters to DrawerNavigator for naming consistency and resolve mis understanding.

IIRC, both contentComponent and contentOptions applies to Drawer/Sidebar of the DrawerNavigator, but name contains **content** and it's confusing that it applies for CONTENT side of DrawerNavigator. So rename configuration for naming consistency.

contentComponent -> drawerComponent, contentOptions -> drawerOptions