### PR TITLE
add headerBackTitleStyle screen option

### DIFF
--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -128,6 +128,10 @@ Style object for the header
 
 Style object for the title component
 
+#### `headerBackTitleStyle`
+
+Style object for the back title, defaults to `headerTitleStyle`
+
 #### `headerTintColor`
 
 Tint color for the header

--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -126,11 +126,11 @@ Style object for the header
 
 #### `headerTitleStyle`
 
-Style object for the title component. These styles are also applied to the `headerBackTitle`
+Style object for the title component
 
 #### `headerBackTitleStyle`
 
-Style object for the back title, can override styles applied using `headerTitleStyle`
+Style object for the back title
 
 #### `headerTintColor`
 

--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -126,11 +126,11 @@ Style object for the header
 
 #### `headerTitleStyle`
 
-Style object for the title component
+Style object for the title component. These styles are also applied to the `headerBackTitle`
 
 #### `headerBackTitleStyle`
 
-Style object for the back title, defaults to `headerTitleStyle`
+Style object for the back title, can override styles applied using `headerTitleStyle`
 
 #### `headerTintColor`
 

--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -221,6 +221,7 @@ export type NavigationStackScreenOptions = NavigationScreenOptions & {
   headerLeft?: React.Element<*>,
   headerBackTitle?: string,
   headerTruncatedBackTitle?: string,
+  headerBackTitleStyle?: Style,
   headerPressColorAndroid?: string,
   headerRight?: React.Element<*>,
   headerStyle?: Style,

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -81,15 +81,13 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
 
   _getBackButtonTitleStyle(scene: NavigationScene): ?Style {
     const lastScene = this._getLastScene(scene);
+    const { headerBackTitleStyle } = this.props.getScreenDetails(scene).options;
     if (!lastScene) {
-      return null;
+      return headerBackTitleStyle;
     }
-    const {
-      headerBackTitleStyle,
-      headerTitleStyle,
-    } = this.props.getScreenDetails(lastScene).options;
+    const { headerTitleStyle } = this.props.getScreenDetails(lastScene).options;
 
-    return headerBackTitleStyle || headerTitleStyle;
+    return [headerTitleStyle, headerBackTitleStyle];
   }
 
   _renderTitleComponent = (props: SceneProps) => {

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -15,7 +15,6 @@ import type {
   NavigationStyleInterpolator,
   LayoutEvent,
   HeaderProps,
-  Style,
 } from '../TypeDefinition';
 
 type SceneProps = {
@@ -79,17 +78,6 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
     ).options.headerTruncatedBackTitle;
   }
 
-  _getBackButtonTitleStyle(scene: NavigationScene): ?Style {
-    const lastScene = this._getLastScene(scene);
-    const { headerBackTitleStyle } = this.props.getScreenDetails(scene).options;
-    if (!lastScene) {
-      return headerBackTitleStyle;
-    }
-    const { headerTitleStyle } = this.props.getScreenDetails(lastScene).options;
-
-    return [headerTitleStyle, headerBackTitleStyle];
-  }
-
   _renderTitleComponent = (props: SceneProps) => {
     const details = this.props.getScreenDetails(props.scene);
     const headerTitle = details.options.headerTitle;
@@ -136,7 +124,6 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
     const truncatedBackButtonTitle = this._getTruncatedBackButtonTitle(
       props.scene,
     );
-    const backButtonTitleStyle = this._getBackButtonTitleStyle(props.scene);
     const width = this.state.widths[props.scene.key]
       ? (this.props.layout.initWidth - this.state.widths[props.scene.key]) / 2
       : undefined;
@@ -149,7 +136,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
         tintColor={options.headerTintColor}
         title={backButtonTitle}
         truncatedTitle={truncatedBackButtonTitle}
-        titleStyle={backButtonTitleStyle}
+        titleStyle={options.headerBackTitleStyle}
         width={width}
       />
     );

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -15,6 +15,7 @@ import type {
   NavigationStyleInterpolator,
   LayoutEvent,
   HeaderProps,
+  Style,
 } from '../TypeDefinition';
 
 type SceneProps = {
@@ -78,6 +79,24 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
     ).options.headerTruncatedBackTitle;
   }
 
+  _getBackButtonTitleStyle(scene: NavigationScene): ?Style {
+    const lastScene = this._getLastScene(scene);
+    if (!lastScene) {
+      return null;
+    }
+    const {
+      headerBackTitleStyle,
+      headerBackTitle,
+      headerTitleStyle,
+    } = this.props.getScreenDetails(lastScene).options;
+
+    if (headerBackTitle === null) {
+      return null;
+    }
+
+    return headerBackTitleStyle || headerTitleStyle;
+  }
+
   _renderTitleComponent = (props: SceneProps) => {
     const details = this.props.getScreenDetails(props.scene);
     const headerTitle = details.options.headerTitle;
@@ -124,6 +143,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
     const truncatedBackButtonTitle = this._getTruncatedBackButtonTitle(
       props.scene,
     );
+    const backButtonTitleStyle = this._getBackButtonTitleStyle(props.scene);
     const width = this.state.widths[props.scene.key]
       ? (this.props.layout.initWidth - this.state.widths[props.scene.key]) / 2
       : undefined;
@@ -136,6 +156,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
         tintColor={options.headerTintColor}
         title={backButtonTitle}
         truncatedTitle={truncatedBackButtonTitle}
+        titleStyle={backButtonTitleStyle}
         width={width}
       />
     );

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -86,13 +86,8 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
     }
     const {
       headerBackTitleStyle,
-      headerBackTitle,
       headerTitleStyle,
     } = this.props.getScreenDetails(lastScene).options;
-
-    if (headerBackTitle === null) {
-      return null;
-    }
 
     return headerBackTitleStyle || headerTitleStyle;
   }

--- a/src/views/HeaderBackButton.js
+++ b/src/views/HeaderBackButton.js
@@ -10,7 +10,7 @@ import {
   StyleSheet,
 } from 'react-native';
 
-import type { LayoutEvent } from '../TypeDefinition';
+import type { LayoutEvent, Style } from '../TypeDefinition';
 
 import TouchableItem from './TouchableItem';
 
@@ -18,6 +18,7 @@ type Props = {
   onPress?: () => void,
   pressColorAndroid?: ?string,
   title?: ?string,
+  titleStyle?: ?Style,
   tintColor?: ?string,
   truncatedTitle?: ?string,
   width?: ?number,
@@ -59,6 +60,7 @@ class HeaderBackButton extends React.PureComponent<DefaultProps, Props, State> {
       pressColorAndroid,
       width,
       title,
+      titleStyle,
       tintColor,
       truncatedTitle,
     } = this.props;
@@ -92,7 +94,7 @@ class HeaderBackButton extends React.PureComponent<DefaultProps, Props, State> {
             title &&
             <Text
               onLayout={this._onTextLayout}
-              style={[styles.title, { color: tintColor }]}
+              style={[styles.title, { color: tintColor }, titleStyle]}
               numberOfLines={1}
             >
               {backButtonTitle}


### PR DESCRIPTION
I'm currently migrating an existing iOS app to React Native, where I use customized titles and back buttons.

The titles currently can be styled using `headerTitleStyle`, but for the back button there was no such option.

So this change adds a `headerBackTitleStyle` screen option, which makes it possible to set the style for the back button title ~, and when not set it inherits the `headerTitleStyle`~.

![](http://g.recordit.co/KMzy6JgM2c.gif)

**TODO**

- [x] Add documentation