### PR TITLE
[Playground] Add TabsInDrawer example

### DIFF
--- a/examples/NavigationPlayground/js/App.js
+++ b/examples/NavigationPlayground/js/App.js
@@ -15,6 +15,7 @@ import { StackNavigator } from 'react-navigation';
 import Banner from './Banner';
 import CustomTabs from './CustomTabs';
 import Drawer from './Drawer';
+import TabsInDrawer from './TabsInDrawer';
 import ModalStack from './ModalStack';
 import StacksInTabs from './StacksInTabs';
 import SimpleStack from './SimpleStack';
@@ -35,6 +36,11 @@ const ExampleRoutes = {
     name: 'Drawer Example',
     description: 'Android-style drawer navigation',
     screen: Drawer,
+  },
+  TabsInDrawer: {
+    name: 'Drawer + Tabs Example',
+    description: 'A drawer combined with tabs',
+    screen: TabsInDrawer,
   },
   CustomTabs: {
     name: 'Custom Tabs',

--- a/examples/NavigationPlayground/js/TabsInDrawer.js
+++ b/examples/NavigationPlayground/js/TabsInDrawer.js
@@ -1,0 +1,59 @@
+/**
+ * @flow
+ */
+
+import React from 'react';
+import {
+  Button,
+  Platform,
+  ScrollView,
+  StyleSheet,
+} from 'react-native';
+import {
+  TabNavigator,
+  DrawerNavigator,
+} from 'react-navigation';
+import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
+import SimpleTabs from './SimpleTabs';
+import StacksOverTabs from './StacksOverTabs';
+
+const TabsInDrawer = DrawerNavigator({
+  SimpleTabs: {
+    screen: SimpleTabs,
+    navigationOptions: {
+      drawer: () => ({
+        label: 'Simple Tabs',
+        icon: ({ tintColor }) => (
+          <MaterialIcons
+            name="filter-1"
+            size={24}
+            style={{ color: tintColor }}
+          />
+        ),
+      }),
+    },
+  },
+  StacksOverTabs: {
+    screen: StacksOverTabs,
+    navigationOptions: {
+      drawer: () => ({
+        label: 'Stacks Over Tabs',
+        icon: ({ tintColor }) => (
+          <MaterialIcons
+            name="filter-2"
+            size={24}
+            style={{ color: tintColor }}
+          />
+        ),
+      }),
+    },
+  },
+});
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: Platform.OS === 'ios' ? 20 : 0,
+  },
+});
+
+export default TabsInDrawer;


### PR DESCRIPTION
This example puts `SimpleTabs` and `StacksOverTabs` into a drawer layout with custom labels and icons. Shows how simple it is to nest the two like this :)

This is how my app works, and I needed to write this example anyway in order to test some integration logic with redux.

(should be merged after https://github.com/react-community/react-navigation/pull/928 since they're dependent)