### PR TITLE
allow headerLeft on 0 index

### DIFF
--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -128,9 +128,6 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
   };
 
   _renderLeftComponent = (props: SceneProps) => {
-    if (props.scene.index === 0) {
-      return null;
-    }
     const details = this.props.getScreenDetails(props.scene);
     const {headerLeft, headerPressColorAndroid} = details.options;
     if (headerLeft) {


### PR DESCRIPTION
Very small change to allow headerLeft on 0 index screens.

Basically, I want a left button on my first screen. And since there is no reason that this is not allowed, I enabled it.