### PR TITLE
clarify title option

### DIFF
--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -94,7 +94,7 @@ Visual options:
 
 #### `title`
 
-Generic title that can be used as a fallback for `headerTitle` and `tabBarLabel`
+String that can be used as a fallback for `headerTitle` and `tabBarLabel`
 
 #### `header`
 


### PR DESCRIPTION
If you attempt to use something other than a string, it will throw an error in some situations. #1318 provides more details about the error. If it is expecting a certain type, the docs should clarify that.


