### PR TITLE
prevent [goBack] to an empty route

### DIFF
--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -278,7 +278,7 @@ export default (
           /* $FlowFixMe */
           backRouteIndex = state.routes.indexOf(backRoute);
         }
-        if (backRouteIndex == null) {
+        if (backRouteIndex == null && state.routes.length > 0) {
           return StateUtils.pop(state);
         }
         if (backRouteIndex > 0) {


### PR DESCRIPTION
A StackNavigator with single screen do difference behave:

Don't work:
```
    const { goBack, state } = this.props.navigation;
    goBack(state.key);
```

Back to empty route (BUG):
```
    const { goBack, state } = this.props.navigation;
    goBack(null);
```
