### PR TITLE
Remove navigationOptions from component props

### DIFF
--- a/src/createNavigationContainer.js
+++ b/src/createNavigationContainer.js
@@ -78,7 +78,6 @@ export default function createNavigationContainer<T: *>(
       const {
         navigation,
         screenProps,
-        navigationOptions,
         ...containerProps
       } = props;
 

--- a/src/views/CardStack.js
+++ b/src/views/CardStack.js
@@ -380,7 +380,6 @@ class CardStack extends Component {
               screenProps={screenProps}
               navigation={navigation}
               component={SceneComponent}
-              navigationOptions={options}
             />
           </View>
           {maybeHeader}
@@ -392,7 +391,6 @@ class CardStack extends Component {
         screenProps={this.props.screenProps}
         navigation={navigation}
         component={SceneComponent}
-        navigationOptions={options}
       />
     );
   }

--- a/src/views/Drawer/DrawerScreen.js
+++ b/src/views/Drawer/DrawerScreen.js
@@ -44,10 +44,6 @@ class DrawerScreen extends PureComponent<void, Props, void> {
         screenProps={screenProps}
         component={Content}
         navigation={childNavigation}
-        navigationOptions={router.getScreenOptions(
-          childNavigation,
-          screenProps,
-        )}
       />
     );
   }

--- a/src/views/SceneView.js
+++ b/src/views/SceneView.js
@@ -13,7 +13,6 @@ import type {
 type Props = {
   screenProps?: {},
   navigation: NavigationScreenProp<NavigationRoute, NavigationAction>,
-  navigationOptions: *,
   component: ReactClass<NavigationNavigatorProps<NavigationRoute>>,
 };
 
@@ -34,16 +33,9 @@ export default class SceneView extends PureComponent<void, Props, void> {
     const {
       screenProps,
       navigation,
-      navigationOptions,
       component: Component,
     } = this.props;
 
-    return (
-      <Component
-        screenProps={screenProps}
-        navigation={navigation}
-        navigationOptions={navigationOptions}
-      />
-    );
+    return <Component screenProps={screenProps} navigation={navigation} />;
   }
 }

--- a/src/views/TabView/TabView.js
+++ b/src/views/TabView/TabView.js
@@ -84,10 +84,6 @@ class TabView extends PureComponent<void, Props, void> {
         screenProps={screenProps}
         component={TabComponent}
         navigation={childNavigation}
-        navigationOptions={this.props.router.getScreenOptions(
-          childNavigation,
-          screenProps,
-        )}
       />
     );
   };


### PR DESCRIPTION
Fixes #1197 

Note: This was added in recent commit and caused some issues with the way components are re-rendered. It's removed as it was never actually documented and used.

If you stumble upon this PR / diff, please express your use-cases so we got better overview on how to implement that.