### PR TITLE
Removed duplicate navigation flow annotation in CardStack

### DIFF
--- a/src/views/CardStack.js
+++ b/src/views/CardStack.js
@@ -42,7 +42,6 @@ type Props = {
   headerMode: HeaderMode,
   headerComponent?: ReactClass<*>,
   mode: 'card' | 'modal',
-  navigation: NavigationScreenProp<NavigationState, NavigationAction>,
   router: NavigationRouter<
     NavigationState,
     NavigationAction,


### PR DESCRIPTION
Very small pr, the flow annotation was also defined in the NavigationTransitionProps section on line 62. https://github.com/react-community/react-navigation/pull/1993/files#diff-1bb911cc75b3e921fd5d4db86802c58cL62