### PR TITLE
Add "drawerOnPress" handler + demo "account picker"

### DIFF
--- a/docs/api/navigators/DrawerNavigator.md
+++ b/docs/api/navigators/DrawerNavigator.md
@@ -163,6 +163,11 @@ String, React Element or a function that given `{ focused: boolean, tintColor: s
 
 React Element or a function, that given `{ focused: boolean, tintColor: string }` returns a React.Element, to display in drawer sidebar
 
+#### `drawerOnPress`
+
+Callback to handle tap events. Typical behavior would be to call `navigation.navigate('DrawerClose')` after performing your other logic.
+If explicitly set to `null`, there will be no touch feedback for this drawer item; this can be used e.g. for header items / section separators.
+
 ### Navigator Props
 
 The navigator component created by `DrawerNavigator(...)` takes the following props:

--- a/docs/api/navigators/DrawerNavigator.md
+++ b/docs/api/navigators/DrawerNavigator.md
@@ -131,6 +131,7 @@ const styles = StyleSheet.create({
 ### `contentOptions` for `DrawerItems`
 
 - `items` - an array of routes to use in place of `navigation.state.routes`
+- `itemComponent` - a component to use in place of `DrawerNavigatorItem` for each item
 - `activeTintColor` - label and icon color of the active label
 - `activeBackgroundColor` - background color of the active label
 - `inactiveTintColor` - label and icon color of the inactive label

--- a/docs/api/navigators/DrawerNavigator.md
+++ b/docs/api/navigators/DrawerNavigator.md
@@ -130,6 +130,7 @@ const styles = StyleSheet.create({
 
 ### `contentOptions` for `DrawerItems`
 
+- `items` - an array of routes to use in place of `navigation.state.routes`
 - `activeTintColor` - label and icon color of the active label
 - `activeBackgroundColor` - background color of the active label
 - `inactiveTintColor` - label and icon color of the inactive label

--- a/examples/NavigationPlayground/js/Drawer.js
+++ b/examples/NavigationPlayground/js/Drawer.js
@@ -145,7 +145,7 @@ const DrawerExample = DrawerNavigator(drawerRoutes, {
   contentOptions: {
     activeTintColor: '#e91e63',
     items: drawerItems,
-    drawerItemComponent: CustomDrawerItem,
+    itemComponent: CustomDrawerItem,
   },
 });
 

--- a/examples/NavigationPlayground/js/Drawer.js
+++ b/examples/NavigationPlayground/js/Drawer.js
@@ -4,14 +4,15 @@
 
 import React from 'react';
 import {
+  View,
   Button,
   Platform,
   ScrollView,
   StyleSheet,
-  Text,
 } from 'react-native';
 import {
   DrawerNavigator,
+  DrawerItems,
   DrawerItem,
 } from 'react-navigation';
 import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
@@ -66,29 +67,48 @@ DraftsScreen.navigationOptions = {
 };
 
 const CustomDrawerItem = (props) => {
-  const { route: item } = props;
-
-  // Simply render the default component if the item is a route.
-  if (item.routeName) {
-    return (
-      <DrawerItem {...props} />
-    );
-  }
+  const { item, focused, activeTintColor, inactiveTintColor } = props;
+  const tintColor = focused ? activeTintColor : inactiveTintColor;
 
   const screenOptions = typeof item.screenOptions === 'function'
     ? item.screenOptions(props)
     : item.screenOptions;
+  const { drawerIcon, drawerLabel, drawerOnPress } = screenOptions;
 
-  const { drawerIcon, drawerLabel } = screenOptions;
-
-  // If it's not a route, override a few of the props to make it render nicely.
   return (
     <DrawerItem
       {...props}
-      renderIcon={(iconProps) => drawerIcon ? drawerIcon(iconProps) : null}
-      getLabel={() => drawerLabel}
-      getScreenOptions={() => screenOptions}
+      focused={false}
+      icon={drawerIcon ? drawerIcon({ tintColor }) : null}
+      label={drawerLabel}
+      onPress={drawerOnPress}
     />
+  );
+};
+
+const CustomDrawerItems = (props) => {
+  const { items } = props;
+
+  return (
+    <View style={[styles.drawerContainer]}>
+      {items.map((item) => {
+        const { routeName, key } = item;
+
+        // Simply render the default component if the item is a route.
+        if (routeName) {
+          return (
+            <DrawerItems
+              {...props}
+              key={key}
+              items={[item]}
+              style={styles.drawerContainerInner}
+            />
+          );
+        }
+
+        return <CustomDrawerItem {...props} key={key} item={item} />;
+      })}
+    </View>
   );
 };
 
@@ -145,13 +165,21 @@ const DrawerExample = DrawerNavigator(drawerRoutes, {
   contentOptions: {
     activeTintColor: '#e91e63',
     items: drawerItems,
-    itemComponent: CustomDrawerItem,
   },
+  contentComponent: CustomDrawerItems,
 });
 
 const styles = StyleSheet.create({
   container: {
     marginTop: Platform.OS === 'ios' ? 20 : 0,
+  },
+  drawerContainer: {
+    marginTop: Platform.OS === 'ios' ? 20 : 0,
+    paddingVertical: 4,
+  },
+  drawerContainerInner: {
+    marginTop: 0,
+    paddingVertical: 0,
   },
 });
 

--- a/examples/NavigationPlayground/js/Drawer.js
+++ b/examples/NavigationPlayground/js/Drawer.js
@@ -87,7 +87,7 @@ RefreshButton.navigationOptions = ({ navigation }) => ({
 const MailboxesLabel = () => null;
 MailboxesLabel.navigationOptions = {
   drawerLabel: 'Mailboxes',
-  drawerOnPress: () => {},
+  drawerOnPress: null,
 };
 
 const DrawerExample = DrawerNavigator({

--- a/examples/NavigationPlayground/js/Drawer.js
+++ b/examples/NavigationPlayground/js/Drawer.js
@@ -64,7 +64,39 @@ DraftsScreen.navigationOptions = {
   ),
 };
 
+const RefreshButton = () => null;
+RefreshButton.navigationOptions = ({ navigation }) => ({
+  drawerLabel: navigation.state.params.isRefreshing ? 'Refreshing...' : 'Refresh',
+  drawerIcon: ({ tintColor }) => (
+    <MaterialIcons
+      name="refresh"
+      size={24}
+      style={{ color: tintColor }}
+    />
+  ),
+  drawerOnPress: () => {
+    navigation.setParams({ isRefreshing: true });
+
+    // Finish refreshing after a short delay.
+    setTimeout(() => {
+      navigation.setParams({ isRefreshing: false });
+    }, 500);
+  },
+});
+
+const MailboxesLabel = () => null;
+MailboxesLabel.navigationOptions = {
+  drawerLabel: 'Mailboxes',
+  drawerOnPress: () => {},
+};
+
 const DrawerExample = DrawerNavigator({
+  RefreshButton: {
+    screen: RefreshButton,
+  },
+  MailboxesLabel: {
+    screen: MailboxesLabel,
+  },
   Inbox: {
     path: '/',
     screen: InboxScreen,

--- a/src/react-navigation.js
+++ b/src/react-navigation.js
@@ -70,6 +70,9 @@ module.exports = {
   get DrawerItems() {
     return require('./views/Drawer/DrawerNavigatorItems').default;
   },
+  get DrawerItem() {
+    return require('./views/Drawer/DrawerNavigatorItem').default;
+  },
 
   // TabView
   get TabView() {

--- a/src/views/Drawer/DrawerNavigatorItem.js
+++ b/src/views/Drawer/DrawerNavigatorItem.js
@@ -15,6 +15,7 @@ import type {
 import type { DrawerScene } from './DrawerView.js';
 
 type Props = {
+  index: number,
   navigation: NavigationScreenProp<NavigationState, NavigationAction>,
   route: NavigationRoute,
   activeTintColor?: string,
@@ -23,6 +24,7 @@ type Props = {
   inactiveBackgroundColor?: string,
   getLabel: (scene: DrawerScene) => ?(React.Element<*> | string),
   renderIcon: (scene: DrawerScene) => ?React.Element<*>,
+  getScreenOptions: (routeKey: string) => { drawerOnPress?: () => void },
   getDrawerOnPress: (scene: DrawerScene) => ?() => void,
   labelStyle?: Style,
 };
@@ -32,6 +34,7 @@ type Props = {
  */
 const DrawerNavigatorItem = (
   {
+    index,
     navigation: {
       state,
       navigate,
@@ -53,7 +56,7 @@ const DrawerNavigatorItem = (
   const backgroundColor = focused
     ? activeBackgroundColor
     : inactiveBackgroundColor;
-  const scene = { route, focused, tintColor: color };
+  const scene = { route, focused, index, tintColor: color };
   const icon = renderIcon(scene);
   const label = getLabel(scene);
 

--- a/src/views/Drawer/DrawerNavigatorItem.js
+++ b/src/views/Drawer/DrawerNavigatorItem.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import React from 'react';
-import { View, Text, Platform, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet } from 'react-native';
 
 import TouchableItem from '../TouchableItem';
 
@@ -16,7 +16,7 @@ import type { DrawerScene } from './DrawerView.js';
 
 type Props = {
   navigation: NavigationScreenProp<NavigationState, NavigationAction>,
-  items?: Array<NavigationRoute>,
+  route: NavigationRoute,
   activeTintColor?: string,
   activeBackgroundColor?: string,
   inactiveTintColor?: string,
@@ -24,20 +24,19 @@ type Props = {
   getLabel: (scene: DrawerScene) => ?(React.Element<*> | string),
   renderIcon: (scene: DrawerScene) => ?React.Element<*>,
   getDrawerOnPress: (scene: DrawerScene) => ?() => void,
-  style?: Style,
   labelStyle?: Style,
 };
 
 /**
- * Component that renders the navigation list in the drawer.
+ * Component for each item in the drawer.
  */
-const DrawerNavigatorItems = (
+const DrawerNavigatorItem = (
   {
     navigation: {
       state,
       navigate,
     },
-    items,
+    route,
     activeTintColor,
     activeBackgroundColor,
     inactiveTintColor,
@@ -45,67 +44,57 @@ const DrawerNavigatorItems = (
     getLabel,
     renderIcon,
     getScreenOptions,
-    style,
     labelStyle,
   }: Props,
-) => (
-  <View style={[styles.container, style]}>
-    {(items || state.routes).map((route: NavigationRoute, index: number) => {
-      const { drawerOnPress } = getScreenOptions(route.key);
-      const focused = state.routes[state.index].key === route.key;
-      const color = focused ? activeTintColor : inactiveTintColor;
-      const backgroundColor = focused
-        ? activeBackgroundColor
-        : inactiveBackgroundColor;
-      const scene = { route, index, focused, tintColor: color };
-      const icon = renderIcon(scene);
-      const label = getLabel(scene);
+) => {
+  const { drawerOnPress } = getScreenOptions(route.key);
+  const focused = state.routes[state.index].key === route.key;
+  const color = focused ? activeTintColor : inactiveTintColor;
+  const backgroundColor = focused
+    ? activeBackgroundColor
+    : inactiveBackgroundColor;
+  const scene = { route, focused, tintColor: color };
+  const icon = renderIcon(scene);
+  const label = getLabel(scene);
 
-      const drawerItem = (
-        <View style={[styles.item, { backgroundColor }]}>
-          {icon
-            ? <View style={[styles.icon, focused ? null : styles.inactiveIcon]}>
-              {icon}
-            </View>
-            : null}
-          {typeof label === 'string'
-            ? <Text style={[styles.label, { color }, labelStyle]}>
-              {label}
-            </Text>
-            : label}
-        </View>
-      );
-
-      if (drawerOnPress === null) {
-        return (
-          <View key={route.key}>
-            {drawerItem}
+  const drawerItem = (
+    <View style={[styles.item, { backgroundColor }]}>
+      {icon
+        ? <View style={[styles.icon, focused ? null : styles.inactiveIcon]}>
+            {icon}
           </View>
-        );
-      }
+        : null}
+      {typeof label === 'string'
+        ? <Text style={[styles.label, { color }, labelStyle]}>
+            {label}
+          </Text>
+        : label}
+    </View>
+  );
 
-      return (
-        <TouchableItem
-          key={route.key}
-          onPress={
-            drawerOnPress
-              ? () => drawerOnPress()
-              : () => {
+  if (drawerOnPress === null) {
+    return drawerItem;
+  }
+
+  return (
+    <TouchableItem
+      onPress={
+        drawerOnPress
+          ? () => drawerOnPress()
+          : () => {
               navigate('DrawerClose');
               navigate(route.routeName);
             }
-          }
-          delayPressIn={0}
-        >
-          {drawerItem}
-        </TouchableItem>
-      );
-    })}
-  </View>
-);
+      }
+      delayPressIn={0}
+    >
+      {drawerItem}
+    </TouchableItem>
+  );
+};
 
 /* Material design specs - https://material.io/guidelines/patterns/navigation-drawer.html#navigation-drawer-specs */
-DrawerNavigatorItems.defaultProps = {
+DrawerNavigatorItem.defaultProps = {
   activeTintColor: '#2196f3',
   activeBackgroundColor: 'rgba(0, 0, 0, .04)',
   inactiveTintColor: 'rgba(0, 0, 0, .87)',
@@ -113,10 +102,6 @@ DrawerNavigatorItems.defaultProps = {
 };
 
 const styles = StyleSheet.create({
-  container: {
-    marginTop: Platform.OS === 'ios' ? 20 : 0,
-    paddingVertical: 4,
-  },
   item: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -139,4 +124,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default DrawerNavigatorItems;
+export default DrawerNavigatorItem;

--- a/src/views/Drawer/DrawerNavigatorItem.js
+++ b/src/views/Drawer/DrawerNavigatorItem.js
@@ -1,0 +1,142 @@
+/* @flow */
+
+import React from 'react';
+import { View, Text, Platform, StyleSheet } from 'react-native';
+
+import TouchableItem from '../TouchableItem';
+
+import type {
+  NavigationScreenProp,
+  NavigationState,
+  NavigationAction,
+  NavigationRoute,
+  Style,
+} from '../../TypeDefinition';
+import type { DrawerScene } from './DrawerView.js';
+
+type Props = {
+  navigation: NavigationScreenProp<NavigationState, NavigationAction>,
+  items?: Array<NavigationRoute>,
+  activeTintColor?: string,
+  activeBackgroundColor?: string,
+  inactiveTintColor?: string,
+  inactiveBackgroundColor?: string,
+  getLabel: (scene: DrawerScene) => ?(React.Element<*> | string),
+  renderIcon: (scene: DrawerScene) => ?React.Element<*>,
+  getDrawerOnPress: (scene: DrawerScene) => ?() => void,
+  style?: Style,
+  labelStyle?: Style,
+};
+
+/**
+ * Component that renders the navigation list in the drawer.
+ */
+const DrawerNavigatorItems = (
+  {
+    navigation: {
+      state,
+      navigate,
+    },
+    items,
+    activeTintColor,
+    activeBackgroundColor,
+    inactiveTintColor,
+    inactiveBackgroundColor,
+    getLabel,
+    renderIcon,
+    getScreenOptions,
+    style,
+    labelStyle,
+  }: Props,
+) => (
+  <View style={[styles.container, style]}>
+    {(items || state.routes).map((route: NavigationRoute, index: number) => {
+      const { drawerOnPress } = getScreenOptions(route.key);
+      const focused = state.routes[state.index].key === route.key;
+      const color = focused ? activeTintColor : inactiveTintColor;
+      const backgroundColor = focused
+        ? activeBackgroundColor
+        : inactiveBackgroundColor;
+      const scene = { route, index, focused, tintColor: color };
+      const icon = renderIcon(scene);
+      const label = getLabel(scene);
+
+      const drawerItem = (
+        <View style={[styles.item, { backgroundColor }]}>
+          {icon
+            ? <View style={[styles.icon, focused ? null : styles.inactiveIcon]}>
+              {icon}
+            </View>
+            : null}
+          {typeof label === 'string'
+            ? <Text style={[styles.label, { color }, labelStyle]}>
+              {label}
+            </Text>
+            : label}
+        </View>
+      );
+
+      if (drawerOnPress === null) {
+        return (
+          <View key={route.key}>
+            {drawerItem}
+          </View>
+        );
+      }
+
+      return (
+        <TouchableItem
+          key={route.key}
+          onPress={
+            drawerOnPress
+              ? () => drawerOnPress()
+              : () => {
+              navigate('DrawerClose');
+              navigate(route.routeName);
+            }
+          }
+          delayPressIn={0}
+        >
+          {drawerItem}
+        </TouchableItem>
+      );
+    })}
+  </View>
+);
+
+/* Material design specs - https://material.io/guidelines/patterns/navigation-drawer.html#navigation-drawer-specs */
+DrawerNavigatorItems.defaultProps = {
+  activeTintColor: '#2196f3',
+  activeBackgroundColor: 'rgba(0, 0, 0, .04)',
+  inactiveTintColor: 'rgba(0, 0, 0, .87)',
+  inactiveBackgroundColor: 'transparent',
+};
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: Platform.OS === 'ios' ? 20 : 0,
+    paddingVertical: 4,
+  },
+  item: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  icon: {
+    marginHorizontal: 16,
+    width: 24,
+    alignItems: 'center',
+  },
+  inactiveIcon: {
+    /*
+     * Icons have 0.54 opacity according to guidelines
+     * 100/87 * 54 ~= 62
+     */
+    opacity: 0.62,
+  },
+  label: {
+    margin: 16,
+    fontWeight: 'bold',
+  },
+});
+
+export default DrawerNavigatorItems;

--- a/src/views/Drawer/DrawerNavigatorItem.js
+++ b/src/views/Drawer/DrawerNavigatorItem.js
@@ -5,28 +5,18 @@ import { View, Text, StyleSheet } from 'react-native';
 
 import TouchableItem from '../TouchableItem';
 
-import type {
-  NavigationScreenProp,
-  NavigationState,
-  NavigationAction,
-  NavigationRoute,
-  Style,
-} from '../../TypeDefinition';
-import type { DrawerScene } from './DrawerView.js';
+import type { Style } from '../../TypeDefinition';
 
 type Props = {
-  index: number,
-  navigation: NavigationScreenProp<NavigationState, NavigationAction>,
-  route: NavigationRoute,
   activeTintColor?: string,
   activeBackgroundColor?: string,
   inactiveTintColor?: string,
   inactiveBackgroundColor?: string,
-  getLabel: (scene: DrawerScene) => ?(React.Element<*> | string),
-  renderIcon: (scene: DrawerScene) => ?React.Element<*>,
-  getScreenOptions: (routeKey: string) => { drawerOnPress?: () => void },
-  getDrawerOnPress: (scene: DrawerScene) => ?() => void,
   labelStyle?: Style,
+  focused?: string,
+  icon?: React.Element<*>,
+  label?: React.Element<*> | string,
+  onPress?: () => void,
 };
 
 /**
@@ -34,31 +24,21 @@ type Props = {
  */
 const DrawerNavigatorItem = (
   {
-    index,
-    navigation: {
-      state,
-      navigate,
-    },
-    route,
     activeTintColor,
     activeBackgroundColor,
     inactiveTintColor,
     inactiveBackgroundColor,
-    getLabel,
-    renderIcon,
-    getScreenOptions,
     labelStyle,
+    focused,
+    icon,
+    label,
+    onPress,
   }: Props,
 ) => {
-  const { drawerOnPress } = getScreenOptions(route.key);
-  const focused = state.routes[state.index].key === route.key;
-  const color = focused ? activeTintColor : inactiveTintColor;
+  const tintColor = focused ? activeTintColor : inactiveTintColor;
   const backgroundColor = focused
     ? activeBackgroundColor
     : inactiveBackgroundColor;
-  const scene = { route, focused, index, tintColor: color };
-  const icon = renderIcon(scene);
-  const label = getLabel(scene);
 
   const drawerItem = (
     <View style={[styles.item, { backgroundColor }]}>
@@ -68,29 +48,19 @@ const DrawerNavigatorItem = (
           </View>
         : null}
       {typeof label === 'string'
-        ? <Text style={[styles.label, { color }, labelStyle]}>
+        ? <Text style={[styles.label, { color: tintColor }, labelStyle]}>
             {label}
           </Text>
         : label}
     </View>
   );
 
-  if (drawerOnPress === null) {
+  if (!onPress) {
     return drawerItem;
   }
 
   return (
-    <TouchableItem
-      onPress={
-        drawerOnPress
-          ? () => drawerOnPress()
-          : () => {
-              navigate('DrawerClose');
-              navigate(route.routeName);
-            }
-      }
-      delayPressIn={0}
-    >
+    <TouchableItem onPress={onPress} delayPressIn={0}>
       {drawerItem}
     </TouchableItem>
   );

--- a/src/views/Drawer/DrawerNavigatorItems.js
+++ b/src/views/Drawer/DrawerNavigatorItems.js
@@ -1,9 +1,9 @@
 /* @flow */
 
 import React from 'react';
-import { View, Text, Platform, StyleSheet } from 'react-native';
+import { View, Platform, StyleSheet } from 'react-native';
 
-import TouchableItem from '../TouchableItem';
+import DrawerNavigatorItem from './DrawerNavigatorItem';
 
 import type {
   NavigationScreenProp,
@@ -12,20 +12,11 @@ import type {
   NavigationRoute,
   Style,
 } from '../../TypeDefinition';
-import type { DrawerScene } from './DrawerView.js';
 
 type Props = {
   navigation: NavigationScreenProp<NavigationState, NavigationAction>,
   items?: Array<NavigationRoute>,
-  activeTintColor?: string,
-  activeBackgroundColor?: string,
-  inactiveTintColor?: string,
-  inactiveBackgroundColor?: string,
-  getLabel: (scene: DrawerScene) => ?(React.Element<*> | string),
-  renderIcon: (scene: DrawerScene) => ?React.Element<*>,
-  getDrawerOnPress: (scene: DrawerScene) => ?() => void,
   style?: Style,
-  labelStyle?: Style,
 };
 
 /**
@@ -33,109 +24,34 @@ type Props = {
  */
 const DrawerNavigatorItems = (
   {
-    navigation: {
-      state,
-      navigate,
-    },
+    navigation,
     items,
-    activeTintColor,
-    activeBackgroundColor,
-    inactiveTintColor,
-    inactiveBackgroundColor,
-    getLabel,
-    renderIcon,
-    getScreenOptions,
     style,
-    labelStyle,
+    drawerItemComponent: DrawerItemComponent,
+    ...drawerItemProps
   }: Props,
 ) => (
   <View style={[styles.container, style]}>
-    {(items || state.routes).map((route: NavigationRoute, index: number) => {
-      const { drawerOnPress } = getScreenOptions(route.key);
-      const focused = state.routes[state.index].key === route.key;
-      const color = focused ? activeTintColor : inactiveTintColor;
-      const backgroundColor = focused
-        ? activeBackgroundColor
-        : inactiveBackgroundColor;
-      const scene = { route, index, focused, tintColor: color };
-      const icon = renderIcon(scene);
-      const label = getLabel(scene);
-
-      const drawerItem = (
-        <View style={[styles.item, { backgroundColor }]}>
-          {icon
-            ? <View style={[styles.icon, focused ? null : styles.inactiveIcon]}>
-                {icon}
-              </View>
-            : null}
-          {typeof label === 'string'
-            ? <Text style={[styles.label, { color }, labelStyle]}>
-                {label}
-              </Text>
-            : label}
-        </View>
-      );
-
-      if (drawerOnPress === null) {
-        return (
-          <View key={route.key}>
-            {drawerItem}
-          </View>
-        );
-      }
-
-      return (
-        <TouchableItem
+    {(items || navigation.state.routes)
+      .map((route: NavigationRoute) => (
+        <DrawerItemComponent
+          {...drawerItemProps}
           key={route.key}
-          onPress={
-            drawerOnPress
-              ? () => drawerOnPress()
-              : () => {
-                  navigate('DrawerClose');
-                  navigate(route.routeName);
-                }
-          }
-          delayPressIn={0}
-        >
-          {drawerItem}
-        </TouchableItem>
-      );
-    })}
+          navigation={navigation}
+          route={route}
+        />
+      ))}
   </View>
 );
 
-/* Material design specs - https://material.io/guidelines/patterns/navigation-drawer.html#navigation-drawer-specs */
 DrawerNavigatorItems.defaultProps = {
-  activeTintColor: '#2196f3',
-  activeBackgroundColor: 'rgba(0, 0, 0, .04)',
-  inactiveTintColor: 'rgba(0, 0, 0, .87)',
-  inactiveBackgroundColor: 'transparent',
+  drawerItemComponent: DrawerNavigatorItem,
 };
 
 const styles = StyleSheet.create({
   container: {
     marginTop: Platform.OS === 'ios' ? 20 : 0,
     paddingVertical: 4,
-  },
-  item: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  icon: {
-    marginHorizontal: 16,
-    width: 24,
-    alignItems: 'center',
-  },
-  inactiveIcon: {
-    /*
-     * Icons have 0.54 opacity according to guidelines
-     * 100/87 * 54 ~= 62
-     */
-    opacity: 0.62,
-  },
-  label: {
-    margin: 16,
-    fontWeight: 'bold',
   },
 });
 

--- a/src/views/Drawer/DrawerNavigatorItems.js
+++ b/src/views/Drawer/DrawerNavigatorItems.js
@@ -61,6 +61,29 @@ const DrawerNavigatorItems = (
       const icon = renderIcon(scene);
       const label = getLabel(scene);
 
+      const drawerItem = (
+        <View style={[styles.item, { backgroundColor }]}>
+          {icon
+            ? <View style={[styles.icon, focused ? null : styles.inactiveIcon]}>
+                {icon}
+              </View>
+            : null}
+          {typeof label === 'string'
+            ? <Text style={[styles.label, { color }, labelStyle]}>
+                {label}
+              </Text>
+            : label}
+        </View>
+      );
+
+      if (drawerOnPress === null) {
+        return (
+          <View key={route.key}>
+            {drawerItem}
+          </View>
+        );
+      }
+
       return (
         <TouchableItem
           key={route.key}
@@ -74,20 +97,7 @@ const DrawerNavigatorItems = (
           }
           delayPressIn={0}
         >
-          <View style={[styles.item, { backgroundColor }]}>
-            {icon
-              ? <View
-                  style={[styles.icon, focused ? null : styles.inactiveIcon]}
-                >
-                  {icon}
-                </View>
-              : null}
-            {typeof label === 'string'
-              ? <Text style={[styles.label, { color }, labelStyle]}>
-                  {label}
-                </Text>
-              : label}
-          </View>
+          {drawerItem}
         </TouchableItem>
       );
     })}

--- a/src/views/Drawer/DrawerNavigatorItems.js
+++ b/src/views/Drawer/DrawerNavigatorItems.js
@@ -16,6 +16,7 @@ import type {
 type Props = {
   navigation: NavigationScreenProp<NavigationState, NavigationAction>,
   items?: Array<NavigationRoute>,
+  itemComponent: ReactClass<*>,
   style?: Style,
 };
 
@@ -26,17 +27,18 @@ const DrawerNavigatorItems = (
   {
     navigation,
     items,
+    itemComponent: ItemComponent,
     style,
-    drawerItemComponent: DrawerItemComponent,
     ...drawerItemProps
   }: Props,
 ) => (
   <View style={[styles.container, style]}>
     {(items || navigation.state.routes)
-      .map((route: NavigationRoute) => (
-        <DrawerItemComponent
+      .map((route: NavigationRoute, index: number) => (
+        <ItemComponent
           {...drawerItemProps}
           key={route.key}
+          index={index}
           navigation={navigation}
           route={route}
         />
@@ -45,7 +47,7 @@ const DrawerNavigatorItems = (
 );
 
 DrawerNavigatorItems.defaultProps = {
-  drawerItemComponent: DrawerNavigatorItem,
+  itemComponent: DrawerNavigatorItem,
 };
 
 const styles = StyleSheet.create({

--- a/src/views/Drawer/DrawerNavigatorItems.js
+++ b/src/views/Drawer/DrawerNavigatorItems.js
@@ -23,6 +23,7 @@ type Props = {
   inactiveBackgroundColor?: string,
   getLabel: (scene: DrawerScene) => ?(React.Element<*> | string),
   renderIcon: (scene: DrawerScene) => ?React.Element<*>,
+  getDrawerOnPress: (scene: DrawerScene) => ?() => void,
   style?: Style,
   labelStyle?: Style,
 };
@@ -43,12 +44,14 @@ const DrawerNavigatorItems = (
     inactiveBackgroundColor,
     getLabel,
     renderIcon,
+    getScreenOptions,
     style,
     labelStyle,
   }: Props,
 ) => (
   <View style={[styles.container, style]}>
     {(items || state.routes).map((route: NavigationRoute, index: number) => {
+      const { drawerOnPress } = getScreenOptions(route.key);
       const focused = state.routes[state.index].key === route.key;
       const color = focused ? activeTintColor : inactiveTintColor;
       const backgroundColor = focused
@@ -57,13 +60,18 @@ const DrawerNavigatorItems = (
       const scene = { route, index, focused, tintColor: color };
       const icon = renderIcon(scene);
       const label = getLabel(scene);
+
       return (
         <TouchableItem
           key={route.key}
-          onPress={() => {
-            navigate('DrawerClose');
-            navigate(route.routeName);
-          }}
+          onPress={
+            drawerOnPress
+              ? () => drawerOnPress()
+              : () => {
+                  navigate('DrawerClose');
+                  navigate(route.routeName);
+                }
+          }
           delayPressIn={0}
         >
           <View style={[styles.item, { backgroundColor }]}>

--- a/src/views/Drawer/DrawerNavigatorItems.js
+++ b/src/views/Drawer/DrawerNavigatorItems.js
@@ -9,12 +9,14 @@ import type {
   NavigationScreenProp,
   NavigationState,
   NavigationAction,
+  NavigationRoute,
   Style,
 } from '../../TypeDefinition';
 import type { DrawerScene } from './DrawerView.js';
 
 type Props = {
   navigation: NavigationScreenProp<NavigationState, NavigationAction>,
+  items?: Array<NavigationRoute>,
   activeTintColor?: string,
   activeBackgroundColor?: string,
   inactiveTintColor?: string,
@@ -30,7 +32,11 @@ type Props = {
  */
 const DrawerNavigatorItems = (
   {
-    navigation,
+    navigation: {
+      state,
+      navigate,
+    },
+    items,
     activeTintColor,
     activeBackgroundColor,
     inactiveTintColor,
@@ -42,8 +48,8 @@ const DrawerNavigatorItems = (
   }: Props,
 ) => (
   <View style={[styles.container, style]}>
-    {navigation.state.routes.map((route: *, index: number) => {
-      const focused = navigation.state.index === index;
+    {(items || state.routes).map((route: NavigationRoute, index: number) => {
+      const focused = state.routes[state.index].key === route.key;
       const color = focused ? activeTintColor : inactiveTintColor;
       const backgroundColor = focused
         ? activeBackgroundColor
@@ -55,8 +61,8 @@ const DrawerNavigatorItems = (
         <TouchableItem
           key={route.key}
           onPress={() => {
-            navigation.navigate('DrawerClose');
-            navigation.navigate(route.routeName);
+            navigate('DrawerClose');
+            navigate(route.routeName);
           }}
           delayPressIn={0}
         >

--- a/src/views/Drawer/DrawerSidebar.js
+++ b/src/views/Drawer/DrawerSidebar.js
@@ -77,6 +77,8 @@ class DrawerSidebar extends PureComponent<void, Props, void> {
         <ContentComponent
           {...this.props.contentOptions}
           navigation={this.props.navigation}
+          screenProps={this.props.screenProps}
+          getScreenOptions={this._getScreenOptions}
           getLabel={this._getLabel}
           renderIcon={this._renderIcon}
           router={this.props.router}


### PR DESCRIPTION
### Motivation

So we can do things like this:

![sign in demo](https://cloud.githubusercontent.com/assets/2047062/25639067/8e754924-2f58-11e7-8f88-3fc149a9b69e.gif)

And this:

![refresh button demo](https://cloud.githubusercontent.com/assets/2047062/25567520/66fe00a8-2dbd-11e7-80a9-40c9045eb7a2.gif)

### Changes

1. Allow callbacks for drawer items via `drawerOnPress` without needing to write your own custom `contentComponent`
2. Allow rendering custom drawer items via `contentOptions.itemComponent`
3. Factored out and exported `DrawerNavigationItem` for modularity and reuse
4. Updated the demo app to show off some of the new features, including the account picker shown above

No breaking changes, as far as I know.

### Usage

See the changes to the demo app for an implementation example.

### Test Plan

1. Run the NavigationPlayground app
2. Tap the Drawer Example and try it out

Please let me know what you think; the API makes sense to me but I'm open to changing it.