### PR TITLE
Fix typo in StackRouter.md

### DIFF
--- a/docs/api/routers/StackRouter.md
+++ b/docs/api/routers/StackRouter.md
@@ -50,7 +50,7 @@ Each item in the config may have the following:
 
 Config options that are also passed to the stack router.
 
-- `initalRouteName` - The routeName for the default route when the stack first loads
+- `initialRouteName` - The routeName for the default route when the stack first loads
 - `initialRouteParams` - Default params of the initial route
 - `paths` - Provide a mapping of routeName to path config, which overrides the paths set in the routeConfigs.
 


### PR DESCRIPTION
Fixes a small typo in the `initialRouteName` property in StackRouter