### PR TITLE
Add prerelease versions of react 16 to package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "react-test-renderer": "^15.4.2"
   },
   "peerDependencies": {
-    "react": "*",
+    "react": "* || ^16.0.0-0",
     "react-native": "*"
   },
   "dependencies": {


### PR DESCRIPTION
This fixes #2133 by adding prerelease version of React to package.json.

**Test plan (required)**

No code changes made.