### PR TITLE
Use PropTypes from prop-types #1

### DIFF
--- a/examples/ReduxExample/src/components/LoginScreen.js
+++ b/examples/ReduxExample/src/components/LoginScreen.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Button, StyleSheet, Text, View } from 'react-native';
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
Remove warning from React about PropTypes, use prop-types instead