### PR TITLE
ignore files starting with a dot

### DIFF
--- a/scripts/compile-docs.js
+++ b/scripts/compile-docs.js
@@ -9,7 +9,7 @@ function crawl(location) {
     var stat = fs.statSync(join(location, name));
     if (stat.isDirectory()) {
       crawl(join(location, name));
-    } else {
+    } else if (name[0] !== '.') {
       files.push(join(location, name));
     }
   });


### PR DESCRIPTION
macOS creates metadata files named `.DS_Store`. The script incorrect tries to read it with a `.md` extension.  By excluding all files that start with a dot we can prevent this.

Excerpt from the error:
```
Error: ENOENT: no such file or directory, open 'docs/.DS_Store.md'
    at Object.fs.openSync (fs.js:557:18)
    at Object.fs.readFileSync (fs.js:467:33)
```