### PR TITLE
Add a config to override the truncated back title

### DIFF
--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -107,6 +107,10 @@ String or React Element used by the header. Defaults to scene `title`
 
 Title string used by the back button on iOS or `null` to disable label. Defaults to scene `title`
 
+#### `headerTruncatedBackTitle`
+
+Title string used by the back button when `headerBackTitle` doesn't fit on the screen. `"Back"` by default.
+
 #### `headerRight`
 
 String or React Element to display on the right side of the header

--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -201,6 +201,7 @@ export type NavigationStackScreenOptions = NavigationScreenOptions & {
   headerTintColor?: string,
   headerLeft?: React.Element<*>,
   headerBackTitle?: string,
+  headerTruncatedBackTitle?: string,
   headerPressColorAndroid?: string,
   headerRight?: React.Element<*>,
   headerStyle?: Style,

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -123,6 +123,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
         pressColorAndroid={options.headerPressColorAndroid}
         tintColor={options.headerTintColor}
         title={backButtonTitle}
+        truncatedTitle={options.headerTruncatedBackTitle}
         width={width}
       />
     );


### PR DESCRIPTION
Fixes #1136.

Currently `truncatedTitle` is hard-coded to `"Back"` and there is no configuration option to override that default. Because apps can be translated to other languages than English, it's necessary to be able to replace the text with a localized string.

**Test plan (required)**

I tested the config by adding a translated  `headerTruncatedBackTitle` in the stack navigation example:
```diff
diff --git a/examples/NavigationPlayground/js/SimpleStack.js b/examples/NavigationPlayground/js/SimpleStack.js
index 3ab204f..d10648e 100644
--- a/examples/NavigationPlayground/js/SimpleStack.js
+++ b/examples/NavigationPlayground/js/SimpleStack.js
@@ -89,6 +89,10 @@ const SimpleStack = StackNavigator({
     path: 'photos/:name',
     screen: MyPhotosScreen,
   },
+}, {
+  navigationOptions: {
+    headerTruncatedBackTitle: 'Takaisin',
+  },
 });

 export default SimpleStack;
```
The back title was displayed correctly:
![simulator screen shot 20 apr 2017 15 15 32](https://cloud.githubusercontent.com/assets/497214/25230532/fdb553b8-25dc-11e7-9a59-292f3c00d089.png)
