### PR TITLE
export HeaderBackButton

### DIFF
--- a/src/react-navigation.js
+++ b/src/react-navigation.js
@@ -25,6 +25,7 @@ module.exports = {
   get CardStack() { return require('./views/CardStack').default; },
   get DrawerView() { return require('./views/Drawer/DrawerView').default; },
   get TabView() { return require('./views/TabView/TabView').default; },
+  get HeaderBackButton() { return require('./views/HeaderBackButton').default; },
 
   // HOCs
   get withNavigation() { return require('./views/withNavigation').default; },


### PR DESCRIPTION
Previously we can import header back button from CardStack via
`import { CardStack: { BackButton } } from 'react-navigation';`
After this [commit](https://github.com/react-community/react-navigation/commit/93976d358e27580e568ef016f820dc0253423aa7#diff-1bb911cc75b3e921fd5d4db86802c58cL123) , we no longer able to access the BackButton.
For now we can direct import the header back button via 
`import HeaderBackButton from 'react-navigation/src/views/HeaderBackButton';`
or better way is to export it in react-navigation index file (this pull request), then we can import it with
`import { HeaderBackButton } from 'react-navigation';`