### PR TITLE
Fix regressions in Header

### DIFF
--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -95,6 +95,10 @@ Visual options:
 
 Generic title that can be used as a fallback for `headerTitle` and `tabBarLabel`
 
+#### `headerBackTitle`
+
+Title string used by the back button on iOS or `null` to disable label. Defaults to `title`.
+
 #### `headerVisible`
 
 True or false to show or hide the header. Only works when `headerMode` is `screen`. Default value is `true`.

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -128,7 +128,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
 
   _renderLeftComponent = (props: SceneProps) => {
     const options = this.props.getScreenDetails(props.scene).options;
-    if (options.headerLeft) {
+    if (typeof options.headerLeft !== 'undefined') {
       return options.headerLeft;
     }
     if (props.scene.index === 0) {

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -81,16 +81,15 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
   }
 
   _getBackButtonTitleString(scene: NavigationScene): ?string {
-    const sceneOptions = this.props.getScreenDetails(scene).options;
-    const {headerBackTitle} = sceneOptions;
-    const lastScene = scene.index && this.props.scenes.find(s => s.index === scene.index - 1);
-    if (headerBackTitle || headerBackTitle === null) {
-      return headerBackTitle;
-    } else if (lastScene) {
-      return this._getHeaderTitleString(lastScene);
-    } else {
+    const lastScene = this.props.scenes.find(s => s.index === scene.index - 1);
+    if (!lastScene) {
       return null;
     }
+    const { headerBackTitle } = this.props.getScreenDetails(lastScene).options;
+    if (headerBackTitle || headerBackTitle === null) {
+      return headerBackTitle;
+    }
+    return this._getHeaderTitleString(lastScene);
   }
 
   _renderTitleComponent = (props: SceneProps) => {
@@ -128,13 +127,12 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
   };
 
   _renderLeftComponent = (props: SceneProps) => {
+    const options = this.props.getScreenDetails(props.scene).options;
+    if (options.headerLeft) {
+      return options.headerLeft;
+    }
     if (props.scene.index === 0) {
       return null;
-    }
-    const details = this.props.getScreenDetails(props.scene);
-    const {headerLeft, headerPressColorAndroid} = details.options;
-    if (headerLeft) {
-      return headerLeft;
     }
     const backButtonTitle = this._getBackButtonTitleString(props.scene);
     const width = this.state.widths[props.scene.key]
@@ -143,8 +141,8 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
     return (
       <HeaderBackButton
         onPress={() => this.props.navigation.goBack(null)}
-        pressColorAndroid={headerPressColorAndroid}
-        tintColor={details.options.headerTintColor}
+        pressColorAndroid={options.headerPressColorAndroid}
+        tintColor={options.headerTintColor}
         title={backButtonTitle}
         width={width}
       />


### PR DESCRIPTION
After reviewing #1017, I've discovered other changes that have to be applied. I also decided to bring back documentation.

Changes:
- `headerLeft` on scene with index `0` works. Fixes #1015 
- `backButtonTitle` is taken from a proper scene
- `headerLeft` different than `undefined` will take prio over default impl. Fixes #1021