### PR TITLE
Clamps interpolation of x and y values on Card animations

### DIFF
--- a/src/views/CardStackStyleInterpolator.js
+++ b/src/views/CardStackStyleInterpolator.js
@@ -79,6 +79,7 @@ function forHorizontal(props: NavigationSceneRendererProps): Object {
   const translateX = position.interpolate({
     inputRange,
     outputRange,
+    extrapolate: 'clamp',
   });
 
   return {
@@ -117,6 +118,7 @@ function forVertical(props: NavigationSceneRendererProps): Object {
   const translateY = position.interpolate({
     inputRange,
     outputRange: ([height, 0, 0, 0]: Array<number>),
+    extrapolate: 'clamp',
   });
 
   return {


### PR DESCRIPTION
Fixes: https://github.com/react-community/react-navigation/issues/559

By clamping the extrapolation, output values will never go below `min` or above `max`, which is the intended effect.

I wondered if this change was necessary, as it seems like there may have been a pseudo clamp with the input and output ranges.  Is there a reason that method was chosen instead of using extrapolate clamp?

I tested this after making the change, and I was no longer able to reproduce the behaviour described in issue 559.  However, I am unable to reproduce this issue on master currently.  Either way, a clamp seems desirable.

Thanks for the fantastic work on this repo!