### PR TITLE
Throw error if route config path has leading slash symbol

### DIFF
--- a/docs/api/routers/StackRouter.md
+++ b/docs/api/routers/StackRouter.md
@@ -41,7 +41,7 @@ const MyApp = StackRouter({ // This is the RouteConfig:
 
 Each item in the config may have the following:
 
-- `path` - Specify the path (should not start with the "/" character) and params to be parsed for item in the stack
+- `path` - Specify the path and params to be parsed for an item in the stack. The path value should not start with the `/` character.
 - `screen` - Specify the screen component or child navigator
 - `getScreen` - Set a lazy getter for a screen component (but not navigators)
 

--- a/docs/api/routers/StackRouter.md
+++ b/docs/api/routers/StackRouter.md
@@ -41,7 +41,7 @@ const MyApp = StackRouter({ // This is the RouteConfig:
 
 Each item in the config may have the following:
 
-- `path` - Specify the path and params to be parsed for item in the stack
+- `path` - Specify the path (should not start with the "/" character) and params to be parsed for item in the stack
 - `screen` - Specify the screen component or child navigator
 - `getScreen` - Set a lazy getter for a screen component (but not navigators)
 

--- a/docs/api/routers/TabRouter.md
+++ b/docs/api/routers/TabRouter.md
@@ -37,7 +37,7 @@ const MyApp = TabRouter({ // This is the RouteConfig:
 
 Each item in the config may have the following:
 
-- `path` - Specify the path (should not start with the "/" character) for each tab
+- `path` - Specify the path for each tab. The path value should not start with the `/` character.
 - `screen` - Specify the screen component or child navigator
 - `getScreen` - Set a lazy getter for a screen component (but not navigators)
 

--- a/docs/api/routers/TabRouter.md
+++ b/docs/api/routers/TabRouter.md
@@ -37,7 +37,7 @@ const MyApp = TabRouter({ // This is the RouteConfig:
 
 Each item in the config may have the following:
 
-- `path` - Specify the path for each tab
+- `path` - Specify the path (should not start with the "/" character) for each tab
 - `screen` - Specify the screen component or child navigator
 - `getScreen` - Set a lazy getter for a screen component (but not navigators)
 

--- a/src/routers/__tests__/validateRouteConfigMap-test.js
+++ b/src/routers/__tests__/validateRouteConfigMap-test.js
@@ -39,6 +39,15 @@ describe('validateRouteConfigMap', () => {
     };
     expect(() => validateRouteConfigMap(invalidMap)).toThrow();
   });
+  test('Fails if path has a leading slash symbol', () => {
+    const invalidMap = {
+      Home: {
+        screen: ListScreen,
+        path: '/home'
+      }
+    };
+    expect(() => validateRouteConfigMap(invalidMap)).toThrow();
+  });
   test('Succeeds on a valid config', () => {
     const invalidMap = {
       Home: {

--- a/src/routers/__tests__/validateRouteConfigMap-test.js
+++ b/src/routers/__tests__/validateRouteConfigMap-test.js
@@ -43,8 +43,8 @@ describe('validateRouteConfigMap', () => {
     const invalidMap = {
       Home: {
         screen: ListScreen,
-        path: '/home'
-      }
+        path: '/home',
+      },
     };
     expect(() => validateRouteConfigMap(invalidMap)).toThrow();
   });

--- a/src/routers/validateRouteConfigMap.js
+++ b/src/routers/validateRouteConfigMap.js
@@ -55,6 +55,14 @@ function validateRouteConfigMap(routeConfigs: NavigationRouteConfigMap) {
           '}'
       );
     }
+
+    if (routeConfig.path) {
+      invariant(
+        routeConfig.path[0] !== '/',
+        `Invalid path '${routeConfig.path}' for route '${routeName}'. ` +
+          `Path should not start with the slash symbol`
+      );
+    }
   });
 }
 

--- a/src/routers/validateRouteConfigMap.js
+++ b/src/routers/validateRouteConfigMap.js
@@ -60,7 +60,7 @@ function validateRouteConfigMap(routeConfigs: NavigationRouteConfigMap) {
       invariant(
         routeConfig.path[0] !== '/',
         `Invalid path '${routeConfig.path}' for route '${routeName}'. ` +
-          `Path should not start with the slash symbol`
+          `Path should not start with the "/" character.`
       );
     }
   });


### PR DESCRIPTION
Fix for issue #1889 

Currently it is not obvious for developer that something has gone wrong if route config paths have leading slashes. With this fix, error is being thrown on validation of route configs.

Added new test to cover this case.