### PR TITLE
Get truncated back button title from the previous scene

### DIFF
--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -59,8 +59,12 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
     return sceneOptions.title;
   }
 
+  _getLastScene(scene: NavigationScene): ?NavigationScene {
+    return this.props.scenes.find(s => s.index === scene.index - 1);
+  }
+
   _getBackButtonTitleString(scene: NavigationScene): ?string {
-    const lastScene = this.props.scenes.find(s => s.index === scene.index - 1);
+    const lastScene = this._getLastScene(scene);
     if (!lastScene) {
       return null;
     }
@@ -69,6 +73,14 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
       return headerBackTitle;
     }
     return this._getHeaderTitleString(lastScene);
+  }
+
+  _getTruncatedBackButtonTitle(scene: NavigationScene): ?string {
+    const lastScene = this._getLastScene(scene);
+    if (!lastScene) {
+      return null;
+    }
+    return this.props.getScreenDetails(lastScene).options.headerTruncatedBackTitle;
   }
 
   _renderTitleComponent = (props: SceneProps) => {
@@ -114,6 +126,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
       return null;
     }
     const backButtonTitle = this._getBackButtonTitleString(props.scene);
+    const truncatedBackButtonTitle = this._getTruncatedBackButtonTitle(props.scene);
     const width = this.state.widths[props.scene.key]
       ? (this.props.layout.initWidth - this.state.widths[props.scene.key]) / 2
       : undefined;
@@ -123,7 +136,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
         pressColorAndroid={options.headerPressColorAndroid}
         tintColor={options.headerTintColor}
         title={backButtonTitle}
-        truncatedTitle={options.headerTruncatedBackTitle}
+        truncatedTitle={truncatedBackButtonTitle}
         width={width}
       />
     );


### PR DESCRIPTION
Addresses https://github.com/react-community/react-navigation/pull/1137#discussion_r112804103.

Instead of the current screen, the truncated back button title needs to be looked up from the previous one, like we do for the back title.

**Test plan (required)**

Added the option to profile screen of the playground app to test:
```diff
diff --git a/examples/NavigationPlayground/js/SimpleStack.js b/examples/NavigationPlayground/js/SimpleStack.js
index 3ab204f..66ca498 100644
--- a/examples/NavigationPlayground/js/SimpleStack.js
+++ b/examples/NavigationPlayground/js/SimpleStack.js
@@ -66,6 +66,7 @@ MyProfileScreen.navigationOptions = props => {
   const {params} = state;
   return {
     headerTitle: `${params.name}'s Profile!`,
+    headerTruncatedBackTitle: 'Tillbaka',
     // Render a button on the right side of the header.
     // When pressed switches the screen to edit mode.
     headerRight: (
```

It showed up correctly:
![simulator screen shot 22 apr 2017 17 16 49](https://cloud.githubusercontent.com/assets/497214/25305322/e0b7781c-2781-11e7-9257-96c073f12f65.png)
