### PR TITLE
Avoid back button label overlap

### DIFF
--- a/src/views/HeaderStyleInterpolator.js
+++ b/src/views/HeaderStyleInterpolator.js
@@ -20,8 +20,8 @@ function forLeft(props: NavigationSceneRendererProps): Object {
   const { index } = scene;
   return {
     opacity: position.interpolate({
-      inputRange: [index - 1, index, index + 1],
-      outputRange: ([0, 1, 0]: Array<number>),
+      inputRange: [index - 1, index - 0.5, index, index + 0.5, index + 1],
+      outputRange: ([0, 0, 1, 0, 0]: Array<number>),
     }),
   };
 }


### PR DESCRIPTION
This temporarily fixes back button titles that overlap each other. Ultimate fix is to provide animation from title to back button title.