### PR TITLE
removed reptiton of headerBackTitle text

### DIFF
--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -95,10 +95,6 @@ Visual options:
 
 Generic title that can be used as a fallback for `headerTitle` and `tabBarLabel`
 
-#### `headerBackTitle`
-
-Title string used by the back button on iOS or `null` to disable label. Defaults to `title`.
-
 #### `headerVisible`
 
 True or false to show or hide the header. Only works when `headerMode` is `screen`. Default value is `true`.


### PR DESCRIPTION
There was a duplicate in docs/api/navigators/StackNavigator.md where the headerBackTitle instructions was duplicate. I removed the first one after title.