### PR TITLE
Allow optionally override back-button-image on StackNavigator.

### DIFF
--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -222,6 +222,7 @@ export type NavigationStackScreenOptions = NavigationScreenOptions & {
   headerBackTitle?: string,
   headerTruncatedBackTitle?: string,
   headerBackTitleStyle?: Style,
+  headerBackButtonAsset?: ?any,
   headerPressColorAndroid?: string,
   headerRight?: React.Element<*>,
   headerStyle?: Style,

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -135,6 +135,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
         pressColorAndroid={options.headerPressColorAndroid}
         tintColor={options.headerTintColor}
         title={backButtonTitle}
+        asset={options.headerBackButtonAsset}
         truncatedTitle={truncatedBackButtonTitle}
         titleStyle={options.headerBackTitleStyle}
         width={width}

--- a/src/views/HeaderBackButton.js
+++ b/src/views/HeaderBackButton.js
@@ -18,6 +18,7 @@ type Props = {
   onPress?: () => void,
   pressColorAndroid?: ?string,
   title?: ?string,
+  asset?: ?any,
   titleStyle?: ?Style,
   tintColor?: ?string,
   truncatedTitle?: ?string,
@@ -72,7 +73,7 @@ class HeaderBackButton extends React.PureComponent<DefaultProps, Props, State> {
     const backButtonTitle = renderTruncated ? truncatedTitle : title;
 
     // eslint-disable-next-line global-require
-    const asset = require('./assets/back-icon.png');
+    const asset = this.props.asset || require('./assets/back-icon.png');
 
     return (
       <TouchableItem


### PR DESCRIPTION
It really make scenes to change back-icon-image (replace *blue* default one).
This `pull-request` allow safe way to optionally override the back-icon-image.

**Example usage:**
```js
navigationOptions = {
	headerTintColor: '#ffffff',
	headerStyle: {
		backgroundColor: 'orange',
	},
	headerBackButtonAsset: require('./whiteBack.png'),
};
```