### PR TITLE
Added tabStyle property

### DIFF
--- a/docs/api/navigators/TabNavigator.md
+++ b/docs/api/navigators/TabNavigator.md
@@ -104,6 +104,7 @@ Several options get passed to the underlying router to modify navigation logic:
 - `showLabel` - whether to show label for tab, default is true
 - `style` - style object for the tab bar
 - `labelStyle` - style object for the tab label
+- `tabStyle` - style object for the tab
 
 Example:
 
@@ -141,6 +142,9 @@ Example:
 tabBarOptions: {
   labelStyle: {
     fontSize: 12,
+  },
+  tabStyle: {
+    width: 100,    
   },
   style: {
     backgroundColor: 'blue',

--- a/src/views/TabView/TabBarBottom.js
+++ b/src/views/TabView/TabBarBottom.js
@@ -35,6 +35,7 @@ type Props = {
   showLabel: boolean,
   style?: Style,
   labelStyle?: Style,
+  tabStyle?: Style,
   showIcon: boolean,
 };
 
@@ -127,6 +128,7 @@ export default class TabBarBottom
       activeBackgroundColor,
       inactiveBackgroundColor,
       style,
+      tabStyle,
     } = this.props;
     const { routes } = navigation.state;
     // Prepend '-1', so there are always at least 2 items in inputRange
@@ -153,7 +155,11 @@ export default class TabBarBottom
               onPress={() => jumpToIndex(index)}
             >
               <Animated.View
-                style={[styles.tab, { backgroundColor, justifyContent }]}
+                style={[
+                  styles.tab,
+                  { backgroundColor, justifyContent },
+                  tabStyle,
+                ]}
               >
                 {this._renderIcon(scene)}
                 {this._renderLabel(scene)}


### PR DESCRIPTION
Adds tabStyle property for TabNavigator under tabBarOptions. Would close issue #1472.

#### Usage

```jsx
tabBarOptions: {
  activeTintColor: '#e91e63',
  labelStyle: {
    fontSize: 12,
  },
  tabStyle: {
    width: 100
  },
  style: {
    backgroundColor: 'blue',
  },
}

```


