### PR TITLE
Only delegate inner action to current tab if the outer action matches

### DIFF
--- a/src/routers/TabRouter.js
+++ b/src/routers/TabRouter.js
@@ -61,11 +61,9 @@ export default (
         const routes = order.map((routeName: string) => {
           const tabRouter = tabRouters[routeName];
           if (tabRouter) {
-            const childAction =
-              action.action ||
-              NavigationActions.init({
-                ...(action.params ? { params: action.params } : {}),
-              });
+            const childAction = NavigationActions.init({
+              ...(action.params ? { params: action.params } : {}),
+            });
             return {
               ...tabRouter.getStateForAction(childAction),
               key: routeName,
@@ -106,7 +104,7 @@ export default (
       const activeTabRouter = tabRouters[order[state.index]];
       if (activeTabRouter) {
         const activeTabState = activeTabRouter.getStateForAction(
-          action.action || action,
+          action,
           activeTabLastState
         );
         if (!activeTabState && inputState) {


### PR DESCRIPTION
**Motivation**
As described in [#875](https://github.com/react-community/react-navigation/issues/875) TabRouters seem to incorrectly pass down the inner action when delegating to the current tab (If delegating the action to other tabs the original action is always passed)

**Test plan**

I've added a test case to demonstrate a minimal case of the issue I was having and the change fixes this.
