### PR TITLE
Removed dependency on fbjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
   },
   "dependencies": {
     "clamp": "^1.0.1",
-    "fbjs": "^0.8.12",
     "hoist-non-react-statics": "^1.2.0",
     "path-to-regexp": "^1.7.0",
     "prop-types": "^15.5.10",

--- a/src/StateUtils.js
+++ b/src/StateUtils.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from './utils/invariant';
 
 import type { NavigationRoute, NavigationState } from './TypeDefinition';
 

--- a/src/createNavigationContainer.js
+++ b/src/createNavigationContainer.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import React from 'react';
-import invariant from 'fbjs/lib/invariant';
+import invariant from './utils/invariant';
 import { BackAndroid, Linking } from './PlatformHelpers';
 import NavigationActions from './NavigationActions';
 import addNavigationHelpers from './addNavigationHelpers';

--- a/src/routers/TabRouter.js
+++ b/src/routers/TabRouter.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from '../utils/invariant';
 import getScreenForRouteName from './getScreenForRouteName';
 import createConfigGetter from './createConfigGetter';
 

--- a/src/routers/createConfigGetter.js
+++ b/src/routers/createConfigGetter.js
@@ -2,7 +2,7 @@
  * @flow
  */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from '../utils/invariant';
 
 import getScreenForRouteName from './getScreenForRouteName';
 import addNavigationHelpers from '../addNavigationHelpers';

--- a/src/routers/getScreenConfigDeprecated.js
+++ b/src/routers/getScreenConfigDeprecated.js
@@ -1,7 +1,7 @@
 /*
  * @flow
  */
-import invariant from 'fbjs/lib/invariant';
+import invariant from '../utils/invariant';
 
 export default () =>
   invariant(

--- a/src/routers/getScreenForRouteName.js
+++ b/src/routers/getScreenForRouteName.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from '../utils/invariant';
 
 import type {
   NavigationComponent,

--- a/src/routers/validateRouteConfigMap.js
+++ b/src/routers/validateRouteConfigMap.js
@@ -1,6 +1,6 @@
 /** @flow */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from '../utils/invariant';
 
 import type { NavigationRouteConfigMap } from '../TypeDefinition';
 

--- a/src/routers/validateScreenOptions.js
+++ b/src/routers/validateScreenOptions.js
@@ -1,5 +1,5 @@
 /* @flow */
-import invariant from 'fbjs/lib/invariant';
+import invariant from '../utils/invariant';
 
 import type { NavigationRoute } from '../TypeDefinition';
 

--- a/src/utils/invariant.js
+++ b/src/utils/invariant.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule invariant
+ */
+
+'use strict';
+
+/**
+ * Use invariant() to assert state which your program assumes to be true.
+ *
+ * Provide sprintf-style format (only %s is supported) and arguments
+ * to provide information about what broke and what you were
+ * expecting.
+ *
+ * The invariant message will be stripped in production, but the invariant
+ * will remain to ensure logic does not differ in production.
+ */
+
+var validateFormat = function(format) {};
+
+if (__DEV__) {
+  validateFormat = function(format) {
+    if (format === undefined) {
+      throw new Error('invariant requires an error message argument');
+    }
+  };
+}
+
+function invariant(condition, format, a, b, c, d, e, f) {
+  validateFormat(format);
+
+  if (!condition) {
+    var error;
+    if (format === undefined) {
+      error = new Error(
+        'Minified exception occurred; use the non-minified dev environment for the full error message and additional helpful warnings.'
+      );
+    } else {
+      var args = [a, b, c, d, e, f];
+      var argIndex = 0;
+      error = new Error(
+        format.replace(/%s/g, function() {
+          return args[argIndex++];
+        })
+      );
+      error.name = 'Invariant Violation';
+    }
+
+    error.framesToPop = 1; // we don't care about invariant's own frame
+    throw error;
+  }
+}
+
+module.exports = invariant;

--- a/src/utils/shallowEqual.js
+++ b/src/utils/shallowEqual.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule shallowEqual
+ * @typechecks
+ * @flow
+ */
+
+/*eslint-disable no-self-compare */
+
+'use strict';
+
+const hasOwnProperty = Object.prototype.hasOwnProperty;
+
+/**
+ * inlined Object.is polyfill to avoid requiring consumers ship their own
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
+ */
+function is(x: mixed, y: mixed): boolean {
+  // SameValue algorithm
+  if (x === y) {
+    // Steps 1-5, 7-10
+    // Steps 6.b-6.e: +0 != -0
+    // Added the nonzero y check to make Flow happy, but it is redundant
+    return x !== 0 || y !== 0 || 1 / x === 1 / y;
+  } else {
+    // Step 6.a: NaN == NaN
+    return x !== x && y !== y;
+  }
+}
+
+/**
+ * Performs equality by iterating through keys on an object and returning false
+ * when any key has values which are not strictly equal between the arguments.
+ * Returns true when the values of all keys are strictly equal.
+ */
+function shallowEqual(objA: mixed, objB: mixed): boolean {
+  if (is(objA, objB)) {
+    return true;
+  }
+  if (
+    typeof objA !== 'object' ||
+    objA === null ||
+    typeof objB !== 'object' ||
+    objB === null
+  ) {
+    return false;
+  }
+
+  const keysA = Object.keys(objA);
+  const keysB = Object.keys(objB);
+
+  if (keysA.length !== keysB.length) {
+    return false;
+  }
+
+  // Test for A's keys different from B.
+  for (let i = 0; i < keysA.length; i++) {
+    if (
+      !hasOwnProperty.call(objB, keysA[i]) ||
+      !is(objA[keysA[i]], objB[keysA[i]])
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+module.exports = shallowEqual;

--- a/src/views/PointerEventsContainer.js
+++ b/src/views/PointerEventsContainer.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from '../utils/invariant';
 
 import AnimatedValueSubscription from './AnimatedValueSubscription';
 

--- a/src/views/ScenesReducer.js
+++ b/src/views/ScenesReducer.js
@@ -1,7 +1,7 @@
 /* @flow */
 
-import invariant from 'fbjs/lib/invariant';
-import shallowEqual from 'fbjs/lib/shallowEqual';
+import invariant from '../utils/invariant';
+import shallowEqual from '../utils/shallowEqual';
 
 import type {
   NavigationRoute,

--- a/src/views/Transitioner.js
+++ b/src/views/Transitioner.js
@@ -4,7 +4,7 @@ import React from 'react';
 
 import { Animated, StyleSheet, View } from 'react-native';
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from '../utils/invariant';
 
 import NavigationScenesReducer from './ScenesReducer';
 import TransitionConfigs from './TransitionConfigs';


### PR DESCRIPTION
fbjs is a big part of the dependencies of this project, as can be seen here:

```diff
├─┬ react-navigation@1.0.0-beta.10 invalid
│ ├── clamp@1.0.1 extraneous
+│ ├─┬ fbjs@0.8.12
+│ │ ├── core-js@1.2.7
+│ │ ├─┬ isomorphic-fetch@2.2.1
+│ │ │ ├── node-fetch@1.7.0 deduped
+│ │ │ └── whatwg-fetch@1.1.1 deduped
+│ │ ├── loose-envify@1.3.1 deduped
+│ │ ├── object-assign@4.1.1 deduped
+│ │ ├── promise@7.1.1 deduped
+│ │ ├── setimmediate@1.0.5
+│ │ └── ua-parser-js@0.7.12
│ ├── hoist-non-react-statics@1.2.0
│ ├── path-to-regexp@1.7.0 extraneous
│ ├── prop-types@15.5.10 deduped
│ ├── react-native-drawer-layout-polyfill@1.3.1 extraneous
│ └── react-native-tab-view@0.0.65 extraneous
```

It is required for only two small functions that can be easily incorporated into the source code of this project.

It also require `isomorphic-fetch` which, if inadvertently imported in a react-native project, will break the project.

![img_0011](https://cloud.githubusercontent.com/assets/671923/26516606/2a80ce4a-4257-11e7-9f2e-d001b221b317.PNG)

fbjs is also not recommended for use outside of Facebook's internal projects, as mentioned in it's README:

 > __Note:__ If you are consuming the code here and you are not also a Facebook project, be prepared for a bad time. APIs may appear or disappear and we may not follow semver strictly, though we will do our best to. This library is being published with our use cases in mind and is not necessarily meant to be consumed by the broader public. In order for us to move fast and ship projects like React and Relay, we've made the decision to not support everybody. We probably won't take your feature requests unless they align with our needs. There will be overlap in functionality here and in other open source projects.
