### PR TITLE
Remove unused flow suppressions (Fixes #1671)

### DIFF
--- a/src/routers/__tests__/StackRouter-test.js
+++ b/src/routers/__tests__/StackRouter-test.js
@@ -752,7 +752,6 @@ describe('StackRouter', () => {
     expect(state2 && state2.routes[1].params).toEqual({ foo: '42' });
     /* $FlowFixMe */
     expect(state2 && state2.routes[1].routes).toEqual([
-      /* $FlowFixMe */
       expect.objectContaining({
         routeName: 'Baz',
         params: { foo: '42' },
@@ -819,7 +818,6 @@ describe('StackRouter', () => {
     }
     expect(state && state.index).toEqual(0);
     expect(state && state.routes[0]).toEqual(
-      // $FlowFixMe
       expect.objectContaining({
         routeName: 'Bar',
         type: undefined,


### PR DESCRIPTION
Simply removes the unused suppressions so flow works with the library.

Temporary workaround until this lands. In `.flowconfig`, add:
```
[ignore]
; Ignore issues with react-navigation
.*/node_modules/react-navigation/src/routers/__tests__/StackRouter-test.js
```

Fixes #1671