### PR TITLE
goBack() additional functionality

### DIFF
--- a/docs/api/navigators/DrawerNavigator.md
+++ b/docs/api/navigators/DrawerNavigator.md
@@ -81,7 +81,7 @@ DrawerNavigator(RouteConfigs, DrawerNavigatorConfig)
 
 ### RouteConfigs
 
-The route configs object is a mapping from route name to a route config, which tells the navigator what to present for that route, see [example](https://github.com/coodoo/react-navigation/blob/master/docs/api/navigators/StackNavigator.md#routeconfigs) from `StackNavigator`.
+The route configs object is a mapping from route name to a route config, which tells the navigator what to present for that route, see [example](/docs/api/navigators/StackNavigator.md#routeconfigs) from `StackNavigator`.
 
 
 ### DrawerNavigatorConfig

--- a/docs/api/navigators/TabNavigator.md
+++ b/docs/api/navigators/TabNavigator.md
@@ -79,7 +79,7 @@ TabNavigator(RouteConfigs, TabNavigatorConfig)
 
 ### RouteConfigs
 
-The route configs object is a mapping from route name to a route config, which tells the navigator what to present for that route, see [example](https://github.com/coodoo/react-navigation/blob/master/docs/api/navigators/StackNavigator.md#routeconfigs) from `StackNavigator`.
+The route configs object is a mapping from route name to a route config, which tells the navigator what to present for that route, see [example](/docs/api/navigators/StackNavigator.md#routeconfigs) from `StackNavigator`.
 
 ### TabNavigatorConfig
 

--- a/docs/guides/Screen-Navigation-Prop.md
+++ b/docs/guides/Screen-Navigation-Prop.md
@@ -91,6 +91,10 @@ class ProfileScreen extends React.Component {
 ## `goBack` - Close the active screen and move back
 
 Optionally provide a key, which specifies the route to go back from. By default, goBack will close the route that it is called from. If the goal is to go back *anywhere*, without specifying what is getting closed, call `.goBack(null);`
+Accepts such objects: 
+`.goBack({ key: 'your-route-key' })`
+`.goBack({ numberOfPages: 3 })` - goes back `numberOfPages` screens
+`.goBack({ routeName: 'YourRouteName' })` - goes back to the screen in stack with such `routeName`.
 
 ```js
 class HomeScreen extends React.Component {
@@ -107,7 +111,7 @@ class HomeScreen extends React.Component {
           title="Go back anywhere"
         />
         <Button
-          onPress={() => goBack('screen-123')}
+          onPress={() => goBack({key: 'screen-123'})}
           title="Go back from screen-123"
         />
       </View>

--- a/src/__tests__/addNavigationHelpers-test.js
+++ b/src/__tests__/addNavigationHelpers-test.js
@@ -9,7 +9,7 @@ describe('addNavigationHelpers', () => {
     expect(addNavigationHelpers({
       state: { key: 'A', routeName: 'Home' },
       dispatch: mockedDispatch,
-    }).goBack('A')).toEqual(true);
+    }).goBack({ key: 'A' })).toEqual(true);
     expect(mockedDispatch).toBeCalledWith({ type: NavigationActions.BACK, key: 'A' });
     expect(mockedDispatch.mock.calls.length).toBe(1);
   });

--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -222,7 +222,7 @@ export default (
           /* $FlowFixMe */
           const backRoute = state.routes.find((route: *) => route.key === action.key);
           /* $FlowFixMe */
-          backRouteIndex = state.routes.indexOf(backRoute);
+          backRouteIndex = state.routes.indexOf(backRoute) - 1;
         }
         if (backRouteIndex == null) {
           return StateUtils.pop(state);

--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -91,7 +91,6 @@ export default (
 
     getStateForAction(action: NavigationStackAction, state: ?NavigationState) {
       action = NavigationActions.mapDeprecatedActionAndWarn(action);
-
       // Set up the initial state if needed
       if (!state) {
         let route = {};
@@ -210,6 +209,15 @@ export default (
 
       if (action.type === NavigationActions.BACK) {
         let backRouteIndex = null;
+
+        if (action.routeName) {
+          backRouteIndex = state.routes.findIndex((route: *) => route.routeName === action.routeName);
+        }
+
+        if (action.numberOfPages) {
+          backRouteIndex = state.index - action.numberOfPages;
+        }
+
         if (action.key) {
           /* $FlowFixMe */
           const backRoute = state.routes.find((route: *) => route.key === action.key);
@@ -219,11 +227,11 @@ export default (
         if (backRouteIndex == null) {
           return StateUtils.pop(state);
         }
-        if (backRouteIndex > 0) {
+        if (backRouteIndex > -1) {
           return {
             ...state,
-            routes: state.routes.slice(0, backRouteIndex),
-            index: backRouteIndex - 1,
+            routes: state.routes.slice(0, backRouteIndex + 1),
+            index: backRouteIndex,
           };
         }
       }

--- a/src/views/ScenesReducer.js
+++ b/src/views/ScenesReducer.js
@@ -93,6 +93,7 @@ export default function ScenesReducer(
   const staleScenes: Map<string, NavigationScene> = new Map();
 
   // Populate stale scenes from previous scenes marked as stale.
+
   scenes.forEach((scene) => {
     const { key } = scene;
     if (scene.isStale) {
@@ -157,7 +158,21 @@ export default function ScenesReducer(
     }
   });
 
-  staleScenes.forEach(mergeScene);
+
+  // work around for flashing scenes
+  let k = null;
+  let v = null;
+  staleScenes.forEach(scene => {
+    let {key} = scene;
+    k = key;
+    v = scene;
+  });
+
+  newStaleScenes = k && v ? new Map([[k, v]]) : new Map();
+  newStaleScenes.forEach(mergeScene);
+  // staleScenes.forEach(mergeScene);
+  // work around end
+
   freshScenes.forEach(mergeScene);
 
   nextScenes.sort(compareScenes);

--- a/src/views/ScenesReducer.js
+++ b/src/views/ScenesReducer.js
@@ -163,7 +163,7 @@ export default function ScenesReducer(
   let k = null;
   let v = null;
   staleScenes.forEach(scene => {
-    let {key} = scene;
+    let { key } = scene;
     k = key;
     v = scene;
   });


### PR DESCRIPTION
I and many other people meet lack of base functionality provided by RN Navigator such as `.popToTop` and `.popN()`.
This pull request add such functionality by modifying input params for `.goBack()`

Now it accepts such objects: 
`.goBack({ key: 'your-route-key' })`
`.goBack({ numberOfPages: 3 })` - goes back `numberOfPages` screens
`.goBack({ routeName: 'YourRouteName' })` - goes back to the screen in stack with such `routeName`. 

Adding these stuff other issued popped -- when moving back few screens previous screens are flashing. `I added work around, but would like to hear a solid solution to fix that before merging PR`. This requires tests to be fixed.

Now I use these branch and these functions on my own production project and it works perfectly!