### PR TITLE
Allow the routes outputted by DrawerView.Items to be overridden

### DIFF
--- a/docs/api/navigators/DrawerNavigator.md
+++ b/docs/api/navigators/DrawerNavigator.md
@@ -130,6 +130,7 @@ const styles = StyleSheet.create({
 
 ### `contentOptions` for `DrawerItems`
 
+- `items` - an array of routes to use in place of `navigation.state.routes`
 - `activeTintColor` - label and icon color of the active label
 - `activeBackgroundColor` - background color of the active label
 - `inactiveTintColor` - label and icon color of the inactive label

--- a/docs/api/navigators/DrawerNavigator.md
+++ b/docs/api/navigators/DrawerNavigator.md
@@ -130,11 +130,13 @@ const styles = StyleSheet.create({
 
 ### `contentOptions` for `DrawerItems`
 
-- `items` - an array of routes to use in place of `navigation.state.routes`
+- `items` - the array of routes, can be modified or overridden
+- `activeItemKey` - key identifying the active route
 - `activeTintColor` - label and icon color of the active label
 - `activeBackgroundColor` - background color of the active label
 - `inactiveTintColor` - label and icon color of the inactive label
 - `inactiveBackgroundColor` - background color of the inactive label
+- `onItemPress(route)` - function to be invoked when an item is pressed
 - `style` - style object for the content section
 - `labelStyle` - style object to overwrite `Text` style inside content section, when your label is a string
 

--- a/src/views/Drawer/DrawerNavigatorItems.js
+++ b/src/views/Drawer/DrawerNavigatorItems.js
@@ -12,17 +12,19 @@ import type {
   NavigationRoute,
   Style,
 } from '../../TypeDefinition';
-import type { DrawerScene } from './DrawerView.js';
+import type { DrawerScene, DrawerItem } from './DrawerView.js';
 
 type Props = {
   navigation: NavigationScreenProp<NavigationState, NavigationAction>,
-  items?: Array<NavigationRoute>,
+  items: Array<NavigationRoute>,
+  activeItemKey?: string,
   activeTintColor?: string,
   activeBackgroundColor?: string,
   inactiveTintColor?: string,
   inactiveBackgroundColor?: string,
   getLabel: (scene: DrawerScene) => ?(React.Element<*> | string),
   renderIcon: (scene: DrawerScene) => ?React.Element<*>,
+  onItemPress: (info: DrawerItem) => void,
   style?: Style,
   labelStyle?: Style,
 };
@@ -30,26 +32,23 @@ type Props = {
 /**
  * Component that renders the navigation list in the drawer.
  */
-const DrawerNavigatorItems = (
-  {
-    navigation: {
-      state,
-      navigate,
-    },
-    items,
-    activeTintColor,
-    activeBackgroundColor,
-    inactiveTintColor,
-    inactiveBackgroundColor,
-    getLabel,
-    renderIcon,
-    style,
-    labelStyle,
-  }: Props
-) => (
+const DrawerNavigatorItems = ({
+  navigation: { state, navigate },
+  items,
+  activeItemKey,
+  activeTintColor,
+  activeBackgroundColor,
+  inactiveTintColor,
+  inactiveBackgroundColor,
+  getLabel,
+  renderIcon,
+  onItemPress,
+  style,
+  labelStyle,
+}: Props) => (
   <View style={[styles.container, style]}>
-    {(items || state.routes).map((route: NavigationRoute, index: number) => {
-      const focused = state.routes[state.index].key === route.key;
+    {items.map((route: NavigationRoute, index: number) => {
+      const focused = activeItemKey === route.key;
       const color = focused ? activeTintColor : inactiveTintColor;
       const backgroundColor = focused
         ? activeBackgroundColor
@@ -61,8 +60,7 @@ const DrawerNavigatorItems = (
         <TouchableItem
           key={route.key}
           onPress={() => {
-            navigate('DrawerClose');
-            navigate(route.routeName);
+            onItemPress({ route, focused });
           }}
           delayPressIn={0}
         >

--- a/src/views/Drawer/DrawerNavigatorItems.js
+++ b/src/views/Drawer/DrawerNavigatorItems.js
@@ -9,12 +9,14 @@ import type {
   NavigationScreenProp,
   NavigationState,
   NavigationAction,
+  NavigationRoute,
   Style,
 } from '../../TypeDefinition';
 import type { DrawerScene } from './DrawerView.js';
 
 type Props = {
   navigation: NavigationScreenProp<NavigationState, NavigationAction>,
+  items?: Array<NavigationRoute>,
   activeTintColor?: string,
   activeBackgroundColor?: string,
   inactiveTintColor?: string,
@@ -28,20 +30,26 @@ type Props = {
 /**
  * Component that renders the navigation list in the drawer.
  */
-const DrawerNavigatorItems = ({
-  navigation,
-  activeTintColor,
-  activeBackgroundColor,
-  inactiveTintColor,
-  inactiveBackgroundColor,
-  getLabel,
-  renderIcon,
-  style,
-  labelStyle,
-}: Props) => (
+const DrawerNavigatorItems = (
+  {
+    navigation: {
+      state,
+      navigate,
+    },
+    items,
+    activeTintColor,
+    activeBackgroundColor,
+    inactiveTintColor,
+    inactiveBackgroundColor,
+    getLabel,
+    renderIcon,
+    style,
+    labelStyle,
+  }: Props
+) => (
   <View style={[styles.container, style]}>
-    {navigation.state.routes.map((route: *, index: number) => {
-      const focused = navigation.state.index === index;
+    {(items || state.routes).map((route: NavigationRoute, index: number) => {
+      const focused = state.routes[state.index].key === route.key;
       const color = focused ? activeTintColor : inactiveTintColor;
       const backgroundColor = focused
         ? activeBackgroundColor
@@ -53,8 +61,8 @@ const DrawerNavigatorItems = ({
         <TouchableItem
           key={route.key}
           onPress={() => {
-            navigation.navigate('DrawerClose');
-            navigation.navigate(route.routeName);
+            navigate('DrawerClose');
+            navigate(route.routeName);
           }}
           delayPressIn={0}
         >

--- a/src/views/Drawer/DrawerSidebar.js
+++ b/src/views/Drawer/DrawerSidebar.js
@@ -81,6 +81,8 @@ class DrawerSidebar extends PureComponent<void, Props, void> {
         <ContentComponent
           {...this.props.contentOptions}
           navigation={this.props.navigation}
+          screenProps={this.props.screenProps}
+          getScreenOptions={this._getScreenOptions}
           getLabel={this._getLabel}
           renderIcon={this._renderIcon}
           router={this.props.router}

--- a/src/views/Drawer/DrawerSidebar.js
+++ b/src/views/Drawer/DrawerSidebar.js
@@ -12,12 +12,13 @@ import type {
   NavigationRouter,
   NavigationDrawerScreenOptions,
   NavigationState,
+  NavigationStateRoute,
   Style,
 } from '../../TypeDefinition';
 
-import type { DrawerScene } from './DrawerView';
+import type { DrawerScene, DrawerItem } from './DrawerView';
 
-type Navigation = NavigationScreenProp<NavigationRoute, NavigationAction>;
+type Navigation = NavigationScreenProp<NavigationStateRoute, NavigationAction>;
 
 type Props = {
   router: NavigationRouter<
@@ -74,17 +75,27 @@ class DrawerSidebar extends PureComponent<void, Props, void> {
     return null;
   };
 
+  _onItemPress = ({ route }: DrawerItem) => {
+    this.props.navigation.navigate('DrawerClose');
+    this.props.navigation.navigate(route.routeName);
+  };
+
   render() {
     const ContentComponent = this.props.contentComponent;
+    const { state } = this.props.navigation;
     return (
       <View style={[styles.container, this.props.style]}>
         <ContentComponent
           {...this.props.contentOptions}
           navigation={this.props.navigation}
+          items={state.routes}
+          activeItemKey={
+            state.routes[state.index] && state.routes[state.index].key
+          }
           screenProps={this.props.screenProps}
-          getScreenOptions={this._getScreenOptions}
           getLabel={this._getLabel}
           renderIcon={this._renderIcon}
+          onItemPress={this._onItemPress}
           router={this.props.router}
         />
       </View>

--- a/src/views/Drawer/DrawerView.js
+++ b/src/views/Drawer/DrawerView.js
@@ -23,6 +23,11 @@ export type DrawerScene = {
   tintColor?: string,
 };
 
+export type DrawerItem = {
+  route: NavigationRoute,
+  focused: boolean,
+};
+
 export type DrawerViewConfig = {
   drawerWidth: number,
   drawerPosition: 'left' | 'right',


### PR DESCRIPTION
Among other things, this allows sections and dividers to be implemented by providing multiple DrawerView.Items with partial versions of `navigation.state.routes`.

`getScreenOptions` is also exposed so contentComponent can make use of its own navigation properties.

## Test plan (required)
Here's a screenshot of an app with a custom contentComponent using these changes to add its own divider/subheading handling.
![screenshot_20170413-190353](https://cloud.githubusercontent.com/assets/53399/25031331/08c0c82a-2081-11e7-94ef-a61da56bdae4.png)
