### PR TITLE
Migrate from BackAndroid to BackHandler

### DIFF
--- a/src/PlatformHelpers.js
+++ b/src/PlatformHelpers.js
@@ -6,6 +6,6 @@ export const Linking = {
   getInitialURL: () => Promise.reject('Unsupported platform'),
 };
 
-export const BackAndroid = {
+export const BackHandler = {
   addEventListener: () => {},
 };

--- a/src/PlatformHelpers.native.js
+++ b/src/PlatformHelpers.native.js
@@ -1,5 +1,5 @@
 /* @flow */
 
-import { BackAndroid, Linking } from 'react-native';
+import { BackHandler, Linking } from 'react-native';
 
-export { BackAndroid, Linking };
+export { BackHandler, Linking };

--- a/src/createNavigationContainer.js
+++ b/src/createNavigationContainer.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import invariant from 'fbjs/lib/invariant';
-import { BackAndroid, Linking } from './PlatformHelpers';
+import { BackHandler, Linking } from './PlatformHelpers';
 import NavigationActions from './NavigationActions';
 import addNavigationHelpers from './addNavigationHelpers';
 
@@ -157,7 +157,7 @@ export default function createNavigationContainer<T: *>(
         return;
       }
 
-      this.subs = BackAndroid.addEventListener('backPress', () =>
+      this.subs = BackHandler.addEventListener('backPress', () =>
         this.dispatch(NavigationActions.back()));
 
       Linking.addEventListener('url', ({ url }: { url: string }) => {


### PR DESCRIPTION
Hello!

`BackAndroid` [is deprecated now](https://facebook.github.io/react-native/docs/backandroid.html) and because of this I updated code.

Please check my PR.