### PR TITLE
Upgrade React Native Tab View to v0.0.66

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "path-to-regexp": "^1.7.0",
     "prop-types": "^15.5.10",
     "react-native-drawer-layout-polyfill": "^1.3.0",
-    "react-native-tab-view": "^0.0.65"
+    "react-native-tab-view": "^0.0.66"
   },
   "jest": {
     "notify": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4074,9 +4074,9 @@ react-native-drawer-layout@1.3.0:
   dependencies:
     react-native-dismiss-keyboard "1.0.0"
 
-react-native-tab-view@^0.0.65:
-  version "0.0.65"
-  resolved "https://registry.yarnpkg.com/react-native-tab-view/-/react-native-tab-view-0.0.65.tgz#b685ea3081ff7c96486cd997361026c407302c59"
+react-native-tab-view@^0.0.66:
+  version "0.0.66"
+  resolved "https://registry.yarnpkg.com/react-native-tab-view/-/react-native-tab-view-0.0.66.tgz#681a91bf0e714de92bbd5255839fc096fcff4bb5"
   dependencies:
     prop-types "^15.5.8"
 


### PR DESCRIPTION
This adds 2 changes:

https://github.com/react-native-community/react-native-tab-view/commit/13243a2c6e048c73b089de63da58b7320fdb8bf0
https://github.com/react-native-community/react-native-tab-view/commit/27429c9fcc7b50598732c38062b2ead270f93618

I'm so stupid that this didn't occur to me earlier. This should now make it possible to absolutely position the tabs properly.

cc @skevy 