### PR TITLE
Add testID to HeaderBackButton

### DIFF
--- a/src/views/HeaderBackButton.js
+++ b/src/views/HeaderBackButton.js
@@ -79,6 +79,7 @@ class HeaderBackButton extends React.PureComponent<DefaultProps, Props, State> {
         accessibilityComponentType="button"
         accessibilityLabel={backButtonTitle}
         accessibilityTraits="button"
+        testID="header-back"
         delayPressIn={0}
         onPress={onPress}
         pressColor={pressColorAndroid}


### PR DESCRIPTION
We are using Appium for end2end testing and need to be able to access the back button. An appropriate `testID` is the way to do this.

**Test plan (required)**

Here you can see the back button identified in Appium:

![appium2](https://cloud.githubusercontent.com/assets/30143/25753986/88acb252-31b5-11e7-8eb0-46c6329d916c.png)

