### PR TITLE
Migrate 'website' and 'examples' to 'prop-types'

### DIFF
--- a/examples/NavigationPlayground/package.json
+++ b/examples/NavigationPlayground/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
+    "prop-types": "^15.5.8",
     "react": "16.0.0-alpha.6",
     "react-native": "^0.43.2",
     "react-native-vector-icons": "^4.0.1"

--- a/examples/ReduxExample/src/components/AuthButton.js
+++ b/examples/ReduxExample/src/components/AuthButton.js
@@ -1,7 +1,8 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { Button } from 'react-native';
 import { NavigationActions } from 'react-navigation';
+import PropTypes from 'prop-types';
 
 const AuthButton = ({ logout, login, isLoggedIn }) => (
   <Button

--- a/examples/ReduxExample/src/components/LoginScreen.js
+++ b/examples/ReduxExample/src/components/LoginScreen.js
@@ -1,10 +1,11 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
 import {
   Button,
   StyleSheet,
   Text,
   View,
 } from 'react-native';
+import PropTypes from 'prop-types';
 
 const styles = StyleSheet.create({
   container: {

--- a/examples/ReduxExample/src/components/LoginStatusMessage.js
+++ b/examples/ReduxExample/src/components/LoginStatusMessage.js
@@ -1,4 +1,4 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import {
   Button,
@@ -7,6 +7,7 @@ import {
   View,
 } from 'react-native';
 import { NavigationActions } from 'react-navigation';
+import PropTypes from 'prop-types';
 
 const styles = StyleSheet.create({
   welcome: {

--- a/examples/ReduxExample/src/navigators/AppNavigator.js
+++ b/examples/ReduxExample/src/navigators/AppNavigator.js
@@ -1,10 +1,11 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { addNavigationHelpers, StackNavigator } from 'react-navigation';
 
 import LoginScreen from '../components/LoginScreen';
 import MainScreen from '../components/MainScreen';
 import ProfileScreen from '../components/ProfileScreen';
+import PropTypes from 'prop-types';
 
 export const AppNavigator = StackNavigator({
   Login: { screen: LoginScreen },

--- a/src/views/SceneView.js
+++ b/src/views/SceneView.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import React, { PureComponent } from 'react';
-import propTypes from 'prop-types';
+import PropTypes from 'prop-types';
 
 import type {
   NavigationScreenProp,
@@ -19,7 +19,7 @@ type Props = {
 
 export default class SceneView extends PureComponent<void, Props, void> {
   static childContextTypes = {
-    navigation: propTypes.object.isRequired,
+    navigation: PropTypes.object.isRequired,
   };
 
   props: Props;

--- a/src/views/withNavigation.js
+++ b/src/views/withNavigation.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import React from 'react';
-import propTypes from 'prop-types';
+import PropTypes from 'prop-types';
 import hoistStatics from 'hoist-non-react-statics';
 
 import type {
@@ -27,7 +27,7 @@ export default function withNavigation<T: *>(Component: ReactClass<T & InjectedP
   componentWithNavigation.displayName = `withNavigation(${Component.displayName || Component.name})`;
 
   componentWithNavigation.contextTypes = {
-    navigation: propTypes.object.isRequired,
+    navigation: PropTypes.object.isRequired,
   };
 
   return hoistStatics(componentWithNavigation, Component);

--- a/website/package.json
+++ b/website/package.json
@@ -54,6 +54,7 @@
   "dependencies": {
     "@blueprintjs/core": "^1.0.1",
     "prismjs": "^1.6.0",
+    "prop-types": "^15.5.8",
     "react": "~15.3.2",
     "react-addons-css-transition-group": "~15.3.2",
     "react-dom": "~15.3.2",

--- a/website/src/BrowserAppContainer.js
+++ b/website/src/BrowserAppContainer.js
@@ -1,6 +1,6 @@
 
 import React from 'react';
-
+import PropTypes from 'prop-types';
 import { NavigationActions, addNavigationHelpers } from 'react-navigation';
 
 function getAction(router, path, params) {
@@ -83,9 +83,9 @@ module.exports = (NavigationAwareView) => {
       return NavigationAwareView.router.getActionForPathAndParams(path, params);
     }
     static childContextTypes = {
-      getActionForPathAndParams: React.PropTypes.func.isRequired,
-      getURIForAction: React.PropTypes.func.isRequired,
-      dispatch: React.PropTypes.func.isRequired,
+      getActionForPathAndParams: PropTypes.func.isRequired,
+      getURIForAction: PropTypes.func.isRequired,
+      dispatch: PropTypes.func.isRequired,
     };
     getChildContext() {
       return {

--- a/website/src/Link.js
+++ b/website/src/Link.js
@@ -1,5 +1,6 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
 import { NavigationActions } from 'react-navigation'
+import PropTypes from 'prop-types';
 
 const isModifiedEvent = (event) =>
   !!(event.metaKey || event.altKey || event.ctrlKey || event.shiftKey);

--- a/website/src/Server.js
+++ b/website/src/Server.js
@@ -7,6 +7,7 @@ const join = require('path').join;
 const basicAuth = require('basic-auth-connect');
 const server = require('express');
 const ReactDOMServer = require('react-dom/server');
+import PropTypes from 'prop-types';
 
 import App from './App';
 
@@ -14,9 +15,9 @@ import { NavigationActions, addNavigationHelpers } from 'react-navigation';
 
 class ServerApp extends React.Component {
   static childContextTypes = {
-    getURIForAction: React.PropTypes.func.isRequired,
-    getActionForPathAndParams: React.PropTypes.func.isRequired,
-    dispatch: React.PropTypes.func.isRequired,
+    getURIForAction: PropTypes.func.isRequired,
+    getActionForPathAndParams: PropTypes.func.isRequired,
+    dispatch: PropTypes.func.isRequired,
   };
   getChildContext() {
     return {


### PR DESCRIPTION
Implements [#1034](https://github.com/react-community/react-navigation/issues/1034)

Migrate website and examples to  prop-types