### PR TITLE
accept style prop on Header component

### DIFF
--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -14,6 +14,7 @@ export type HeaderProps = NavigationSceneRendererProps & {
   getScreenDetails: (
     NavigationScene,
   ) => NavigationScreenDetails<NavigationStackScreenOptions>,
+  style: Style,
 };
 
 /**

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -283,14 +283,15 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
       position,
       screenProps,
       progress,
+      style,
       ...rest
     } = this.props;
 
     const { options } = this.props.getScreenDetails(scene, screenProps);
-    const style = options.headerStyle;
+    const headerStyle = options.headerStyle;
 
     return (
-      <Animated.View {...rest} style={[styles.container, style]}>
+      <Animated.View {...rest} style={[styles.container, headerStyle, style]}>
         <View style={styles.appBar}>
           {appBar}
         </View>


### PR DESCRIPTION
To allow composition of the Header component when using a custom header
component, styling is probably one of the options you want to have.

For example, I need to dynamicly change the height of the header based
on scroll position, and without this change I have to inherit from the
Header component and copy the render function, instead of composing the
Header component in my own component.