### PR TITLE
Upgrade `babel-plugin-flow-prop-types`

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,4 @@
 {
-  "presets": ["react-native"],
   "env": {
     // For RN example development
     "development": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "babel-core": "^6.24.0",
     "babel-eslint": "^7.0.0",
     "babel-jest": "^19.0.0",
-    "babel-plugin-flow-react-proptypes": "^1.0.0",
+    "babel-plugin-flow-react-proptypes": "grabbou/babel-plugin-flow-react-proptypes#release",
     "babel-preset-es2015": "^6.24.0",
     "babel-preset-react": "^6.23.0",
     "babel-preset-react-native": "^1.9.0",

--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -2,7 +2,8 @@
 
 import React from 'react';
 
-// @todo figure out how to use Animated.Value type in web context
+// @todo when we split types into common, native and web,
+// we can properly change Animated.Value to its real value
 type AnimatedValue = *;
 
 export type HeaderMode = 'float' | 'screen' | 'none';

--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -2,14 +2,16 @@
 
 import React from 'react';
 
-import {
-  Animated,
-} from 'react-native';
+// @todo figure out how to use Animated.Value type in web context
+type AnimatedValue = *;
 
-import type {
-  HeaderMode,
-  HeaderProps,
-} from './views/Header';
+export type HeaderMode = 'float' | 'screen' | 'none';
+
+export type HeaderProps = NavigationSceneRendererProps & {
+  mode: HeaderMode,
+  router: NavigationRouter<NavigationState, NavigationAction, NavigationStackScreenOptions>,
+  getScreenDetails: NavigationScene => NavigationScreenDetails<NavigationStackScreenOptions>,
+};
 
 /**
  * NavigationState is a tree of routes for a single navigator, where each child
@@ -204,9 +206,11 @@ export type NavigationStackViewConfig = {
 export type NavigationStackScreenOptions = NavigationScreenOptions & {
   headerTitle?: string | React.Element<*>,
   headerTitleStyle?: Style,
-  headerLeft?: string | React.Element<*>,
+  headerTintColor?: string,
+  headerLeft?: React.Element<*>,
   headerBackTitle?: string,
-  headerRight?: string | React.Element<*>,
+  headerPressColorAndroid?: string,
+  headerRight?: React.Element<*>,
   headerStyle?: Style,
   headerVisible?: boolean,
   gesturesEnabled?: boolean,
@@ -308,11 +312,11 @@ export type NavigationNavigatorProps = {
 export type NavigationGestureDirection = 'horizontal' | 'vertical';
 
 export type NavigationLayout = {
-  height: Animated.Value,
+  height: AnimatedValue,
   initHeight: number,
   initWidth: number,
   isMeasured: boolean,
-  width: Animated.Value,
+  width: AnimatedValue,
 };
 
 export type NavigationScene = {
@@ -331,14 +335,14 @@ export type NavigationTransitionProps = {
   navigation: NavigationScreenProp<NavigationState, NavigationAction>,
 
   // The progressive index of the transitioner's navigation state.
-  position: Animated.Value,
+  position: AnimatedValue,
 
   // The value that represents the progress of the transition when navigation
   // state changes from one to another. Its numberic value will range from 0
   // to 1.
   //  progress.__getAnimatedValue() < 1 : transtion is happening.
   //  progress.__getAnimatedValue() == 1 : transtion completes.
-  progress: Animated.Value,
+  progress: AnimatedValue,
 
   // All the scenes of the transitioner.
   scenes: Array<NavigationScene>,
@@ -350,6 +354,8 @@ export type NavigationTransitionProps = {
   // is the index of the scene
   scene: NavigationScene,
   index: number,
+
+  screenProps?: {},
 };
 
 // The scene renderer props are nearly identical to the props used for rendering
@@ -362,11 +368,11 @@ export type NavigationTransitionSpec = {
   // An easing function from `Easing`.
   easing?: () => any,
   // A timing function such as `Animated.timing`.
-  timing?: (value: Animated.Value, config: any) => any,
+  timing?: (value: AnimatedValue, config: any) => any,
 };
 
 export type NavigationAnimationSetter = (
-  position: Animated.Value,
+  position: AnimatedValue,
   newState: NavigationState,
   lastState: NavigationState,
 ) => void;

--- a/src/views/CardStack.js
+++ b/src/views/CardStack.js
@@ -19,17 +19,15 @@ import type {
   NavigationState,
   NavigationScreenDetails,
   NavigationStackScreenOptions,
+  HeaderMode,
   Style,
 } from '../TypeDefinition';
-
-import type { HeaderMode } from './Header';
 
 import type { TransitionConfig } from './TransitionConfigs';
 
 import TransitionConfigs from './TransitionConfigs';
 
 const emptyFunction = () => {};
-
 
 type Props = {
   screenProps?: {},

--- a/src/views/CardStackTransitioner.js
+++ b/src/views/CardStackTransitioner.js
@@ -12,7 +12,6 @@ import Header from './Header';
 const NativeAnimatedModule = NativeModules &&
   NativeModules.NativeAnimatedModule;
 
-
 import type {
   NavigationAction,
   NavigationSceneRenderer,
@@ -21,14 +20,11 @@ import type {
   NavigationState,
   NavigationTransitionProps,
   NavigationRouter,
+  HeaderMode,
   Style,
 } from '../TypeDefinition';
 
-
-import type { HeaderMode } from './Header';
-
 import type { TransitionConfig } from './TransitionConfigs';
-
 
 type Props = {
   screenProps?: {},

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -1,5 +1,3 @@
-'no babel-plugin-flow-react-proptypes'; // doesn't support intersection yet
-
 /* @flow */
 
 import React from 'react';

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+'no babel-plugin-flow-react-proptypes';
+
 import React from 'react';
 
 import {
@@ -15,23 +17,10 @@ import HeaderStyleInterpolator from './HeaderStyleInterpolator';
 
 import type {
   NavigationScene,
-  NavigationRouter,
-  NavigationAction,
-  NavigationSceneRendererProps,
   NavigationStyleInterpolator,
-  NavigationScreenDetails,
-  NavigationStackScreenOptions,
-  NavigationState,
   LayoutEvent,
+  HeaderProps,
 } from '../TypeDefinition';
-
-export type HeaderMode = 'float' | 'screen' | 'none';
-
-export type HeaderProps = NavigationSceneRendererProps & {
-  mode: HeaderMode,
-  router: NavigationRouter<NavigationState, NavigationAction, NavigationStackScreenOptions>,
-  getScreenDetails: NavigationScene => NavigationScreenDetails<NavigationStackScreenOptions>,
-};
 
 type SceneProps = {
   scene: NavigationScene,
@@ -130,7 +119,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
       : undefined;
     return (
       <HeaderBackButton
-        onPress={() => this.props.navigation.goBack(null)}
+        onPress={() => { this.props.navigation.goBack(null); }}
         pressColorAndroid={options.headerPressColorAndroid}
         tintColor={options.headerTintColor}
         title={backButtonTitle}
@@ -206,7 +195,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
       return null;
     }
 
-    let subView = renderer(props);
+    const subView = renderer(props);
 
     if (subView == null) {
       return null;
@@ -258,7 +247,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
     let appBar;
 
     if (this.props.mode === 'float') {
-      const scenesProps: Array<NavigationSceneRendererProps> = this.props.scenes
+      const scenesProps: Array<SceneProps> = this.props.scenes
         .map((scene: NavigationScene) => ({
           position: this.props.position,
           progress: this.props.progress,

--- a/src/views/TabView/TabBarIcon.js
+++ b/src/views/TabView/TabBarIcon.js
@@ -11,7 +11,6 @@ import type {
   NavigationAction,
   NavigationState,
   NavigationScreenProp,
-  NavigationRoute,
   Style,
 } from '../../TypeDefinition';
 

--- a/src/views/TabView/TabBarTop.js
+++ b/src/views/TabView/TabBarTop.js
@@ -12,7 +12,6 @@ import type {
   NavigationAction,
   NavigationScreenProp,
   NavigationState,
-  NavigationRoute,
   Style,
 } from '../../TypeDefinition';
 

--- a/website/package.json
+++ b/website/package.json
@@ -9,6 +9,7 @@
     "babel-eslint": "7.0.0",
     "babel-jest": "16.0.0",
     "babel-loader": "6.2.5",
+    "babel-plugin-flow-react-proptypes": "grabbou/babel-plugin-flow-react-proptypes#release",
     "babel-preset-react-app": "^1.0.0",
     "case-sensitive-paths-webpack-plugin": "1.1.4",
     "chalk": "1.1.3",

--- a/website/scripts/build.js
+++ b/website/scripts/build.js
@@ -157,6 +157,7 @@ function printErrors(summary, errors) {
   console.log();
   errors.forEach((err) => {
     console.log(err.message || err);
+    console.log(err.stack);
     console.log();
   });
 }

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -93,13 +93,6 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
-animated@^0.1.3:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/animated/-/animated-0.1.5.tgz#83df8dc443d57abab7b0bb04818b0b655b31c9b9"
-  dependencies:
-    invariant "^2.2.0"
-    normalize-css-color "^1.0.1"
-
 ansi-align@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-1.1.0.tgz#2f0c1658829739add5ebb15e6b0c6e3423f016ba"
@@ -177,10 +170,6 @@ array-differ@^1.0.0:
 array-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
-
-array-find-index@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
 
 array-flatten@1.1.1:
   version "1.1.1"
@@ -348,7 +337,7 @@ babel-core@6.17.0:
     slash "^1.0.0"
     source-map "^0.5.0"
 
-babel-core@^6.0.0, babel-core@^6.11.4, babel-core@^6.22.0, babel-core@^6.22.1:
+babel-core@^6.0.0, babel-core@^6.11.4, babel-core@^6.18.0, babel-core@^6.22.0, babel-core@^6.22.1:
   version "6.22.1"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.22.1.tgz#9c5fd658ba1772d28d721f6d25d968fc7ae21648"
   dependencies:
@@ -530,6 +519,15 @@ babel-plugin-check-es2015-constants@^6.22.0, babel-plugin-check-es2015-constants
   resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz#35157b101426fd2ffd3da3f75c7d1e91835bbf8a"
   dependencies:
     babel-runtime "^6.22.0"
+
+babel-plugin-flow-react-proptypes@grabbou/babel-plugin-flow-react-proptypes#release:
+  version "1.1.0"
+  resolved "https://codeload.github.com/grabbou/babel-plugin-flow-react-proptypes/tar.gz/5bf48951cf7d1dbfdb0115630a7a86361f07c464"
+  dependencies:
+    babel-core "^6.18.0"
+    babel-template "^6.16.0"
+    babel-traverse "^6.18.0"
+    babel-types "^6.18.0"
 
 babel-plugin-istanbul@^2.0.0:
   version "2.0.3"
@@ -1008,7 +1006,7 @@ babel-runtime@6.5.0:
   dependencies:
     core-js "^1.2.0"
 
-babel-runtime@^6.0.0, babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.9.0, babel-runtime@^6.9.1:
+babel-runtime@^6.0.0, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.9.0, babel-runtime@^6.9.1:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.22.0.tgz#1cf8b4ac67c77a4ddb0db2ae1f74de52ac4ca611"
   dependencies:
@@ -1126,10 +1124,6 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
-bowser@^1.0.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.6.0.tgz#37fc387b616cb6aef370dab4d6bd402b74c5c54d"
-
 boxen@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/boxen/-/boxen-0.6.0.tgz#8364d4248ac34ff0ef1b2f2bf49a6c60ce0d81b6"
@@ -1171,14 +1165,14 @@ browserify-zlib@~0.1.4:
   dependencies:
     pako "~0.2.0"
 
-browserslist@^1.0.1, browserslist@^1.4.0, browserslist@^1.5.2:
+browserslist@^1.0.1, browserslist@^1.5.2:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-1.7.1.tgz#cc9bd193979a2a4b09fdb3df6003fefe48ccefe1"
   dependencies:
     caniuse-db "^1.0.30000617"
     electron-to-chromium "^1.2.1"
 
-browserslist@~1.4.0:
+browserslist@^1.4.0, browserslist@~1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-1.4.0.tgz#9cfdcf5384d9158f5b70da2aa00b30e8ff019049"
   dependencies:
@@ -1804,19 +1798,9 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-date-now@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/date-now/-/date-now-1.0.1.tgz#bb7d086438debe4182a485fb3df3fbfb99d6153c"
-
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
-
-debounce@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.0.0.tgz#0948af513d2e4ce407916f8506a423d3f9cf72d8"
-  dependencies:
-    date-now "1.0.1"
 
 debug@2.2.0, debug@~2.2.0:
   version "2.2.0"
@@ -1887,12 +1871,6 @@ decompress@^4.0.0:
     mkdirp "^0.5.1"
     pify "^2.3.0"
     strip-dirs "^1.1.1"
-
-deep-assign@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/deep-assign/-/deep-assign-2.0.0.tgz#ebe06b1f07f08dae597620e3dd1622f371a1c572"
-  dependencies:
-    is-obj "^1.0.0"
 
 deep-extend@~0.4.0:
   version "0.4.1"
@@ -3049,10 +3027,6 @@ https-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-0.0.0.tgz#b3ffdfe734b2a3d4a9efd58e8654c91fce86eafd"
 
-hyphenate-style-name@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
-
 iconv-lite@0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
@@ -3107,13 +3081,6 @@ inherits@2.0.1:
 ini@^1.3.4, ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
-
-inline-style-prefixer@^2.0.1:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-2.0.5.tgz#c153c7e88fd84fef5c602e95a8168b2770671fe7"
-  dependencies:
-    bowser "^1.0.0"
-    hyphenate-style-name "^1.0.1"
 
 inquirer@^0.12.0:
   version "0.12.0"
@@ -4237,10 +4204,6 @@ nopt@3.x, nopt@~3.0.6:
   dependencies:
     abbrev "1"
 
-normalize-css-color@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/normalize-css-color/-/normalize-css-color-1.0.2.tgz#02991e97cccec6623fe573afbbf0de6a1f3e9f8d"
-
 normalize-package-data@^2.3.2:
   version "2.3.5"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.3.5.tgz#8d924f142960e1777e7ffe170543631cc7cb02df"
@@ -5039,32 +5002,9 @@ react-markdown@^2.4.2:
     commonmark-react-renderer "^4.2.4"
     in-publish "^2.0.0"
 
-react-native-web@^0.0.55:
-  version "0.0.55"
-  resolved "https://registry.yarnpkg.com/react-native-web/-/react-native-web-0.0.55.tgz#7e74f05a18415148e5a45ec42779b79a5b767218"
-  dependencies:
-    animated "^0.1.3"
-    array-find-index "^1.0.2"
-    babel-runtime "^6.11.6"
-    debounce "^1.0.0"
-    deep-assign "^2.0.0"
-    fbjs "^0.8.4"
-    inline-style-prefixer "^2.0.1"
-    react-dom "~15.3.2"
-    react-textarea-autosize "^4.0.4"
-    react-timer-mixin "^0.13.3"
-
 react-navigation@^0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/react-navigation/-/react-navigation-0.0.0.tgz#1e0f865235cdb4d4aa8086484fd3690ff73df553"
-
-react-textarea-autosize@^4.0.4:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-4.0.5.tgz#55379f6a6fa575fc87d1b8de2756e57e3b6c995d"
-
-react-timer-mixin@^0.13.3:
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/react-timer-mixin/-/react-timer-mixin-0.13.3.tgz#0da8b9f807ec07dc3e854d082c737c65605b3d22"
 
 react@~15.3.2:
   version "15.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3317,13 +3317,13 @@ mime-db@~1.23.0:
   version "1.23.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.23.0.tgz#a31b4070adaea27d732ea333740a64d0ec9a6659"
 
-mime-types@2.1.11, mime-types@~2.1.7, mime-types@~2.1.9:
+mime-types@2.1.11, mime-types@~2.1.7:
   version "2.1.11"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.11.tgz#c259c471bda808a85d6cd193b430a5fae4473b3c"
   dependencies:
     mime-db "~1.23.0"
 
-mime-types@^2.1.12, mime-types@~2.1.11, mime-types@~2.1.13, mime-types@~2.1.6:
+mime-types@^2.1.12, mime-types@~2.1.11, mime-types@~2.1.13, mime-types@~2.1.6, mime-types@~2.1.9:
   version "2.1.14"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.14.tgz#f7ef7d97583fcaf3b7d282b6f8b5679dab1e94ee"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -467,9 +467,9 @@ babel-plugin-external-helpers@^6.18.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-flow-react-proptypes@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-flow-react-proptypes/-/babel-plugin-flow-react-proptypes-1.0.0.tgz#020de47d67f670f53ba96949ea1bd0fa5f670c1d"
+babel-plugin-flow-react-proptypes@grabbou/babel-plugin-flow-react-proptypes#release:
+  version "1.1.0"
+  resolved "https://codeload.github.com/grabbou/babel-plugin-flow-react-proptypes/tar.gz/5bf48951cf7d1dbfdb0115630a7a86361f07c464"
   dependencies:
     babel-core "^6.18.0"
     babel-template "^6.16.0"


### PR DESCRIPTION
This PR switches `babel-plugin-flow-prop-types` to our fork temporarily as the npm version is broken for higher order components.

We will switch back to `npm` when this gets merged: https://github.com/brigand/babel-plugin-flow-react-proptypes/pull/76

That unbreaks website build.