### PR TITLE
Pass tintColor to tabBarLabel within navigationOptions

### DIFF
--- a/src/views/TabView/TabBarBottom.js
+++ b/src/views/TabView/TabBarBottom.js
@@ -82,7 +82,8 @@ export default class TabBarBottom
       outputRange,
     });
 
-    const label = this.props.getLabel(scene);
+    const tintColor = scene.focused ? activeTintColor : inactiveTintColor;
+    const label = this.props.getLabel({ ...scene, tintColor });
     if (typeof label === 'string') {
       return (
         <Animated.Text style={[styles.label, { color }, labelStyle]}>
@@ -90,8 +91,9 @@ export default class TabBarBottom
         </Animated.Text>
       );
     }
+
     if (typeof label === 'function') {
-      return label(scene);
+      return label({ ...scene, tintColor });
     }
 
     return label;

--- a/src/views/TabView/TabBarTop.js
+++ b/src/views/TabView/TabBarTop.js
@@ -74,7 +74,8 @@ export default class TabBarTop
       outputRange,
     });
 
-    const label = this.props.getLabel(scene);
+    const tintColor = scene.focused ? activeTintColor : inactiveTintColor;
+    const label = this.props.getLabel({ ...scene, tintColor });
     if (typeof label === 'string') {
       return (
         <Animated.Text style={[styles.label, { color }, labelStyle]}>
@@ -83,7 +84,7 @@ export default class TabBarTop
       );
     }
     if (typeof label === 'function') {
-      return label(scene);
+      return label({ ...scene, tintColor });
     }
 
     return label;


### PR DESCRIPTION
This expands on #1156 in that it now passes tintColor to tabBarLabel functions as per the documentation.