### PR TITLE
Fixed error when navigation.dispatch a RESET action on StackNavigator (#691)

### DIFF
--- a/src/navigators/StackNavigator.js
+++ b/src/navigators/StackNavigator.js
@@ -23,6 +23,7 @@ export default (
   stackConfig: StackNavigatorConfig = {},
 ) => {
   const {
+    stateName,
     initialRouteName,
     initialRouteParams,
     paths,
@@ -35,6 +36,7 @@ export default (
     navigationOptions,
   } = stackConfig;
   const stackRouterConfig = {
+    stateName,
     initialRouteName,
     initialRouteParams,
     paths,

--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -55,6 +55,9 @@ export default (
 
   const initialRouteName = stackConfig.initialRouteName || routeNames[0];
 
+  // If stateName is not explicitly set, just use the initialRouteName as default
+  const stateName = stackConfig.stateName || initialRouteName;
+
   const initialChildRouter = childRouters[initialRouteName];
   const paths = stackConfig.paths || {};
 
@@ -135,6 +138,7 @@ export default (
         };
         // eslint-disable-next-line no-param-reassign
         state = {
+          stateName,
           index: 0,
           routes: [route],
         };
@@ -243,6 +247,11 @@ export default (
       }
 
       if (action.type === NavigationActions.RESET) {
+        // Prevent the RESET action from propagating on child components if
+        // the stateName param is set and just return state as is
+        if (action.stateName && action.stateName !== state.stateName) {
+          return state;
+        }
         const resetAction: NavigationResetAction = action;
 
         return {


### PR DESCRIPTION
Fixed navigation.dispatch a RESET action from propagating to child navigators by explicitly calling with a stateName param (#691)

When keeping the state of your navigation in Redux and you have more than one navigation, on dispatching a RESET action, all reducers will receive it and try to reset the stack which leads to errors like:

```
There is no route defined for key Home. Must be one of:
'FacebookAuthentication','EmailAuthentication'
```


Now you can explicitly give your StackNavigator a name and make sure that the RESET action is only being handled by that specific navigator's reducer. All the other reducers will just return the current state as is.

Ex:

```
const App = StackNavigator({
  Login: {
    screen: Login
  },
  Authenticated: {
    screen: Authenticated
  }
}, {
  stateName: 'MainAppNav', // If you don't give it a name it will just use the value of initialRouteName
  initialRouteName: 'Login'
})
```

And then navigation.dispatch a reset action like so:

```
const resetAction = NavigationActions.reset({
   index: 0,
   stateName: 'MainAppNav',
   actions: [
     NavigationActions.navigate({ routeName: 'Authenticated' })
   ]
});
this.props.navigation.dispatch(resetAction);
```
