### PR TITLE
[docs] clarify params passed to screen

### DIFF
--- a/docs/guides/Screen-Navigation-Prop.md
+++ b/docs/guides/Screen-Navigation-Prop.md
@@ -52,7 +52,7 @@ A screen has access to its route via `this.props.navigation.state`. Each will re
   routeName: 'profile',
   //a unique identifier used to sort routes
   key: 'main0',
-  //an optional object of string options for this screen
+  //an optional object of options for this screen
   params: { hello: 'world' }
 }
 ```


### PR DESCRIPTION
The current docs make it seem like you can only pass string props.

