### PR TITLE
Fix the ReduxExample app (2)

### DIFF
--- a/examples/ReduxExample/index.js
+++ b/examples/ReduxExample/index.js
@@ -3,20 +3,15 @@
  */
 
 import React from 'react';
-import { AppRegistry, AsyncStorage } from 'react-native';
+import { AppRegistry } from 'react-native';
 import { Provider } from 'react-redux';
 import { createStore } from 'redux';
-import { persistStore, autoRehydrate } from 'redux-persist';
 
 import AppReducer from './src/reducers';
 import AppWithNavigationState from './src/navigators/AppNavigator';
 
 class ReduxExampleApp extends React.Component {
-  store = createStore(AppReducer, undefined, autoRehydrate());
-
-  componentDidMount() {
-    persistStore(this.store, { storage: AsyncStorage });
-  }
+  store = createStore(AppReducer);
 
   render() {
     return (

--- a/examples/ReduxExample/index.js
+++ b/examples/ReduxExample/index.js
@@ -8,8 +8,8 @@ import { Provider } from 'react-redux';
 import { createStore } from 'redux';
 import { persistStore, autoRehydrate } from 'redux-persist';
 
-import AppReducer from 'src/reducers';
-import AppWithNavigationState from 'src/navigators/AppNavigator';
+import AppReducer from './src/reducers';
+import AppWithNavigationState from './src/navigators/AppNavigator';
 
 class ReduxExampleApp extends React.Component {
   store = createStore(AppReducer, undefined, autoRehydrate());

--- a/examples/ReduxExample/package.json
+++ b/examples/ReduxExample/package.json
@@ -10,8 +10,7 @@
 		"react": "15.4.2",
 		"react-native": "0.40.0",
 		"react-redux": "^5.0.2",
-		"redux": "^3.6.0",
-		"redux-persist": "^4.0.1"
+		"redux": "^3.6.0"
 	},
 	"devDependencies": {
 		"babel-jest": "18.0.0",

--- a/examples/ReduxExample/src/components/LoginScreen.js
+++ b/examples/ReduxExample/src/components/LoginScreen.js
@@ -42,3 +42,5 @@ LoginScreen.propTypes = {
 LoginScreen.navigationOptions = {
   title: 'Log In',
 };
+
+export default LoginScreen;

--- a/examples/ReduxExample/src/components/MainScreen.js
+++ b/examples/ReduxExample/src/components/MainScreen.js
@@ -19,6 +19,9 @@ const MainScreen = () => (
     <AuthButton />
   </View>
 );
+
 MainScreen.navigationOptions = {
   title: 'Home Screen',
 };
+
+export default MainScreen;

--- a/examples/ReduxExample/src/components/ProfileScreen.js
+++ b/examples/ReduxExample/src/components/ProfileScreen.js
@@ -30,3 +30,5 @@ const ProfileScreen = () => (
 ProfileScreen.navigationOptions = {
   title: 'Profile',
 };
+
+export default ProfileScreen;

--- a/examples/ReduxExample/src/reducers/index.js
+++ b/examples/ReduxExample/src/reducers/index.js
@@ -3,6 +3,7 @@ import { NavigationActions } from 'react-navigation';
 
 import { AppNavigator } from '../navigators/AppNavigator';
 
+// Start with two routes: The Main screen, with the Login screen on top.
 const initialNavState = {
   index: 1,
   routes: [

--- a/examples/ReduxExample/yarn.lock
+++ b/examples/ReduxExample/yarn.lock
@@ -2196,7 +2196,7 @@ json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
   dependencies:
     jsonify "~0.0.0"
 
-json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
+json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
@@ -2270,7 +2270,7 @@ load-json-file@^1.0.0:
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
 
-lodash-es@^4.17.4, lodash-es@^4.2.0, lodash-es@^4.2.1:
+lodash-es@^4.2.0, lodash-es@^4.2.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.4.tgz#dcc1d7552e150a0640073ba9cb31d70f032950e7"
 
@@ -2418,7 +2418,7 @@ lodash@^3.5.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.14.0, lodash@^4.16.6, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1:
+lodash@^4.14.0, lodash@^4.16.6, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -3097,14 +3097,6 @@ redeyed@~1.0.0:
   resolved "https://registry.yarnpkg.com/redeyed/-/redeyed-1.0.1.tgz#e96c193b40c0816b00aec842698e61185e55498a"
   dependencies:
     esprima "~3.0.0"
-
-redux-persist@^4.0.1:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-4.6.0.tgz#3994793d5f2f38bf02591c9e693e16bf8eae2728"
-  dependencies:
-    json-stringify-safe "^5.0.1"
-    lodash "^4.17.4"
-    lodash-es "^4.17.4"
 
 redux@^3.6.0:
   version "3.6.0"


### PR DESCRIPTION
The [awesome refactor](https://github.com/react-community/react-navigation/pull/819) that was done recently (thanks so much for that!) had a few import/export bugs preventing it from running that are fixed here.

I also disabled persistence to AsyncStorage; though it's a cool feature, it isn't necessary to demonstrate how to use react-navigation and may cause more confusion than it's worth. For example, if you change the name of a route and then refresh the app, everything will break because it can't find the old route that had been persisted, even though your code is perfectly fine.

cc @samijaber @ericvicenti 