### PR TITLE
Correct sizing of header back button image on iOS

### DIFF
--- a/src/views/HeaderBackButton.js
+++ b/src/views/HeaderBackButton.js
@@ -118,8 +118,8 @@ const styles = StyleSheet.create({
   },
   icon: Platform.OS === 'ios'
     ? {
-        height: 20,
-        width: 12,
+        height: 21,
+        width: 13,
         marginLeft: 10,
         marginRight: 22,
         marginVertical: 12,


### PR DESCRIPTION
**Summary**

This fixes the slight blurring of the back icon in stack navigator on iOS due to a mismatch between absolute pixel sizes of the icon (and the `@2x`, `@3x`, etc) and the stylesheet width and height.

The alternative here would be to regenerate all the iOS icons at the correct resolution (20x12 @ 1x), but I believe @grabbou has the master file (7a20389e04a41de65e145a456c7dcacb787aad24).

**Test plan**

Before:
![simulator screen shot may 25 2017 10 30 37 am](https://cloud.githubusercontent.com/assets/189568/26462502/ef70235e-4135-11e7-91cc-7dc54178e892.png)

After:
![simulator screen shot may 25 2017 10 30 48 am](https://cloud.githubusercontent.com/assets/189568/26462509/f4c65710-4135-11e7-844a-acc1ca515161.png)
