### PR TITLE
Working drawerLockMode that responds to updates when used with a top level navigator.

### DIFF
--- a/docs/api/navigators/DrawerNavigator.md
+++ b/docs/api/navigators/DrawerNavigator.md
@@ -81,7 +81,7 @@ The route configs object is a mapping from route name to a route config, which t
 
 
 ### DrawerNavigatorConfig
-
+- `drawerLockMode` - Specifies the [lock mode](https://facebook.github.io/react-native/docs/drawerlayoutandroid.html#drawerlockmode) of the drawer.
 - `drawerWidth` - Width of the drawer
 - `drawerPosition` - Options are `left` or `right`. Default is `left` position.
 - `contentComponent` - Component used to render the content of the drawer, for example, navigation items. Receives the `navigation` prop for the drawer. Defaults to `DrawerItems`. For more information, see below.
@@ -178,7 +178,7 @@ The navigator component created by `DrawerNavigator(...)` takes the following pr
    screenProps={/* this prop will get passed to the screen components and nav options as props.screenProps */}
  />
  ```
- 
+
  ### Nesting `DrawerNavigation`
- 
+
 Please bear in mind that if you nest the DrawerNavigation, the drawer will show below the parent navigation.

--- a/src/navigators/DrawerNavigator.js
+++ b/src/navigators/DrawerNavigator.js
@@ -42,6 +42,7 @@ const DrawerNavigator = (
   const {
     containerConfig,
     drawerWidth,
+    drawerLockMode,
     contentComponent,
     contentOptions,
     drawerPosition,
@@ -77,6 +78,7 @@ const DrawerNavigator = (
   )((props: *) => (
     <DrawerView
       {...props}
+      drawerLockMode={drawerLockMode}
       drawerWidth={drawerWidth}
       contentComponent={contentComponent}
       contentOptions={contentOptions}

--- a/src/views/Drawer/DrawerView.js
+++ b/src/views/Drawer/DrawerView.js
@@ -137,7 +137,7 @@ export default class DrawerView<T: *> extends PureComponent<void, Props, void> {
         ref={(c: *) => {
           this._drawer = c;
         }}
-        drawerLockMode={this.props.drawerLockMode || config && config.lockMode}
+        drawerLockMode={config && config.lockMode}
         drawerWidth={this.props.drawerWidth}
         onDrawerOpen={this._handleDrawerOpen}
         onDrawerClose={this._handleDrawerClose}

--- a/src/views/Drawer/DrawerView.js
+++ b/src/views/Drawer/DrawerView.js
@@ -124,11 +124,20 @@ export default class DrawerView<T: *> extends PureComponent<void, Props, void> {
     const DrawerScreen = this.props.router.getComponentForRouteName(
       'DrawerClose',
     );
+
+    const screenNavigation = addNavigationHelpers({
+      state: this._screenNavigationProp.state,
+      dispatch: this._screenNavigationProp.dispatch,
+    });
+
+    const config = this.props.router.getScreenConfig(screenNavigation, 'drawer');
+
     return (
       <DrawerLayout
         ref={(c: *) => {
           this._drawer = c;
         }}
+        drawerLockMode={config && config.lockMode}
         drawerWidth={this.props.drawerWidth}
         onDrawerOpen={this._handleDrawerOpen}
         onDrawerClose={this._handleDrawerClose}

--- a/src/views/Drawer/DrawerView.js
+++ b/src/views/Drawer/DrawerView.js
@@ -130,7 +130,7 @@ export default class DrawerView<T: *> extends PureComponent<void, Props, void> {
       dispatch: this._screenNavigationProp.dispatch,
     });
 
-    const config = this.props.router.getScreenConfig(screenNavigation, 'drawer');
+    const config = this.props.router.getScreenOptions(screenNavigation, 'drawer');
 
     return (
       <DrawerLayout

--- a/src/views/Drawer/DrawerView.js
+++ b/src/views/Drawer/DrawerView.js
@@ -24,6 +24,7 @@ export type DrawerScene = {
 };
 
 export type DrawerViewConfig = {
+  drawerLockMode: 'unlocked' | 'locked-closed' | 'locked-open',
   drawerWidth: number,
   drawerPosition: 'left' | 'right',
   contentComponent: ReactClass<*>,

--- a/src/views/Drawer/DrawerView.js
+++ b/src/views/Drawer/DrawerView.js
@@ -137,7 +137,7 @@ export default class DrawerView<T: *> extends PureComponent<void, Props, void> {
         ref={(c: *) => {
           this._drawer = c;
         }}
-        drawerLockMode={config && config.lockMode}
+        drawerLockMode={this.props.drawerLockMode || config && config.lockMode}
         drawerWidth={this.props.drawerWidth}
         onDrawerOpen={this._handleDrawerOpen}
         onDrawerClose={this._handleDrawerClose}

--- a/src/views/Drawer/DrawerView.js
+++ b/src/views/Drawer/DrawerView.js
@@ -125,19 +125,12 @@ export default class DrawerView<T: *> extends PureComponent<void, Props, void> {
       'DrawerClose',
     );
 
-    const screenNavigation = addNavigationHelpers({
-      state: this._screenNavigationProp.state,
-      dispatch: this._screenNavigationProp.dispatch,
-    });
-
-    const config = this.props.router.getScreenOptions(screenNavigation, 'drawer');
-
     return (
       <DrawerLayout
         ref={(c: *) => {
           this._drawer = c;
         }}
-        drawerLockMode={config && config.lockMode}
+        drawerLockMode={this.props.screenProps.lockMode}
         drawerWidth={this.props.drawerWidth}
         onDrawerOpen={this._handleDrawerOpen}
         onDrawerClose={this._handleDrawerClose}

--- a/src/views/Drawer/DrawerView.js
+++ b/src/views/Drawer/DrawerView.js
@@ -125,12 +125,19 @@ export default class DrawerView<T: *> extends PureComponent<void, Props, void> {
       'DrawerClose',
     );
 
+    const screenNavigation = addNavigationHelpers({
+      state: this._screenNavigationProp.state,
+      dispatch: this._screenNavigationProp.dispatch,
+    });
+
+    const config = this.props.router.getScreenOptions(screenNavigation, 'drawer');
+
     return (
       <DrawerLayout
         ref={(c: *) => {
           this._drawer = c;
         }}
-        drawerLockMode={this.props.screenProps.lockMode}
+        drawerLockMode={this.props.screenProps.lockMode || config && config.lockMode}
         drawerWidth={this.props.drawerWidth}
         onDrawerOpen={this._handleDrawerOpen}
         onDrawerClose={this._handleDrawerClose}


### PR DESCRIPTION
This pr adds drawerLockMode to determine whether or not to allow the drawer to be open by swipe events. This uses screenProps={{lockMode:this.state.lockMode}} that allows it to update accordingly with a top-level navigator.

Create certain routes that are not apart of the DrawerNavigator aka a StackNavigator or TabNavigator and in your navigation function properly handle your if statement like this 

  if (!['DrawerRoute', 'DrawerRoute1', 'DrawerRoute2'].includes(routeName)) {
     // disable drawer
     this.setState({lockMode: 'locked-closed'});
    }

and in your pop function you can do something like this -

  topLevelNavigationPop = () => {
    let drawerEnable = this.navigator._navigation.state.routes[0].routes.find( ( ele ) => {
     return ele.index === 0;
    });
    if ( drawerEnable ) {
     // enable drawer function happens here.
     this.setState({lockMode: 'unlocked'});
    }
}

and then use it in your Navigator like this 

  <DrawerStack ref={nav => { this.navigator = nav; }} screenProps={{lockMode:this.state.lockMode}}/>

works for iOS and android.

