### PR TITLE
Revert "[BUGFIX] Use a proper source of headerBackTitle"

### DIFF
--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -61,7 +61,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
     if (!lastScene) {
       return null;
     }
-    const { headerBackTitle } = this.props.getScreenDetails(scene).options;
+    const { headerBackTitle } = this.props.getScreenDetails(lastScene).options;
     if (headerBackTitle || headerBackTitle === null) {
       return headerBackTitle;
     }


### PR DESCRIPTION
Reverts react-community/react-navigation#2007

Unfortunately not the behavior we want. Going to go with an updated proposal in a follow up PR.