### PR TITLE
allow functions for headerLeft

### DIFF
--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -118,7 +118,7 @@ React Element to display on the right side of the header
 
 #### `headerLeft`
 
-React Element to display on the left side of the header
+React Element or a function that given `HeaderLeftProps` returns a React Element, to display on left side of the header
 
 #### `headerStyle`
 

--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -113,9 +113,17 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
 
   _renderLeftComponent = (props: SceneProps) => {
     const options = this.props.getScreenDetails(props.scene).options;
-    if (typeof options.headerLeft !== 'undefined') {
-      return options.headerLeft;
+
+    const { headerLeft } = options;
+
+    if (typeof headerLeft !== 'undefined' && typeof headerLeft !== 'function') {
+      return headerLeft;
     }
+
+    if (typeof headerLeft === 'function') {
+      return headerLeft(this.props);
+    }
+
     if (props.scene.index === 0) {
       return null;
     }


### PR DESCRIPTION
## Motivation
https://github.com/react-community/react-navigation/issues/1417
Sometimes you want to dynamically decide the header left component based on screen props, for example to show a custom drawer when on the root route

Potential workarounds:
* I have used a custom HeaderLeft component that looks at the navigation state index to determine whether to show the root navigation index HeaderLeft or the back button. However, as the navigation state does not specify which screen you are on, this causes a visual flicker during page transitions
* Using the navigation prop passed into navigationOptions to determine the index and make the determination of which headerLeft to show that way. The problem is the index is not passed into the header props for the navigationOptions as described in the comments for this PR: https://github.com/react-community/react-navigation/pull/1492. In fact, that prop does not contain all the screen options and relevant information that the header options do.

## Test Plan

* I verified that the headerLeft component worked as it had before
* I verified that an absence of a headerLeft component works
* I implemented a headerLeft that was aware of props like so:

```
navigationOptions: {
  headerLeft: (headerProps) => (
    <MyHeaderLeft showBack={headerProps.scene.index > 0}/>
  )
}
```