### PR TITLE
[BUGFIX] Use a proper source of headerBackTitle

### DIFF
--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -61,7 +61,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
     if (!lastScene) {
       return null;
     }
-    const { headerBackTitle } = this.props.getScreenDetails(lastScene).options;
+    const { headerBackTitle } = this.props.getScreenDetails(scene).options;
     if (headerBackTitle || headerBackTitle === null) {
       return headerBackTitle;
     }


### PR DESCRIPTION
**Motivation:**
If you have N screens in the stack (talking about StackNavigator), then back button on screen N will have a title of N - 1 screen. Although, there is a `navigationOptions.headerBackTitle` which is responsible for managing a back button title I've mentioned above. So this option doesn't really work well: currently, it takes `headerBackTitle` from the *previous* screen instead of a current one which doesn't make a lot of sense to me (and I assume is a bug). 

**Explanation:** 
Imagine you have a screen N, N->N1 & N->N2. On screen N1 I want to use a default behavior (show N title as a title of my back button), on screen N2 I want to remove back button's text. Thus, if I specify `headerBackTitle` on screen N (which is how it works at the moment), I won't be able to achieve this behavior.

**Solution:**
Replace `lastScene` by `scene` (that refers to the *current* scene)

cc @skevy 