### PR TITLE
Add headerBackTitleStyle option

### DIFF
--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -99,10 +99,6 @@ Generic title that can be used as a fallback for `headerTitle` and `tabBarLabel`
 
 Title string used by the back button on iOS or `null` to disable label. Defaults to `title`.
 
-#### `headerBackTitleStyle`
-
-Style object for the title string used by the back button.
-
 #### `headerVisible`
 
 True or false to show or hide the header. Only works when `headerMode` is `screen`. Default value is `true`.
@@ -114,6 +110,10 @@ String or React Element used by the header. Defaults to scene `title`
 #### `headerBackTitle`
 
 Title string used by the back button on iOS or `null` to disable label. Defaults to scene `title`
+
+#### `headerBackTitleStyle`
+
+Style object for the title string used by the back button.
 
 #### `headerRight`
 

--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -99,6 +99,10 @@ Generic title that can be used as a fallback for `headerTitle` and `tabBarLabel`
 
 Title string used by the back button on iOS or `null` to disable label. Defaults to `title`.
 
+#### `headerBackTitleStyle`
+
+Style object for the title string used by the back button.
+
 #### `headerVisible`
 
 True or false to show or hide the header. Only works when `headerMode` is `screen`. Default value is `true`.

--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -210,6 +210,7 @@ export type NavigationStackScreenOptions = NavigationScreenOptions & {
   headerTintColor?: string,
   headerLeft?: React.Element<*>,
   headerBackTitle?: string,
+  headerBackTitleStyle?: Style,
   headerPressColorAndroid?: string,
   headerRight?: React.Element<*>,
   headerStyle?: Style,

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -81,7 +81,6 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
 
     const titleStyle = details.options.headerTitleStyle;
     const color = details.options.headerTintColor;
-    const backTitleStyle = details.options.headerBackTitleStyle;
 
     // On iOS, width of left/right components depends on the calculated
     // size of the title.
@@ -125,7 +124,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
         tintColor={options.headerTintColor}
         title={backButtonTitle}
         width={width}
-        titleStyle={backTitleStyle}
+        titleStyle={options.headerBackTitleStyle}
       />
     );
   };

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -81,6 +81,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
 
     const titleStyle = details.options.headerTitleStyle;
     const color = details.options.headerTintColor;
+    const backTitleStyle = details.options.headerBackTitleStyle;
 
     // On iOS, width of left/right components depends on the calculated
     // size of the title.
@@ -124,6 +125,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
         tintColor={options.headerTintColor}
         title={backButtonTitle}
         width={width}
+        titleStyle={backTitleStyle}
       />
     );
   };

--- a/src/views/HeaderBackButton.js
+++ b/src/views/HeaderBackButton.js
@@ -10,7 +10,10 @@ import {
   StyleSheet,
 } from 'react-native';
 
-import type { LayoutEvent } from '../TypeDefinition';
+import type {
+  LayoutEvent,
+  Style
+} from '../TypeDefinition';
 
 import TouchableItem from './TouchableItem';
 
@@ -21,6 +24,7 @@ type Props = {
   tintColor?: ?string,
   truncatedTitle?: ?string,
   width?: ?number,
+  titleStyle?: Style
 };
 
 type DefaultProps = {
@@ -54,7 +58,7 @@ class HeaderBackButton extends React.PureComponent<DefaultProps, Props, State> {
   };
 
   render() {
-    const { onPress, pressColorAndroid, width, title, tintColor, truncatedTitle } = this.props;
+    const { onPress, pressColorAndroid, width, title, tintColor, truncatedTitle, titleStyle } = this.props;
 
     const renderTruncated = this.state.initialTextWidth && width
       ? this.state.initialTextWidth > width
@@ -80,7 +84,7 @@ class HeaderBackButton extends React.PureComponent<DefaultProps, Props, State> {
           {Platform.OS === 'ios' && title && (
             <Text
               onLayout={this._onTextLayout}
-              style={[styles.title, { color: tintColor }]}
+              style={[styles.title, { color: tintColor }, titleStyle]}
               numberOfLines={1}
             >
               {renderTruncated ? truncatedTitle : title}

--- a/src/views/HeaderBackButton.js
+++ b/src/views/HeaderBackButton.js
@@ -12,7 +12,7 @@ import {
 
 import type {
   LayoutEvent,
-  Style
+  Style,
 } from '../TypeDefinition';
 
 import TouchableItem from './TouchableItem';
@@ -58,7 +58,15 @@ class HeaderBackButton extends React.PureComponent<DefaultProps, Props, State> {
   };
 
   render() {
-    const { onPress, pressColorAndroid, width, title, tintColor, truncatedTitle, titleStyle } = this.props;
+    const {
+      onPress,
+      pressColorAndroid,
+      width,
+      title,
+      tintColor,
+      truncatedTitle,
+      titleStyle,
+    } = this.props;
 
     const renderTruncated = this.state.initialTextWidth && width
       ? this.state.initialTextWidth > width


### PR DESCRIPTION
This simple PR adds support for back button title styling.

**Motivation**
Unifying text styles in apps that use custom fonts.

**Testing**
in `examples/NavigationPlayground/js/SimpleStack.js`:
```diff
MyPhotosScreen.navigationOptions = {
  title: 'Photos',
+ headerBackTitleStyle: { textDecorationLine: 'line-through' },
};
```
<img src="https://cloud.githubusercontent.com/assets/23000873/25087480/f0c84d7a-2377-11e7-85ad-555afd33fad7.gif" width="400">
