### PR TITLE
Fix flow type for NavigationParams

### DIFF
--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -169,7 +169,7 @@ export type NavigationNavigator<T, State, Action, Options> = ReactClass<T> & {
 };
 
 export type NavigationParams = {
-  [key: string]: string,
+  [key: string]: mixed,
 };
 
 export type NavigationNavigateAction = {


### PR DESCRIPTION
Fix #252 

In _TypeDefinition.js_, `NavigationParams` should use a `mixed` type instead of `string`, since you may have a param with an integer, or an array for example.