### PR TITLE
	Fix custom back button props & visibility

### DIFF
--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -136,6 +136,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
         tintColor={options.headerTintColor}
         title={backButtonTitle}
         truncatedTitle={truncatedBackButtonTitle}
+        titleStyle={options.headerBackTitleStyle}
         width={width}
       />
     );
@@ -283,14 +284,15 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
       position,
       screenProps,
       progress,
+      style,
       ...rest
     } = this.props;
 
     const { options } = this.props.getScreenDetails(scene, screenProps);
-    const style = options.headerStyle;
+    const headerStyle = options.headerStyle;
 
     return (
-      <Animated.View {...rest} style={[styles.container, style]}>
+      <Animated.View {...rest} style={[styles.container, headerStyle, style]}>
         <View style={styles.appBar}>
           {appBar}
         </View>

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -114,11 +114,11 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
 
   _renderLeftComponent = (props: SceneProps) => {
     const options = this.props.getScreenDetails(props.scene).options;
-    if (typeof options.headerLeft !== 'undefined') {
-      return options.headerLeft;
-    }
     if (props.scene.index === 0) {
       return null;
+    }
+    if (typeof options.headerLeft !== 'undefined') {
+      return options.headerLeft({navigation: this.props.navigation});
     }
     const backButtonTitle = this._getBackButtonTitleString(props.scene);
     const truncatedBackButtonTitle = this._getTruncatedBackButtonTitle(
@@ -136,7 +136,6 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
         tintColor={options.headerTintColor}
         title={backButtonTitle}
         truncatedTitle={truncatedBackButtonTitle}
-        titleStyle={options.headerBackTitleStyle}
         width={width}
       />
     );
@@ -284,15 +283,14 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
       position,
       screenProps,
       progress,
-      style,
       ...rest
     } = this.props;
 
     const { options } = this.props.getScreenDetails(scene, screenProps);
-    const headerStyle = options.headerStyle;
+    const style = options.headerStyle;
 
     return (
-      <Animated.View {...rest} style={[styles.container, headerStyle, style]}>
+      <Animated.View {...rest} style={[styles.container, style]}>
         <View style={styles.appBar}>
           {appBar}
         </View>


### PR DESCRIPTION
I have to have option to add custom styled back button.
So I want to provide a React element styled button.
I need navigation props to be passed to component, that I can call this.props.navigatios.goBack()

I also don't want to handle visibility of button on my own.
If I'm in root it should return null, but that functionality is implemented below custom renderer.

For testing you should build custom back button.
e.g.
`  <TouchableOpacity onPress={() => { his.props.navigation.goBack(null) }} style={styles.row}>
        <View style={styles.backCircle}>
<Icon
            name='ios-arrow-dropleft-circle-outline'
            size={20}
            color="#112233"
          />
        </View>
        <Text>{'back'}</Text>
      </TouchableOpacity>`

Then you can use it e.g.

`headerLeft: props => <BackButtonContainer {...props} />`

Test when it is showing, test on press.