### PR TITLE
Update Redux guide

### DIFF
--- a/docs/guides/Redux-Integration.md
+++ b/docs/guides/Redux-Integration.md
@@ -19,10 +19,7 @@ const appReducer = combineReducers({
   ...
 });
 
-@connect(state => ({
-  nav: state.nav,
-}))
-class AppWithNavigationState extends React.Component {
+class App extends React.Component {
   render() {
     return (
       <AppNavigator navigation={addNavigationHelpers({
@@ -33,9 +30,15 @@ class AppWithNavigationState extends React.Component {
   }
 }
 
+const mapStateToProps = (state) => ({
+  nav: state.nav
+});
+
+const AppWithNavigationState = connect(mapStateToProps)(App);
+
 const store = createStore(appReducer);
 
-class App extends React.Component {
+class Root extends React.Component {
   render() {
     return (
       <Provider store={store}>


### PR DESCRIPTION
Fixes #1180

We shouldn't rely on a non-default babel transform, which is `decorator`s