### PR TITLE
Fix missing screenProps

### DIFF
--- a/src/views/CardStackTransitioner.js
+++ b/src/views/CardStackTransitioner.js
@@ -105,6 +105,7 @@ class CardStackTransitioner extends Component<DefaultProps, Props, void> {
       router,
       style,
       cardStyle,
+      screenProps,
     } = this.props;
     return (
       <CardStack
@@ -114,6 +115,7 @@ class CardStackTransitioner extends Component<DefaultProps, Props, void> {
         router={router}
         cardStyle={cardStyle}
         style={style}
+        screenProps={screenProps}
         {...props}
       />
     );


### PR DESCRIPTION
See [issue here](https://github.com/react-community/react-navigation/issues/1066)
