### PR TITLE
allow uriPrefix to be a regular expression

### DIFF
--- a/src/createNavigationContainer.js
+++ b/src/createNavigationContainer.js
@@ -15,7 +15,7 @@ import type {
 } from './TypeDefinition';
 
 type NavigationContainerProps = {
-  uriPrefix?: string,
+  uriPrefix?: string | RegExp,
   onNavigationStateChange?: (
     NavigationState,
     NavigationState,


### PR DESCRIPTION
when accepting both a protocol url and a normal url, it's hard to define a static prefix.

So for example, in the application I'm currently working on we use iOS applinks for deeplinking, but also want to use a protocol url (`myapp://...`) for in-app linking. Doing this using a static string prefix I also have to use do parsing of the path in `getActionForPathAndParams`, but when using a regex this extra parsing can be omitted.

**NB.** using a regex does already work, but it's nice to have it typed too.