### PR TITLE
Reduce re-renders on header back button

### DIFF
--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -77,6 +77,10 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
       .headerTruncatedBackTitle;
   }
 
+  _navigateBack = () => {
+    this.props.navigation.goBack(null);
+  };
+
   _renderTitleComponent = (props: SceneProps) => {
     const details = this.props.getScreenDetails(props.scene);
     const headerTitle = details.options.headerTitle;
@@ -128,9 +132,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
       : undefined;
     return (
       <HeaderBackButton
-        onPress={() => {
-          this.props.navigation.goBack(null);
-        }}
+        onPress={this._navigateBack}
         pressColorAndroid={options.headerPressColorAndroid}
         tintColor={options.headerTintColor}
         title={backButtonTitle}


### PR DESCRIPTION
First PR related to [Improve performance for React Navigation](https://github.com/react-community/react-navigation/issues/1466)

Although the HeaderBackButton is a `PureComponent` - we are binding a new function on each re-render which still causes a rerender of HeaderBackButton