### PR TITLE
Allow tabBarLabel to be also a function again

### DIFF
--- a/docs/api/navigators/TabNavigator.md
+++ b/docs/api/navigators/TabNavigator.md
@@ -164,7 +164,7 @@ React Element or a function that given `{ focused: boolean, tintColor: string }`
 
 #### `tabBarLabel`
 
-Title string of a tab displayed in the tab bar. When undefined, scene `title` is used. To hide, see `tabBarOptions.showLabel` in the previous section.
+Title string of a tab displayed in the tab bar or React Element or a function that given `{ focused: boolean, tintColor: string }` returns a React.Element, to display in tab bar. When undefined, scene `title` is used. To hide, see `tabBarOptions.showLabel` in the previous section.
 
 ### Navigator Props
 

--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -262,7 +262,8 @@ export type NavigationTabRouterConfig = {
 export type NavigationTabScreenOptions = NavigationScreenOptions & {
   tabBarIcon?: React.Element<*>
     | (options: { tintColor: ?string, focused: boolean }) => ?React.Element<*>,
-  tabBarLabel?: string,
+  tabBarLabel?: string | React.Element<*>
+    | (options: { tintColor: ?string, focused: boolean }) => ?React.Element<*>,
   tabBarVisible?: boolean,
 };
 

--- a/src/views/TabView/TabView.js
+++ b/src/views/TabView/TabView.js
@@ -102,7 +102,9 @@ class TabView extends PureComponent<void, Props, void> {
     );
 
     if (options.tabBarLabel) {
-      return options.tabBarLabel;
+      return typeof options.tabBarLabel === 'function'
+        ? options.tabBarLabel({ tintColor, focused })
+        : options.tabBarLabel;
     }
 
     if (typeof options.title === 'string') {


### PR DESCRIPTION
This fixes #1024

tabBarLabel used to have the same possibilities as tabBarIcon. Unfortunately in the latest updates that was lost. This returns the feature to allow Labels to change with tab focus.

example image should be possible again
<img width="380" alt="screen shot 2017-04-21 at 08 58 01" src="https://cloud.githubusercontent.com/assets/454376/25266232/c5889d80-2670-11e7-9364-54858ff1db29.png">
