### PR TITLE
[Minor] Update Stacks examples for better clarity

### DIFF
--- a/examples/NavigationPlayground/js/StacksInTabs.js
+++ b/examples/NavigationPlayground/js/StacksInTabs.js
@@ -50,9 +50,6 @@ const MyProfileScreen = ({ navigation }) => (
     navigation={navigation}
   />
 );
-MyProfileScreen.navigationOptions = ({ navigation }) => ({
-  title: `${navigation.state.params.name}'s Profile!`,
-});
 
 const MyNotificationsSettingsScreen = ({ navigation }) => (
   <MyNavScreen

--- a/examples/NavigationPlayground/js/StacksInTabs.js
+++ b/examples/NavigationPlayground/js/StacksInTabs.js
@@ -20,15 +20,15 @@ const MyNavScreen = ({ navigation, banner }) => (
     <SampleText>{banner}</SampleText>
     <Button
       onPress={() => navigation.navigate('Profile', { name: 'Jordan' })}
-      title="Go to a profile screen"
+      title="Open profile screen"
     />
     <Button
       onPress={() => navigation.navigate('NotifSettings')}
-      title="Go to notification settings"
+      title="Open notifications screen"
     />
     <Button
       onPress={() => navigation.navigate('SettingsTab')}
-      title="Go to settings"
+      title="Go to settings tab"
     />
     <Button
       onPress={() => navigation.goBack(null)}
@@ -56,14 +56,14 @@ MyProfileScreen.navigationOptions = ({ navigation }) => ({
 
 const MyNotificationsSettingsScreen = ({ navigation }) => (
   <MyNavScreen
-    banner="Notification Settings"
+    banner="Notifications Screen"
     navigation={navigation}
   />
 );
 
 const MySettingsScreen = ({ navigation }) => (
   <MyNavScreen
-    banner="Settings"
+    banner="Settings Screen"
     navigation={navigation}
   />
 );
@@ -96,7 +96,7 @@ const SettingsTab = StackNavigator({
   NotifSettings: {
     screen: MyNotificationsSettingsScreen,
     navigationOptions: {
-      title: 'Notification Settings',
+      title: 'Notifications',
     },
   },
 });

--- a/examples/NavigationPlayground/js/StacksOverTabs.js
+++ b/examples/NavigationPlayground/js/StacksOverTabs.js
@@ -20,15 +20,15 @@ const MyNavScreen = ({ navigation, banner }) => (
     <SampleText>{banner}</SampleText>
     <Button
       onPress={() => navigation.navigate('Profile', { name: 'Jordan' })}
-      title="Go to a profile screen"
+      title="Open profile screen"
     />
     <Button
       onPress={() => navigation.navigate('NotifSettings')}
-      title="Go to notification settings"
+      title="Open notifications screen"
     />
     <Button
       onPress={() => navigation.navigate('SettingsTab')}
-      title="Go to settings"
+      title="Go to settings tab"
     />
     <Button
       onPress={() => navigation.goBack(null)}
@@ -56,14 +56,14 @@ MyProfileScreen.navigationOptions = ({ navigation }) => {
 
 const MyNotificationsSettingsScreen = ({ navigation }) => (
   <MyNavScreen
-    banner="Notification Settings"
+    banner="Notifications Screen"
     navigation={navigation}
   />
 );
 
 const MySettingsScreen = ({ navigation }) => (
   <MyNavScreen
-    banner="Settings"
+    banner="Settings Screen"
     navigation={navigation}
   />
 );
@@ -73,6 +73,7 @@ const TabNav = TabNavigator({
     screen: MyHomeScreen,
     path: '/',
     navigationOptions: {
+      title: 'Welcome',
       tabBarLabel: 'Home',
       tabBarIcon: ({ tintColor, focused }) => (
         <Ionicons
@@ -87,7 +88,7 @@ const TabNav = TabNavigator({
     screen: MySettingsScreen,
     path: '/settings',
     navigationOptions: {
-      tabBarLabel: 'Settings',
+      title: 'Settings',
       tabBarIcon: ({ tintColor, focused }) => (
         <Ionicons
           name={focused ? 'ios-settings' : 'ios-settings-outline'}
@@ -110,7 +111,7 @@ const StacksOverTabs = StackNavigator({
   NotifSettings: {
     screen: MyNotificationsSettingsScreen,
     navigationOptions: {
-      title: 'Notification Settings',
+      title: 'Notifications',
     },
   },
   Profile: {
@@ -120,8 +121,6 @@ const StacksOverTabs = StackNavigator({
       title: `${navigation.state.params.name}'s Profile!`
     },
   },
-}, {
-  headerMode: 'none',
 });
 
 export default StacksOverTabs;

--- a/examples/NavigationPlayground/js/StacksOverTabs.js
+++ b/examples/NavigationPlayground/js/StacksOverTabs.js
@@ -50,9 +50,6 @@ const MyProfileScreen = ({ navigation }) => (
     navigation={navigation}
   />
 );
-MyProfileScreen.navigationOptions = ({ navigation }) => {
-  title: `${navigation.state.params.name}'s Profile!`
-};
 
 const MyNotificationsSettingsScreen = ({ navigation }) => (
   <MyNavScreen

--- a/examples/ReduxExample/src/components/AuthButton.js
+++ b/examples/ReduxExample/src/components/AuthButton.js
@@ -3,17 +3,17 @@ import { connect } from 'react-redux';
 import { Button } from 'react-native';
 import { NavigationActions } from 'react-navigation';
 
-const AuthButton = ({ logout, login, isLoggedIn }) => (
+const AuthButton = ({ logout, loginScreen, isLoggedIn }) => (
   <Button
-    title={isLoggedIn ? 'Log Out' : 'Log In'}
-    onPress={isLoggedIn ? logout : login}
+    title={isLoggedIn ? 'Log Out' : 'Open Login Screen'}
+    onPress={isLoggedIn ? logout : loginScreen}
   />
 );
 
 AuthButton.propTypes = {
   isLoggedIn: PropTypes.bool.isRequired,
   logout: PropTypes.func.isRequired,
-  login: PropTypes.func.isRequired,
+  loginScreen: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = state => ({
@@ -22,7 +22,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
   logout: () => dispatch({ type: 'Logout' }),
-  login: () => dispatch(NavigationActions.navigate({ routeName: 'Login' })),
+  loginScreen: () => dispatch(NavigationActions.navigate({ routeName: 'Login' })),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(AuthButton);


### PR DESCRIPTION
It was previously a bit unclear what was going on because of the wording used. Now all screens are called "screens", tabs are called "tabs", "Open" means push a screen on the stack, and "Go to tab" means change the tab without pushing on top. It's a small change that hopefully helps clear up some confusion and make it more intuitive.

Also adds the header back to the StacksOverTabs example so the scene titles are visible.

---

*Note to reviewers: I'll be traveling for the next couple weeks. Hopefully this can be merged without issue, but I'll try to respond to comments when possible (or on May 23 when I return). Branch is rebased and up to date, and owners have permission to push directly to this branch:*

```console
git remote add cooperka https://github.com/cribspot/react-navigation.git
git fetch cooperka
git checkout -b better-stacks-example
```