### PR TITLE
Fix screenProps not being passed through to CardStack

### DIFF
--- a/src/views/CardStackTransitioner.js
+++ b/src/views/CardStackTransitioner.js
@@ -99,6 +99,7 @@ class CardStackTransitioner extends Component<DefaultProps, Props, void> {
 
   _render = (props: NavigationTransitionProps): React.Element<*> => {
     const {
+      screenProps,
       headerComponent,
       headerMode,
       mode,
@@ -108,6 +109,7 @@ class CardStackTransitioner extends Component<DefaultProps, Props, void> {
     } = this.props;
     return (
       <CardStack
+        screenProps={screenProps}
         headerComponent={headerComponent}
         headerMode={headerMode}
         mode={mode}


### PR DESCRIPTION
`screenProps` were not being passed to `CardStack` and consequently not available for the navigationOptions function in components using `StackNavigator`.

**Test plan (required)**

To test, I modified the Playground app to use `screenProps` in the title of the profile screen:
```diff
diff --git a/examples/NavigationPlayground/js/App.js b/examples/NavigationPlayground/js/App.js
index c5cb31b..4c590e3 100644
--- a/examples/NavigationPlayground/js/App.js
+++ b/examples/NavigationPlayground/js/App.js
@@ -115,7 +115,7 @@ const AppNavigator = StackNavigator({
   mode: Platform.OS === 'ios' ? 'modal' : 'card',
 });

-export default () => <AppNavigator />;
+export default () => <AppNavigator screenProps={{ name: 'Ville' }} />;

 const styles = StyleSheet.create({
   item: {
diff --git a/examples/NavigationPlayground/js/SimpleStack.js b/examples/NavigationPlayground/js/SimpleStack.js
index 3ab204f..f2f3df4 100644
--- a/examples/NavigationPlayground/js/SimpleStack.js
+++ b/examples/NavigationPlayground/js/SimpleStack.js
@@ -61,11 +61,11 @@ const MyProfileScreen = ({ navigation }) => (
 );

 MyProfileScreen.navigationOptions = props => {
-  const {navigation} = props;
+  const {navigation, screenProps} = props;
   const {state, setParams} = navigation;
   const {params} = state;
   return {
-    headerTitle: `${params.name}'s Profile!`,
+    headerTitle: `${screenProps.name}'s Profile!`,
     // Render a button on the right side of the header.
     // When pressed switches the screen to edit mode.
     headerRight: (
```
Screenshot before the change:
![simulator screen shot 14 apr 2017 18 51 44](https://cloud.githubusercontent.com/assets/497214/25048227/f4e8e184-2143-11e7-91a4-a6a7534b461a.png)

Screenshot after the change:
![simulator screen shot 14 apr 2017 18 51 58](https://cloud.githubusercontent.com/assets/497214/25048231/f92800ae-2143-11e7-9fad-636a829b1e50.png)
