### PR TITLE
Fix back navigation in tabNavigator

### DIFF
--- a/src/views/TabView/TabView.js
+++ b/src/views/TabView/TabView.js
@@ -164,7 +164,7 @@ class TabView extends PureComponent<void, Props, void> {
       }
     }
 
-    if (animationEnabled === false && swipeEnabled === false) {
+    if (animationEnabled === false && swipeEnabled === false && tabBarVisible) {
       renderPager = this._renderPager;
     }
 


### PR DESCRIPTION
Fix #1398 

In `TabNavigator` when `tabBarVisible` is `false` the navigation back throw an error.