### PR TITLE
allow back button customization. more than just title change and tint.

### DIFF
--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -120,6 +120,10 @@ React Element to display on the right side of the header
 
 React Element to display on the left side of the header
 
+#### `headerBack`
+
+React Element to display on the left side of the header, that is wrapped to act as a back button.
+
 #### `headerStyle`
 
 Style object for the header

--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -228,6 +228,7 @@ export type NavigationStackScreenOptions = NavigationScreenOptions & {
   headerTitleStyle?: Style,
   headerTintColor?: string,
   headerLeft?: React.Element<*>,
+  headerBack?: React.Element<*>,
   headerBackTitle?: string,
   headerTruncatedBackTitle?: string,
   headerBackTitleStyle?: Style,

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -7,6 +7,7 @@ import React from 'react';
 import { Animated, Platform, StyleSheet, View } from 'react-native';
 
 import HeaderTitle from './HeaderTitle';
+import HeaderBackButtonWrapper from './HeaderBackButtonWrapper';
 import HeaderBackButton from './HeaderBackButton';
 import HeaderStyleInterpolator from './HeaderStyleInterpolator';
 
@@ -123,23 +124,33 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
     if (props.scene.index === 0) {
       return null;
     }
-    const backButtonTitle = this._getBackButtonTitleString(props.scene);
-    const truncatedBackButtonTitle = this._getTruncatedBackButtonTitle(
-      props.scene
-    );
     const width = this.state.widths[props.scene.key]
       ? (this.props.layout.initWidth - this.state.widths[props.scene.key]) / 2
       : undefined;
+    var backButtonElement = options.headerBack;
+    if (backButtonElement === null || backButtonElement === undefined) {
+      const backButtonTitle = this._getBackButtonTitleString(props.scene);
+      const truncatedBackButtonTitle = this._getTruncatedBackButtonTitle(
+        props.scene,
+      );
+      const asset = require('./assets/back-icon.png');
+      backButtonElement = (
+        <HeaderBackButton
+          tintColor={options.headerTintColor}
+          title={backButtonTitle}
+          truncatedTitle={truncatedBackButtonTitle}
+          titleStyle={options.headerBackTitleStyle}
+          width={width}
+        />
+      );
+    }
     return (
-      <HeaderBackButton
+      <HeaderBackButtonWrapper
         onPress={this._navigateBack}
         pressColorAndroid={options.headerPressColorAndroid}
-        tintColor={options.headerTintColor}
-        title={backButtonTitle}
-        truncatedTitle={truncatedBackButtonTitle}
-        titleStyle={options.headerBackTitleStyle}
-        width={width}
-      />
+      >
+        {backButtonElement}
+      </HeaderBackButtonWrapper>
     );
   };
 

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -57,6 +57,30 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
     return this.props.scenes.find((s: *) => s.index === scene.index - 1);
   }
 
+  _getBackButtonElement(props: SceneProps): ?React.Element {
+    const options = this.props.getScreenDetails(props.scene).options;
+    const width = this.state.widths[props.scene.key]
+      ? (this.props.layout.initWidth - this.state.widths[props.scene.key]) / 2
+      : undefined;
+
+    let backButtonElement = options.headerBack;
+    if (backButtonElement === null || backButtonElement === undefined) {
+      const backButtonTitle = this._getBackButtonTitleString(props.scene);
+      const truncatedBackButtonTitle = this._getTruncatedBackButtonTitle(props.scene);
+      const asset = require('./assets/back-icon.png');
+      backButtonElement = (
+        <HeaderBackButton
+          tintColor={options.headerTintColor}
+          title={backButtonTitle}
+          truncatedTitle={truncatedBackButtonTitle}
+          titleStyle={options.headerBackTitleStyle}
+          width={width}
+        />
+      );
+    }
+    return backButtonElement;
+  }
+
   _getBackButtonTitleString(scene: NavigationScene): ?string {
     const lastScene = this._getLastScene(scene);
     if (!lastScene) {
@@ -124,26 +148,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
     if (props.scene.index === 0) {
       return null;
     }
-    const width = this.state.widths[props.scene.key]
-      ? (this.props.layout.initWidth - this.state.widths[props.scene.key]) / 2
-      : undefined;
-    var backButtonElement = options.headerBack;
-    if (backButtonElement === null || backButtonElement === undefined) {
-      const backButtonTitle = this._getBackButtonTitleString(props.scene);
-      const truncatedBackButtonTitle = this._getTruncatedBackButtonTitle(
-        props.scene,
-      );
-      const asset = require('./assets/back-icon.png');
-      backButtonElement = (
-        <HeaderBackButton
-          tintColor={options.headerTintColor}
-          title={backButtonTitle}
-          truncatedTitle={truncatedBackButtonTitle}
-          titleStyle={options.headerBackTitleStyle}
-          width={width}
-        />
-      );
-    }
+    const backButtonElement = this._getBackButtonElement(props);
     return (
       <HeaderBackButtonWrapper
         onPress={this._navigateBack}

--- a/src/views/HeaderBackButton.js
+++ b/src/views/HeaderBackButton.js
@@ -12,11 +12,7 @@ import {
 
 import type { LayoutEvent, Style } from '../TypeDefinition';
 
-import TouchableItem from './TouchableItem';
-
 type Props = {
-  onPress?: () => void,
-  pressColorAndroid?: ?string,
   title?: ?string,
   titleStyle?: ?Style,
   tintColor?: ?string,
@@ -25,7 +21,6 @@ type Props = {
 };
 
 type DefaultProps = {
-  pressColorAndroid: ?string,
   tintColor: ?string,
   truncatedTitle: ?string,
 };
@@ -36,7 +31,6 @@ type State = {
 
 class HeaderBackButton extends React.PureComponent<DefaultProps, Props, State> {
   static defaultProps = {
-    pressColorAndroid: 'rgba(0, 0, 0, .32)',
     tintColor: Platform.select({
       ios: '#037aff',
     }),
@@ -56,8 +50,6 @@ class HeaderBackButton extends React.PureComponent<DefaultProps, Props, State> {
 
   render() {
     const {
-      onPress,
-      pressColorAndroid,
       width,
       title,
       titleStyle,
@@ -75,33 +67,21 @@ class HeaderBackButton extends React.PureComponent<DefaultProps, Props, State> {
     const asset = require('./assets/back-icon.png');
 
     return (
-      <TouchableItem
-        accessibilityComponentType="button"
-        accessibilityLabel={backButtonTitle}
-        accessibilityTraits="button"
-        testID="header-back"
-        delayPressIn={0}
-        onPress={onPress}
-        pressColor={pressColorAndroid}
-        style={styles.container}
-        borderless
-      >
-        <View style={styles.container}>
-          <Image
-            style={[styles.icon, title && styles.iconWithTitle, { tintColor }]}
-            source={asset}
-          />
-          {Platform.OS === 'ios' &&
-            title &&
-            <Text
-              onLayout={this._onTextLayout}
-              style={[styles.title, { color: tintColor }, titleStyle]}
-              numberOfLines={1}
-            >
-              {backButtonTitle}
-            </Text>}
-        </View>
-      </TouchableItem>
+      <View style={styles.container}>
+        <Image
+          style={[styles.icon, title && styles.iconWithTitle, { tintColor }]}
+          source={asset}
+        />
+        {Platform.OS === 'ios' &&
+          title &&
+          <Text
+            onLayout={this._onTextLayout}
+            style={[styles.title, { color: tintColor }, titleStyle]}
+            numberOfLines={1}
+          >
+            {backButtonTitle}
+          </Text>}
+      </View>
     );
   }
 }

--- a/src/views/HeaderBackButtonWrapper.js
+++ b/src/views/HeaderBackButtonWrapper.js
@@ -1,0 +1,84 @@
+/* @flow */
+
+import React, { Children } from 'react';
+import {
+  I18nManager,
+  View,
+  Image,
+  Text,
+  Platform,
+  StyleSheet,
+} from 'react-native';
+
+import type { LayoutEvent } from '../TypeDefinition';
+
+import TouchableItem from './TouchableItem';
+
+type Props = {
+  onPress?: () => void,
+  pressColorAndroid?: ?string,
+  children: React.Children<*>,
+};
+
+type DefaultProps = {
+  pressColorAndroid: ?string,
+};
+
+type State = {};
+
+class HeaderBackButtonWrapper
+  extends React.PureComponent<DefaultProps, Props, State> {
+  static defaultProps = {
+    pressColorAndroid: 'rgba(0, 0, 0, .32)',
+    accessibilityLabel: 'Back',
+  };
+
+  state = {};
+
+  render() {
+    const {
+      onPress,
+      pressColorAndroid,
+      accessibilityLabel,
+    } = this.props;
+
+    return (
+      <TouchableItem
+        accessibilityComponentType="button"
+        accessibilityLabel={accessibilityLabel}
+        accessibilityTraits="button"
+        testID="header-back"
+        delayPressIn={0}
+        onPress={onPress}
+        pressColor={pressColorAndroid}
+        style={styles.container}
+        borderless
+      >
+        <View style={[styles.container, styles.backContainer]}>
+          {Children.only(this.props.children)}
+        </View>
+      </TouchableItem>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    backgroundColor: 'transparent',
+  },
+  backContainer: Platform.OS === 'ios'
+    ? {
+        marginLeft: 10,
+        marginRight: 22,
+        marginVertical: 12,
+        transform: [{ scaleX: I18nManager.isRTL ? -1 : 1 }],
+      }
+    : {
+        margin: 16,
+        transform: [{ scaleX: I18nManager.isRTL ? -1 : 1 }],
+      },
+});
+
+export default HeaderBackButtonWrapper;


### PR DESCRIPTION
This PR allows the user to use any react element as a back button.
We can already use something like
```
const Navigator = StackNavigator(
  {
    Splash: { screen: SplashScreen },
    Login: { screen: LoginScreen },
    Main: { screen: MainScreen },
  },
  {
    initialRouteName: 'Splash',
    navigationOptions: {
      headerMode: 'screen',
      headerStyle: {
        backgroundColor: Colors.navBarBackground,
        borderBottomWidth: 1 / PixelRatio.get(),
        borderBottomColor: Colors.separator,
      },
      headerTitleStyle: {
        color: Colors.textBlue,
        fontFamily: Fonts.type.base,
      },
```
Now we can also add something like
```
    headerBack: <Image source={Images.iconBack} />,
```
or like
```
    headerBack: (
      <View style={{
        alignItems: 'center',
        flexDirection: 'row',
      }}>
        <Image source={Images.iconBack} />
        <Text style={{paddingRight: 10, }} numberOfLines={1}>BACK</Text>
      </View>
    ),
```
This will be wrapped and made into a button that goes back.
The difference with `headerLeft` is basically that `headerLeft` can be anything, and added in any screen. `headerBack` is always a button that goes back, that contains any custom element the user gives, and it will only appear on non-zero index screens.

Without a custom `headerBack` (regular back button, automatically rendered, as before):
![img_0052](https://cloud.githubusercontent.com/assets/100233/26007178/b1c8ee1e-373f-11e7-8f28-087338452b00.PNG)
(`PavlosTv` is the title of the previous screen)

With a custom `headerBack` (custom element, wrapped as a `goBack` button):
![img_0051](https://cloud.githubusercontent.com/assets/100233/26007123/8246ae42-373f-11e7-84de-cf0c71ec84a0.PNG)

With a custom `headerBack` (custom element, wrapped as a `goBack` button):
![img_0053](https://cloud.githubusercontent.com/assets/100233/26007154/a22ea2f0-373f-11e7-88e3-fd7cdc73f46d.PNG)

