### PR TITLE
Typo

### DIFF
--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -94,7 +94,7 @@ Visual options:
 
 #### `title`
 
-String that can be used as a fallback for `headerTitle` and `tabBarLabel`
+String that can be used as a fallback for `headerTitle`
 
 #### `header`
 


### PR DESCRIPTION
There is no 'tabBarTitle' in a StackNavigator.
