### PR TITLE
Add pressColor to StackNavigator header options

### DIFF
--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -126,8 +126,8 @@ All `navigationOptions` for the `StackNavigator`:
   - `style` - Style object for the header
   - `titleStyle` - Style object for the title component
   - `tintColor` - Tint color for the header
-  - `pressColor` - Color for material ripple (Android >= 5.0 only)
-- `cardStack` - a config object for the card stack:
+  - `pressColorAndroid` - Color for material ripple (Android >= 5.0 only)
+  - `cardStack` - a config object for the card stack:
   - `gesturesEnabled` - Whether you can use gestures to dismiss this screen. Defaults to true on iOS, false on Android
 
 ### Navigator Props

--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -126,6 +126,7 @@ All `navigationOptions` for the `StackNavigator`:
   - `style` - Style object for the header
   - `titleStyle` - Style object for the title component
   - `tintColor` - Tint color for the header
+  - `pressColor` - Color for material ripple (Android >= 5.0 only)
 - `cardStack` - a config object for the card stack:
   - `gesturesEnabled` - Whether you can use gestures to dismiss this screen. Defaults to true on iOS, false on Android
 

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -39,7 +39,7 @@ type SubViewRenderer = (subViewProps: SubViewProps) => ?React.Element<any>;
 export type HeaderProps = NavigationSceneRendererProps & {
   mode: HeaderMode,
   onNavigateBack?: () => void,
-  pressColor?: string,
+  pressColorAndroid?: string,
   renderLeftComponent: SubViewRenderer,
   renderRightComponent: SubViewRenderer,
   renderTitleComponent: SubViewRenderer,
@@ -109,10 +109,10 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
     return undefined;
   }
 
-  _getHeaderPressColor(navigation: Navigation): ?string {
+  _getHeaderPressColorAndroid(navigation: Navigation): ?string {
     const header = this.props.router.getScreenConfig(navigation, 'header');
-    if (header && header.pressColor) {
-      return header.pressColor;
+    if (header && header.pressColorAndroid) {
+      return header.pressColorAndroid;
     }
     return undefined;
   }
@@ -158,7 +158,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
       return null;
     }
     const tintColor = this._getHeaderTintColor(props.navigation);
-    const pressColor = this._getHeaderPressColor(props.navigation);
+    const pressColorAndroid = this._getHeaderPressColorAndroid(props.navigation);
     const previousNavigation = addNavigationHelpers({
       ...props.navigation,
       state: props.scenes[props.scene.index - 1].route,
@@ -170,7 +170,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
     return (
       <HeaderBackButton
         onPress={props.onNavigateBack}
-        pressColor={pressColor}
+        pressColorAndroid={pressColorAndroid}
         tintColor={tintColor}
         title={backButtonTitle}
         width={width}

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -39,6 +39,7 @@ type SubViewRenderer = (subViewProps: SubViewProps) => ?React.Element<any>;
 export type HeaderProps = NavigationSceneRendererProps & {
   mode: HeaderMode,
   onNavigateBack?: () => void,
+  pressColor?: string,
   renderLeftComponent: SubViewRenderer,
   renderRightComponent: SubViewRenderer,
   renderTitleComponent: SubViewRenderer,
@@ -108,6 +109,14 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
     return undefined;
   }
 
+  _getHeaderPressColor(navigation: Navigation): ?string {
+    const header = this.props.router.getScreenConfig(navigation, 'header');
+    if (header && header.pressColor) {
+      return header.pressColor;
+    }
+    return undefined;
+  }
+
   _getHeaderTitleStyle(navigation: Navigation): Style {
     const header = this.props.router.getScreenConfig(navigation, 'header');
     if (header && header.titleStyle) {
@@ -149,6 +158,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
       return null;
     }
     const tintColor = this._getHeaderTintColor(props.navigation);
+    const pressColor = this._getHeaderPressColor(props.navigation);
     const previousNavigation = addNavigationHelpers({
       ...props.navigation,
       state: props.scenes[props.scene.index - 1].route,
@@ -160,6 +170,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
     return (
       <HeaderBackButton
         onPress={props.onNavigateBack}
+        pressColor={pressColor}
         tintColor={tintColor}
         title={backButtonTitle}
         width={width}

--- a/src/views/HeaderBackButton.js
+++ b/src/views/HeaderBackButton.js
@@ -16,6 +16,7 @@ import TouchableItem from './TouchableItem';
 
 type Props = {
   onPress?: () => void,
+  pressColor?: ?string,
   title?: ?string,
   tintColor?: ?string,
   truncatedTitle?: ?string,
@@ -23,6 +24,7 @@ type Props = {
 };
 
 type DefaultProps = {
+  pressColor: ?string,
   tintColor: ?string,
   truncatedTitle: ?string,
 };
@@ -34,6 +36,7 @@ type State = {
 class HeaderBackButton extends React.PureComponent<DefaultProps, Props, State> {
   static propTypes = {
     onPress: PropTypes.func.isRequired,
+    pressColor: PropTypes.string,
     title: PropTypes.string,
     tintColor: PropTypes.string,
     truncatedTitle: PropTypes.string,
@@ -41,6 +44,7 @@ class HeaderBackButton extends React.PureComponent<DefaultProps, Props, State> {
   };
 
   static defaultProps = {
+    pressColor: 'rgba(0, 0, 0, .32)',
     tintColor: Platform.select({
       ios: '#037aff',
     }),
@@ -59,7 +63,7 @@ class HeaderBackButton extends React.PureComponent<DefaultProps, Props, State> {
   };
 
   render() {
-    const { onPress, width, title, tintColor, truncatedTitle } = this.props;
+    const { onPress, pressColor, width, title, tintColor, truncatedTitle } = this.props;
 
     const renderTruncated = this.state.initialTextWidth && width
       ? this.state.initialTextWidth > width
@@ -69,6 +73,7 @@ class HeaderBackButton extends React.PureComponent<DefaultProps, Props, State> {
       <TouchableItem
         delayPressIn={0}
         onPress={onPress}
+        pressColor={pressColor}
         style={styles.container}
         borderless
       >

--- a/src/views/HeaderBackButton.js
+++ b/src/views/HeaderBackButton.js
@@ -16,7 +16,7 @@ import TouchableItem from './TouchableItem';
 
 type Props = {
   onPress?: () => void,
-  pressColor?: ?string,
+  pressColorAndroid?: ?string,
   title?: ?string,
   tintColor?: ?string,
   truncatedTitle?: ?string,
@@ -24,7 +24,7 @@ type Props = {
 };
 
 type DefaultProps = {
-  pressColor: ?string,
+  pressColorAndroid: ?string,
   tintColor: ?string,
   truncatedTitle: ?string,
 };
@@ -36,7 +36,7 @@ type State = {
 class HeaderBackButton extends React.PureComponent<DefaultProps, Props, State> {
   static propTypes = {
     onPress: PropTypes.func.isRequired,
-    pressColor: PropTypes.string,
+    pressColorAndroid: PropTypes.string,
     title: PropTypes.string,
     tintColor: PropTypes.string,
     truncatedTitle: PropTypes.string,
@@ -44,7 +44,7 @@ class HeaderBackButton extends React.PureComponent<DefaultProps, Props, State> {
   };
 
   static defaultProps = {
-    pressColor: 'rgba(0, 0, 0, .32)',
+    pressColorAndroid: 'rgba(0, 0, 0, .32)',
     tintColor: Platform.select({
       ios: '#037aff',
     }),
@@ -63,7 +63,7 @@ class HeaderBackButton extends React.PureComponent<DefaultProps, Props, State> {
   };
 
   render() {
-    const { onPress, pressColor, width, title, tintColor, truncatedTitle } = this.props;
+    const { onPress, pressColorAndroid, width, title, tintColor, truncatedTitle } = this.props;
 
     const renderTruncated = this.state.initialTextWidth && width
       ? this.state.initialTextWidth > width
@@ -73,7 +73,7 @@ class HeaderBackButton extends React.PureComponent<DefaultProps, Props, State> {
       <TouchableItem
         delayPressIn={0}
         onPress={onPress}
-        pressColor={pressColor}
+        pressColor={pressColorAndroid}
         style={styles.container}
         borderless
       >

--- a/src/views/TouchableItem.js
+++ b/src/views/TouchableItem.js
@@ -26,14 +26,14 @@ type Props = {
   onPress: Function,
   delayPressIn?: number;
   borderless?: boolean;
-  pressColor?: string;
+  pressColor?: ?string;
   activeOpacity?: number;
   children?: React.Element<*>;
   style?: Style;
 };
 
 type DefaultProps = {
-  pressColor: string;
+  pressColor: ?string;
 };
 
 export default class TouchableItem extends Component<DefaultProps, Props, void> {


### PR DESCRIPTION
This resolves https://github.com/react-community/react-navigation/issues/925, adding the option to change the back button's ripple colour. For example:

![screenshot_20170405-124107_01](https://cloud.githubusercontent.com/assets/4429247/24704460/b086f152-19ff-11e7-8975-b3f73548993a.png)

All tests and flow checks are passing. Test plan:

- Don't set `pressColor` in `navigationOptions.header` on a `StackNavigator`. Everything is the same as before.
- Set `pressColor` to anything you want as above. Ripple colour has changed.

Do let me know if there's anything you'd prefer to be done differently :slightly_smiling_face: 
