### PR TITLE
Added the Header accessibility trait to the header title

### DIFF
--- a/src/views/HeaderTitle.js
+++ b/src/views/HeaderTitle.js
@@ -18,7 +18,7 @@ type Props = {
 };
 
 const HeaderTitle = ({ style, ...rest }: Props) => (
-  <Text numberOfLines={1} {...rest} style={[styles.title, style]} />
+  <Text numberOfLines={1} {...rest} style={[styles.title, style]} accessibilityTraits="header" />
 );
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
Without this trait, VoiceOver on IOS does not identify the title as a heading, which it is.

Test plan:
1. Launch an app with a title.
2. Turn on VoiceOver.
3. Observe that with this change, VO identifies the title as a heading.
4. Observe that with this change, VO identifies the title as a heading.
5. Launch almost any Apple app, including Find My Friends, Music, or even the Phone app, and notice that screen titles are also identified as headings in these apps.