### PR TITLE
Fix StackRouter's back navigation to pop routes up until the route which is identified by the key

### DIFF
--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -246,21 +246,16 @@ export default (
       }
 
       if (action.type === NavigationActions.BACK) {
-        let backRouteIndex = null;
-        if (action.key) {
-          /* $FlowFixMe */
-          const backRoute = state.routes.find((route: *) => route.key === action.key);
-          /* $FlowFixMe */
-          backRouteIndex = state.routes.indexOf(backRoute);
-        }
-        if (backRouteIndex == null) {
+        let backRouteIndex = action.key ? StateUtils.indexOf(state, action.key) : null;
+
+        if (backRouteIndex === null) {
           return StateUtils.pop(state);
         }
-        if (backRouteIndex > 0) {
+        if (backRouteIndex >= 0) {
           return {
             ...state,
-            routes: state.routes.slice(0, backRouteIndex),
-            index: backRouteIndex - 1,
+            routes: state.routes.slice(0, backRouteIndex + 1),
+            index: backRouteIndex,
           };
         }
       }

--- a/src/routers/__tests__/StackRouter-test.js
+++ b/src/routers/__tests__/StackRouter-test.js
@@ -407,7 +407,7 @@ describe('StackRouter', () => {
     const state4 = router.getStateForAction({ type: NavigationActions.BACK, key: 'wrongKey' }, state3);
     expect(state3).toEqual(state4);
     const state5 = router.getStateForAction({ type: NavigationActions.BACK, key: state3 && state3.routes[1].key }, state4);
-    expect(state5).toEqual(state);
+    expect(state5).toEqual(state2);
   });
 
   test('Handle initial route navigation', () => {


### PR DESCRIPTION
I fixed the behavior of StackRouter's back navigation when used with a route key. Before the fix, the route identified by the key is also popped from the route stack. After the fix, the identified route is at the top of the stack.

Consider issuing the back navigation with key 'C' in the following example:
Route stack: [A B C D E]
State routes before fix: [A B]
State routes after fix: [A B C]

I feel it is more natural to read it as 'back to the screen identified by the key'. In most cases, your application knows the target route to go back to. Not having to search through the route stack again for the index of the next route saves a lot of complexity in the code.

**Test plan (required)**
I updated the test 'Handle goBack identified by key' in src/routers/__tests__/StackRouter-test.js with the new expectation.