### PR TITLE
Use animatable text component for the header title

### DIFF
--- a/src/views/HeaderTitle.js
+++ b/src/views/HeaderTitle.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 
-import { Platform, StyleSheet, Text } from 'react-native';
+import { Platform, StyleSheet, Animated } from 'react-native';
 
 import type { Style } from '../TypeDefinition';
 
@@ -11,14 +11,13 @@ type Props = {
   style?: Style,
 };
 
-const HeaderTitle = ({ style, ...rest }: Props) => (
-  <Text
+const HeaderTitle = ({ style, ...rest }: Props) =>
+  <Animated.Text
     numberOfLines={1}
     {...rest}
     style={[styles.title, style]}
     accessibilityTraits="header"
-  />
-);
+  />;
 
 const styles = StyleSheet.create({
   title: {

--- a/src/views/HeaderTitle.js
+++ b/src/views/HeaderTitle.js
@@ -11,13 +11,14 @@ type Props = {
   style?: Style,
 };
 
-const HeaderTitle = ({ style, ...rest }: Props) =>
+const HeaderTitle = ({ style, ...rest }: Props) => (
   <Animated.Text
     numberOfLines={1}
     {...rest}
     style={[styles.title, style]}
     accessibilityTraits="header"
-  />;
+  />
+);
 
 const styles = StyleSheet.create({
   title: {


### PR DESCRIPTION
# Motivation
This PR replaces `Text` component by its animatable version `Animated.Text`.
Having an animatable component for the header title allows features like the change of header title opacity based on the scroll animation.

![auto-hiding-header](https://user-images.githubusercontent.com/5569608/27259357-8c610122-5411-11e7-9a56-34481c585d34.gif)
