### PR TITLE
Fix type of Easing function to match type in react-native module

### DIFF
--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -397,7 +397,7 @@ export type NavigationSceneRendererProps = NavigationTransitionProps;
 export type NavigationTransitionSpec = {
   duration?: number,
   // An easing function from `Easing`.
-  easing?: () => any,
+  easing?: (t: number) => number,
   // A timing function such as `Animated.timing`.
   timing?: (value: AnimatedValue, config: any) => any,
 };


### PR DESCRIPTION
Before [this fix](https://github.com/facebook/react-native/commit/c7387fefc85fd15dceadfa291857099ed3e848b8) landed last month, Flow wasn't evaluating the types of any imports from react-native. This fix isn't in RN 0.44.0, but it is in master.

The type of the Easing function in TypeDefinition.js is mistyped, and this trips up Flow errors when using react-native master (with Flow 0.45.0, as specified in master's package.json). This pull request simply fixes the type.

I've tested this with RN 0.44.0/Flow 0.42.0 (current npm releases) as well, and it doesn't cause any new Flow errors there.

Test plan:
In a project using react-navigation and react-native:
```bash
# first, make sure node_modules points to a react-navigation with this pull request merged
npm install --save react-native@0.44.0 # install npm react-native
vim .flowconfig # set flow version 0.42.0
npm install --save-dev flow-bin@0.42.0
flow
npm install git+https://github.com/facebook/react-native.git # install master react-native
vim .flowconfig # set flow version 0.45.0
npm install --save-dev flow-bin@0.45.0
flow
```

Errors from `node_modules/react-navigation` should not appear in either call to Flow. Without this pull request, the second call to Flow will show errors.

Note that errors from `react-native-tab-view` will still appear. Here is [the full list](https://gist.github.com/Ashoat/95569ccc5dd40b1c5ff9d0f5d59b461a) of 8 Flow errors; the 6 ones at the bottom are fixed by this pull request, whereas the first 2 (related to `react-native-tab-view` are extant).