### PR TITLE
Fix gesturesEnabled regression

### DIFF
--- a/src/views/CardStack.js
+++ b/src/views/CardStack.js
@@ -446,7 +446,15 @@ class CardStack extends Component<DefaultProps, Props, void> {
         });
       },
     });
-    const gesturesEnabled = this.props.mode === 'card' && Platform.OS === 'ios';
+
+    const cardStackConfig = this.props.router.getScreenConfig(
+      props.navigation,
+      'cardStack'
+    ) || {};
+
+    const gesturesEnabled = typeof cardStackConfig.gesturesEnabled === 'boolean' ?
+      cardStackConfig.gesturesEnabled :
+      this.props.mode === 'card' && Platform.OS === 'ios';
     const handlers = gesturesEnabled ? responder.panHandlers : {};
     return (
       <View


### PR DESCRIPTION
`gesturesEnabled` property stopped working on master. This fixes this regression.

Closes #818
Regression caused by https://github.com/react-community/react-navigation/commit/11cab8eab62b6ca1c2a0445f30a9d0dc75458e2e
