### PR TITLE
Don’t use `Init#` keys for reset

### DIFF
--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -248,19 +248,19 @@ export default (
         return {
           ...state,
           routes: resetAction.actions.map(
-            (childAction: NavigationNavigateAction, index: number) => {
+            (childAction: NavigationNavigateAction) => {
               const router = childRouters[childAction.routeName];
               if (router) {
                 return {
                   ...childAction,
                   ...router.getStateForAction(childAction),
                   routeName: childAction.routeName,
-                  key: `Init${index}`,
+                  key: _getUuid(),
                 };
               }
               const route = {
                 ...childAction,
-                key: `Init${index}`,
+                key: _getUuid(),
               };
               delete route.type;
               return route;


### PR DESCRIPTION
This Init{index} pattern guarantees that the same keys will always be re-used when doing a RESET.
This behaviour doesn’t match how the rest of the router works and causes bugs.

Namely if you are on `{ routeName: ‘Dashboard’, params: { user: ‘A’ } }` and use RESET to `{ routeName: ‘Dashboard’, params: { user: ‘B’ } }` when the user switches, it will act like a `setParams` action instead of a `RESET` action and the Dashboard will not be re-mounted.
