### PR TITLE
Update drawer layout polyfill to 1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "hoist-non-react-statics": "^1.2.0",
     "path-to-regexp": "^1.7.0",
     "prop-types": "^15.5.10",
-    "react-native-drawer-layout-polyfill": "^1.3.0",
+    "react-native-drawer-layout-polyfill": "^1.3.1",
     "react-native-tab-view": "^0.0.66"
   },
   "jest": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4062,15 +4062,15 @@ react-native-dismiss-keyboard@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/react-native-dismiss-keyboard/-/react-native-dismiss-keyboard-1.0.0.tgz#32886242b3f2317e121f3aeb9b0a585e2b879b49"
 
-react-native-drawer-layout-polyfill@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/react-native-drawer-layout-polyfill/-/react-native-drawer-layout-polyfill-1.3.0.tgz#50ea3f1dceed360b06f24a33b5ef3701d5c1417a"
+react-native-drawer-layout-polyfill@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/react-native-drawer-layout-polyfill/-/react-native-drawer-layout-polyfill-1.3.1.tgz#b514e34dec22c856b1e9e7253162e0af7d0eb4f0"
   dependencies:
-    react-native-drawer-layout "1.3.0"
+    react-native-drawer-layout "1.3.1"
 
-react-native-drawer-layout@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/react-native-drawer-layout/-/react-native-drawer-layout-1.3.0.tgz#3f9942c4c57e18bfe947a1a9b624365c91914280"
+react-native-drawer-layout@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/react-native-drawer-layout/-/react-native-drawer-layout-1.3.1.tgz#eb976df8fc43844811acebeed109029395406fe9"
   dependencies:
     react-native-dismiss-keyboard "1.0.0"
 


### PR DESCRIPTION
`react-native-drawer-layout-polyfill@1.3.1` fixes a bug which failed to clear interactions meaning that functions invoked through `InteractionManager.runAfterInteractions` were never called.

For this reason it is currently not possible to do the "render inexpensive component until navigation is done"-trick in a `DrawerNavigator`.

See [react-native-drawer-layout#16](https://github.com/react-native-community/react-native-drawer-layout/issues/16)

Moved from issue #1626
