### PR TITLE
Fix custom `items` prop for DrawerItems

### DIFF
--- a/src/views/Drawer/DrawerSidebar.js
+++ b/src/views/Drawer/DrawerSidebar.js
@@ -98,7 +98,6 @@ class DrawerSidebar extends PureComponent<void, Props, void> {
     return (
       <View style={[styles.container, this.props.style]}>
         <ContentComponent
-          {...this.props.contentOptions}
           navigation={this.props.navigation}
           items={state.routes}
           activeItemKey={
@@ -109,6 +108,7 @@ class DrawerSidebar extends PureComponent<void, Props, void> {
           renderIcon={this._renderIcon}
           onItemPress={this._onItemPress}
           router={this.props.router}
+          {...this.props.contentOptions}
         />
       </View>
     );


### PR DESCRIPTION
## Motivation

The `items` prop was added in [this PR](https://github.com/react-community/react-navigation/pull/1039), but unfortunately it never actually worked due to being immediately overridden by `items={state.routes}`.

This fixes the prop by allowing everything specified in [`contentOptions`](https://reactnavigation.org/docs/navigators/drawer#contentOptions-for-DrawerItems) to override the default behavior.

## Test Plan

Try it out on the example app, e.g. in `Drawer.js`:

```js
    initialRouteName: 'Drafts',
    contentOptions: {
      items: [{
        key: 'Drafts',
        routeName: 'DraftsScreen',
      }],
    },
```