### PR TITLE
Modal gestureEnabled

### DIFF
--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -138,7 +138,7 @@ Color for material ripple (Android >= 5.0 only)
 
 #### `gesturesEnabled`
 
-Whether you can use gestures to dismiss this screen. Defaults to true on iOS, false on Android. This value when set is only respected in `mode` == `card`.
+Whether you can use gestures to dismiss this screen. Defaults to true on iOS, false on Android.
 
 ### Navigator Props
 

--- a/src/views/CardStack.js
+++ b/src/views/CardStack.js
@@ -81,8 +81,8 @@ const RESPOND_THRESHOLD = 12;
 /**
  * The distance of touch start from the edge of the screen where the gesture will be recognized
  */
-const GESTURE_RESPONSE_DISTANCE_SIDE = 35;
-const GESTURE_RESPONSE_DISTANCE_TOP = 135;
+const GESTURE_RESPONSE_DISTANCE_HORIZONTAL = 35;
+const GESTURE_RESPONSE_DISTANCE_VERTICAL = 135;
 
 const animatedSubscribeValue = (animatedValue: Animated.Value) => {
   if (!animatedValue.__isNative) {
@@ -267,8 +267,8 @@ class CardStack extends Component {
         const screenEdgeDistance = currentDragPosition - currentDragDistance;
         // Compare to the gesture distance relavant to card or modal
         const gestureResponseDistance = isVertical
-          ? GESTURE_RESPONSE_DISTANCE_TOP
-          : GESTURE_RESPONSE_DISTANCE_SIDE;
+          ? GESTURE_RESPONSE_DISTANCE_VERTICAL
+          : GESTURE_RESPONSE_DISTANCE_HORIZONTAL;
         // GESTURE_RESPONSE_DISTANCE is about 30 or 35. Or 135 for modals
         if (screenEdgeDistance > gestureResponseDistance) {
           // Reject touches that started in the middle of the screen

--- a/src/views/CardStack.js
+++ b/src/views/CardStack.js
@@ -81,7 +81,8 @@ const RESPOND_THRESHOLD = 12;
 /**
  * The distance of touch start from the edge of the screen where the gesture will be recognized
  */
-const GESTURE_RESPONSE_DISTANCE = 35;
+const GESTURE_RESPONSE_DISTANCE_SIDE = 35;
+const GESTURE_RESPONSE_DISTANCE_TOP = 135;
 
 const animatedSubscribeValue = (animatedValue: Animated.Value) => {
   if (!animatedValue.__isNative) {
@@ -249,7 +250,7 @@ class CardStack extends Component {
         if (index !== scene.index) {
           return false;
         }
-        const isVertical = false; // todo: bring back gestures for mode=modal
+        const isVertical = mode === 'modal'; // todo: bring back gestures for mode=modal
         const immediateIndex = this._immediateIndex == null
           ? index
           : this._immediateIndex;
@@ -264,8 +265,12 @@ class CardStack extends Component {
 
         // Measure the distance from the touch to the edge of the screen
         const screenEdgeDistance = currentDragPosition - currentDragDistance;
-        // GESTURE_RESPONSE_DISTANCE is about 30 or 35
-        if (screenEdgeDistance > GESTURE_RESPONSE_DISTANCE) {
+        // Compare to the gesture distance relavant to card or modal
+        const gestureResponseDistance = isVertical
+          ? GESTURE_RESPONSE_DISTANCE_TOP
+          : GESTURE_RESPONSE_DISTANCE_SIDE;
+        // GESTURE_RESPONSE_DISTANCE is about 30 or 35. Or 135 for modals
+        if (screenEdgeDistance > gestureResponseDistance) {
           // Reject touches that started in the middle of the screen
           return false;
         }
@@ -282,7 +287,7 @@ class CardStack extends Component {
       onPanResponderMove: (event: any, gesture: any) => {
         // Handle the moving touches for our granted responder
         const layout = this.props.layout;
-        const isVertical = false;
+        const isVertical = mode === 'modal';
         const startValue = this._gestureStartValue;
         const axis = isVertical ? 'dy' : 'dx';
         const distance = isVertical
@@ -303,7 +308,7 @@ class CardStack extends Component {
           return;
         }
         this._isResponding = false;
-        const isVertical = false;
+        const isVertical = mode === 'modal';
         const velocity = gesture[isVertical ? 'vy' : 'vx'];
         const immediateIndex = this._immediateIndex == null
           ? index
@@ -334,10 +339,9 @@ class CardStack extends Component {
     });
 
     const { options } = this._getScreenDetails(scene);
-    const gesturesEnabled = mode === 'card' &&
-      (typeof options.gesturesEnabled === 'boolean'
-        ? options.gesturesEnabled
-        : Platform.OS === 'ios');
+    const gesturesEnabled = typeof options.gesturesEnabled === 'boolean'
+      ? options.gesturesEnabled
+      : Platform.OS === 'ios';
 
     const handlers = gesturesEnabled ? responder.panHandlers : {};
 

--- a/src/views/CardStack.js
+++ b/src/views/CardStack.js
@@ -250,7 +250,7 @@ class CardStack extends Component {
         if (index !== scene.index) {
           return false;
         }
-        const isVertical = mode === 'modal'; // todo: bring back gestures for mode=modal
+        const isVertical = mode === 'modal';
         const immediateIndex = this._immediateIndex == null
           ? index
           : this._immediateIndex;


### PR DESCRIPTION
Fixes #902

Adding swipe down gesture back to modals.

Tested within our app on iOS and android.

Animations on android probably need some work but does the job. Card animation animates downwards.