### PR TITLE
Show icons in tab navigations in playground in android

### DIFF
--- a/examples/NavigationPlayground/js/SimpleTabs.js
+++ b/examples/NavigationPlayground/js/SimpleTabs.js
@@ -132,6 +132,7 @@ const SimpleTabs = TabNavigator({
   },
 }, {
   tabBarOptions: {
+    showIcon: true,
     activeTintColor: Platform.OS === 'ios' ? '#e91e63' : '#fff',
   },
 });

--- a/examples/NavigationPlayground/js/StacksInTabs.js
+++ b/examples/NavigationPlayground/js/StacksInTabs.js
@@ -135,9 +135,12 @@ const StacksInTabs = TabNavigator({
     },
   },
 }, {
-  tabBarPosition: 'bottom',
-  animationEnabled: false,
+  tabBarOptions: {
+    showIcon: true,
+  },
   swipeEnabled: false,
+  animationEnabled: false,
+  tabBarPosition: 'bottom',
 });
 
 export default StacksInTabs;


### PR DESCRIPTION
As it is mentioned here https://github.com/react-community/react-navigation/issues/516 there is need to set `showIcon: true` for tab navigators to show the icons.

This PR fixes navigation playground on android platform.