### PR TITLE
Fix a race condition in the way SET_PARAMS dispatch is handled.

### DIFF
--- a/src/createNavigationContainer.js
+++ b/src/createNavigationContainer.js
@@ -143,6 +143,16 @@ export default function createNavigationContainer<T: *>(
       if (!this._isStateful()) {
         return false;
       }
+
+      // For SET_PARAMS, we need to ensure that we serialize the state in the following way
+      // Needed to prevent race conditions when SET_PARAMS is called in quick successions across
+      // different route keys, e.g. when screens in TabNavigator call setParams
+      // in componentWillMount
+      if (action.type === NavigationActions.SET_PARAMS) {
+        this.setState(({ nav }: *) => ({ nav: Component.router.getStateForAction(action, nav) }));
+        return true;
+      }
+
       const nav = Component.router.getStateForAction(action, state.nav);
 
       if (nav && nav !== state.nav) {


### PR DESCRIPTION
## The problem:
There's a race condition in `SET_PARAMS` dispatch handling, which manifests whenever `SET_PARAMS` is called on different route keys in quick succession, e.g. if `this.props.navigation.setParams()` is called during `componentWillMount()` of each screen in a TabNavigator

This happens because currently `SET_PARAMS` dispatch calls `setState({ nav })` for each call. When a lot of SET_PARAMS calls are received in quick succession, because of the async nature of `setState()`, the effect is that of only some of the `setState()` actually happening. For a test with 4 tabs, only the first and last saw the corresponding state change done.

## The solution:
This patch modifies the dispatch handling of `SET_PARAMS` to ensure that `setState()` uses a serialised approach to ensure that all the individual `setState()` calls see the previous state as set by other `SET_PARAMS` calls

## Potential concerns
This makes `setParams()` potentially _noisy_. But given that `setState()` is being called inside `createNavigationContainer`, which isn't aware of the internal state maintained by the actual router, there doesn't appear to be a better way around this.