### PR TITLE
[Playgrond] Add StacksOverTabs example

### DIFF
--- a/examples/NavigationPlayground/js/App.js
+++ b/examples/NavigationPlayground/js/App.js
@@ -17,6 +17,7 @@ import CustomTabs from './CustomTabs';
 import Drawer from './Drawer';
 import ModalStack from './ModalStack';
 import StacksInTabs from './StacksInTabs';
+import StacksOverTabs from './StacksOverTabs';
 import SimpleStack from './SimpleStack';
 import SimpleTabs from './SimpleTabs';
 
@@ -50,6 +51,11 @@ const ExampleRoutes = {
     name: 'Stacks in Tabs',
     description: 'Nested stack navigation in tabs',
     screen: StacksInTabs,
+  },
+  StacksOverTabs: {
+    name: 'Stacks over Tabs',
+    description: 'Nested stack navigation that pushes on top of tabs',
+    screen: StacksOverTabs,
   },
   LinkStack: {
     name: 'Link in Stack',

--- a/examples/NavigationPlayground/js/StacksInTabs.js
+++ b/examples/NavigationPlayground/js/StacksInTabs.js
@@ -27,7 +27,7 @@ const MyNavScreen = ({ navigation, banner }) => (
       title="Go to notification settings"
     />
     <Button
-      onPress={() => navigation.navigate('Settings')}
+      onPress={() => navigation.navigate('SettingsTab')}
       title="Go to settings"
     />
     <Button

--- a/examples/NavigationPlayground/js/StacksOverTabs.js
+++ b/examples/NavigationPlayground/js/StacksOverTabs.js
@@ -1,0 +1,143 @@
+/**
+ * @flow
+ */
+
+import React from 'react';
+import {
+  Button,
+  ScrollView,
+} from 'react-native';
+import {
+  StackNavigator,
+  TabNavigator,
+} from 'react-navigation';
+
+import Ionicons from 'react-native-vector-icons/Ionicons';
+import SampleText from './SampleText';
+
+const MyNavScreen = ({ navigation, banner }) => (
+  <ScrollView>
+    <SampleText>{banner}</SampleText>
+    <Button
+      onPress={() => navigation.navigate('Profile', { name: 'Jordan' })}
+      title="Go to a profile screen"
+    />
+    <Button
+      onPress={() => navigation.navigate('NotifSettings')}
+      title="Go to notification settings"
+    />
+    <Button
+      onPress={() => navigation.navigate('Settings')}
+      title="Go to settings"
+    />
+    <Button
+      onPress={() => navigation.goBack(null)}
+      title="Go back"
+    />
+  </ScrollView>
+);
+
+const MyHomeScreen = ({ navigation }) => (
+  <MyNavScreen
+    banner="Home Screen"
+    navigation={navigation}
+  />
+);
+
+const MyProfileScreen = ({ navigation }) => (
+  <MyNavScreen
+    banner={`${navigation.state.params.name}s Profile`}
+    navigation={navigation}
+  />
+);
+MyProfileScreen.navigationOptions = {
+  title: ({ state }) => `${state.params.name}'s Profile!`,
+};
+
+const MyNotificationsSettingsScreen = ({ navigation }) => (
+  <MyNavScreen
+    banner="Notification Settings"
+    navigation={navigation}
+  />
+);
+
+const MySettingsScreen = ({ navigation }) => (
+  <MyNavScreen
+    banner="Settings"
+    navigation={navigation}
+  />
+);
+
+const MainTab = StackNavigator({
+  Home: {
+    screen: MyHomeScreen,
+    path: '/',
+    navigationOptions: {
+      title: () => 'Welcome',
+    },
+  },
+  Profile: {
+    screen: MyProfileScreen,
+    path: '/people/:name',
+    navigationOptions: {
+      title: ({ state }) => `${state.params.name}'s Profile!`,
+    },
+  },
+});
+
+const SettingsTab = StackNavigator({
+  Settings: {
+    screen: MySettingsScreen,
+    path: '/',
+    navigationOptions: {
+      title: () => 'Settings',
+    },
+  },
+  NotifSettings: {
+    screen: MyNotificationsSettingsScreen,
+    navigationOptions: {
+      title: () => 'Notification Settings',
+    },
+  },
+});
+
+const StacksInTabs = TabNavigator({
+  MainTab: {
+    screen: MainTab,
+    path: '/',
+    navigationOptions: {
+      tabBar: () => ({
+        label: 'Home',
+        icon: ({ tintColor, focused }) => (
+          <Ionicons
+            name={focused ? 'ios-home' : 'ios-home-outline'}
+            size={26}
+            style={{ color: tintColor }}
+          />
+        ),
+      }),
+    },
+  },
+  SettingsTab: {
+    screen: SettingsTab,
+    path: '/settings',
+    navigationOptions: {
+      tabBar: () => ({
+        label: 'Settings',
+        icon: ({ tintColor, focused }) => (
+          <Ionicons
+            name={focused ? 'ios-settings' : 'ios-settings-outline'}
+            size={26}
+            style={{ color: tintColor }}
+          />
+        ),
+      }),
+    },
+  },
+}, {
+  tabBarPosition: 'bottom',
+  animationEnabled: false,
+  swipeEnabled: false,
+});
+
+export default StacksInTabs;

--- a/examples/NavigationPlayground/js/StacksOverTabs.js
+++ b/examples/NavigationPlayground/js/StacksOverTabs.js
@@ -76,13 +76,6 @@ const MainTab = StackNavigator({
       title: () => 'Welcome',
     },
   },
-  Profile: {
-    screen: MyProfileScreen,
-    path: '/people/:name',
-    navigationOptions: {
-      title: ({ state }) => `${state.params.name}'s Profile!`,
-    },
-  },
 });
 
 const SettingsTab = StackNavigator({
@@ -93,15 +86,9 @@ const SettingsTab = StackNavigator({
       title: () => 'Settings',
     },
   },
-  NotifSettings: {
-    screen: MyNotificationsSettingsScreen,
-    navigationOptions: {
-      title: () => 'Notification Settings',
-    },
-  },
 });
 
-const StacksInTabs = TabNavigator({
+const TabNav = TabNavigator({
   MainTab: {
     screen: MainTab,
     path: '/',
@@ -140,4 +127,25 @@ const StacksInTabs = TabNavigator({
   swipeEnabled: false,
 });
 
-export default StacksInTabs;
+const StacksOverTabs = StackNavigator({
+  Root: {
+    screen: TabNav,
+  },
+  NotifSettings: {
+    screen: MyNotificationsSettingsScreen,
+    navigationOptions: {
+      title: () => 'Notification Settings',
+    },
+  },
+  Profile: {
+    screen: MyProfileScreen,
+    path: '/people/:name',
+    navigationOptions: {
+      title: ({ state }) => `${state.params.name}'s Profile!`,
+    },
+  },
+}, {
+  headerMode: 'none',
+});
+
+export default StacksOverTabs;

--- a/examples/NavigationPlayground/js/StacksOverTabs.js
+++ b/examples/NavigationPlayground/js/StacksOverTabs.js
@@ -27,7 +27,7 @@ const MyNavScreen = ({ navigation, banner }) => (
       title="Go to notification settings"
     />
     <Button
-      onPress={() => navigation.navigate('Settings')}
+      onPress={() => navigation.navigate('SettingsTab')}
       title="Go to settings"
     />
     <Button
@@ -68,29 +68,9 @@ const MySettingsScreen = ({ navigation }) => (
   />
 );
 
-const MainTab = StackNavigator({
-  Home: {
-    screen: MyHomeScreen,
-    path: '/',
-    navigationOptions: {
-      title: () => 'Welcome',
-    },
-  },
-});
-
-const SettingsTab = StackNavigator({
-  Settings: {
-    screen: MySettingsScreen,
-    path: '/',
-    navigationOptions: {
-      title: () => 'Settings',
-    },
-  },
-});
-
 const TabNav = TabNavigator({
   MainTab: {
-    screen: MainTab,
+    screen: MyHomeScreen,
     path: '/',
     navigationOptions: {
       tabBar: () => ({
@@ -106,7 +86,7 @@ const TabNav = TabNavigator({
     },
   },
   SettingsTab: {
-    screen: SettingsTab,
+    screen: MySettingsScreen,
     path: '/settings',
     navigationOptions: {
       tabBar: () => ({


### PR DESCRIPTION
`StacksOverTabs` is exactly the same as `StacksInTabs`, except that when navigating, the routes get pushed on top of the tabs instead of inside of them. This is a common paradigm.

Also fixes `StacksInTabs` so it navigates to `SettingsTab` instead of pushing a new `Settings` screen to the stack.