### PR TITLE
pass screenProps to TabBarComponent

### DIFF
--- a/src/views/TabView/TabView.js
+++ b/src/views/TabView/TabView.js
@@ -121,6 +121,7 @@ class TabView extends PureComponent<void, Props, void> {
       <TabBarComponent
         {...props}
         {...tabBarOptions}
+        screenProps={this.props.screenProps}
         navigation={this.props.navigation}
         getLabel={this._getLabel}
         renderIcon={this._renderIcon}


### PR DESCRIPTION
To support for example filtering the tabs (like @satya164 suggested here: https://github.com/react-community/react-navigation/issues/717#issuecomment-287392565)  based on a property passed to a parent navigator, I need to have to access to the screenProps in the tab bar.