### PR TITLE
Syntax highlighting in first code block

### DIFF
--- a/docs/guides/Redux-Integration.md
+++ b/docs/guides/Redux-Integration.md
@@ -4,7 +4,7 @@ To handle your app's navigation state in redux, you can pass your own `navigatio
 
 With redux, your app's state is defined by a reducer. Each navigation router effectively has a reducer, called `getStateForAction`. The following is a minimal example of how you might use navigators within a redux application:
 
-```
+```javascript
 import { addNavigationHelpers } from 'react-navigation';
 
 const AppNavigator = StackNavigator(AppRouteConfigs);


### PR DESCRIPTION
Added markdown syntax highlighting to the first code block in this doc page. No code changes.