### PR TITLE
Fix link to Transitioner docs

### DIFF
--- a/docs/api/views/Views.md
+++ b/docs/api/views/Views.md
@@ -12,6 +12,6 @@ Navigation views are controlled React components that can present the current na
 - [Tabs](https://github.com/react-community/react-navigation/blob/master/src/views/TabView) - A configurable tab switcher / pager
 - [Drawer](https://github.com/react-community/react-navigation/tree/master/src/views/Drawer) - A view with a drawer that slides from the left
 
-## [Transitioner](/docs/views/transitioner)
+## [Transitioner](/docs/api/views/Transitioner.md)
 
-`Transitioner` manages the animations during the transition and can be used to build fully custom navigation views. It is used inside the `CardStack` view. [Learn more about Transitioner here.](/docs/views/transitioner)
+`Transitioner` manages the animations during the transition and can be used to build fully custom navigation views. It is used inside the `CardStack` view. [Learn more about Transitioner here.](/docs/api/views/Transitioner.md)


### PR DESCRIPTION
This changes the docs to correct a broken link to the Transitioner page.

**Test plan (required)**
This is a documentation-only change, there are no tests.
