### PR TITLE
DrawerNav: don't push screen to stack if it's already focused

### DIFF
--- a/src/views/Drawer/DrawerSidebar.js
+++ b/src/views/Drawer/DrawerSidebar.js
@@ -75,9 +75,11 @@ class DrawerSidebar extends PureComponent<void, Props, void> {
     return null;
   };
 
-  _onItemPress = ({ route }: DrawerItem) => {
+  _onItemPress = ({ route, focused }: DrawerItem) => {
     this.props.navigation.navigate('DrawerClose');
-    this.props.navigation.navigate(route.routeName);
+    if (!focused) {
+      this.props.navigation.navigate(route.routeName);
+    }
   };
 
   render() {


### PR DESCRIPTION
Explain the **motivation** for making this change. What existing problem does the pull request solve?

Right now if same screen is opened from drawer multiple times, it'll push the screen to the stack every time. So navigating back will render the same screen over & over. This commit fixes that.

The issue was explained in a comment in here [https://github.com/react-community/react-navigation/issues/954#issuecomment-302872661](https://github.com/react-community/react-navigation/issues/954#issuecomment-302872661)

