### PR TITLE
Expose CardStackTransitioner as export (closes #1326)

### DIFF
--- a/src/react-navigation.js
+++ b/src/react-navigation.js
@@ -45,6 +45,9 @@ module.exports = {
   get Transitioner() {
     return require('./views/Transitioner').default;
   },
+  get CardStackTransitioner() {
+    return require('./views/CardStackTransitioner').default;
+  },
   get CardStack() {
     return require('./views/CardStack').default;
   },


### PR DESCRIPTION
(from #1326)
I prefer to use the transitioners and other components directly over using the helper functions since I want more fine tuned control over them.

Previously, I was using the CardStack component by itself, but within the last few betas a lot of its functionality has been moved to CardStackTransitioner and it now doesn't have much useful behavior by default. Currently the only normal way to get an instance of the component is by creating an entire StackNavigator.

I keep my router declarations separate, so the main issue I have against just using a StackNavigator instance is that I can't use an existing router instance.
