### PR TITLE
	Add headerLeftOnPress to change the default behavior of the back button

### DIFF
--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -219,6 +219,7 @@ export type NavigationStackScreenOptions = NavigationScreenOptions & {
   headerTitleStyle?: Style,
   headerTintColor?: string,
   headerLeft?: React.Element<*>,
+  headerLeftOnPress?: () => void,
   headerBackTitle?: string,
   headerTruncatedBackTitle?: string,
   headerBackTitleStyle?: Style,

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -127,11 +127,12 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
     const width = this.state.widths[props.scene.key]
       ? (this.props.layout.initWidth - this.state.widths[props.scene.key]) / 2
       : undefined;
+    const onPress = () => {
+      this.props.navigation.goBack(null);
+    };
     return (
       <HeaderBackButton
-        onPress={() => {
-          this.props.navigation.goBack(null);
-        }}
+        onPress={options.headerLeftOnPress || onPress}
         pressColorAndroid={options.headerPressColorAndroid}
         tintColor={options.headerTintColor}
         title={backButtonTitle}


### PR DESCRIPTION
This PR adds the option `headerLeftOnPress` to `NavigationStackScreenOptions` to allow overwriting the onPress property without having to replace the whole component using `headerLeft`.