### PR TITLE
Stack navigation actions are now idempotent.

### DIFF
--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -72,6 +72,8 @@ export default (
     paths[routeName] = { re, keys, toPath: pathToRegexp.compile(pathPattern) };
   });
 
+  let inProgressNavigationRouteName: ?string = null;
+
   return {
     getComponentForState(state: NavigationState): NavigationComponent {
       const activeChildRoute = state.routes[state.index];
@@ -110,6 +112,7 @@ export default (
             ],
           };
         }
+
         if (initialChildRouter) {
           route = initialChildRouter.getStateForAction(
             NavigationActions.navigate({
@@ -137,6 +140,16 @@ export default (
           routes: [route],
         };
       }
+
+      // Check if action wants to route to the route that is in-progress navigating
+      if (
+        inProgressNavigationRouteName !== null &&
+        inProgressNavigationRouteName === passedAction.routeName
+      ) {
+        inProgressNavigationRouteName = null;
+        return false;
+      }
+      inProgressNavigationRouteName = passedAction.routeName;
 
       // Check if a child scene wants to handle the action as long as it is not a reset to the root stack
       if (action.type !== NavigationActions.RESET || action.key !== null) {


### PR DESCRIPTION
Related issues: #135, #1532

The `StackNavigator` does not allow for idempotent pushes. If a user clicks on a component that fires a `navigation.navigate('OtherScreen')` many times from the current screen, the screen will navigate as many times to the screen as the user clicked. This means that the screen will be stacked upon itself a lot of times, so when the user clicks "Go Back", they will have to navigate back through the entire mess of a stack that they created.

![idempotent-pushes](https://cloud.githubusercontent.com/assets/11802078/26224762/7f737034-3be9-11e7-8f26-7a8b6040f603.gif)

Feel free to help me add tests to this to ensure that this always works. As you can see from my gif, it's working pretty great for me.
