### PR TITLE
Allow transition configuration between tabs

### DIFF
--- a/docs/api/navigators/TabNavigator.md
+++ b/docs/api/navigators/TabNavigator.md
@@ -87,7 +87,7 @@ The route configs object is a mapping from route name to a route config, which t
 - `tabBarPosition` - Position of the tab bar, can be `'top'` or `'bottom'`.
 - `swipeEnabled` - Whether to allow swiping between tabs.
 - `animationEnabled` - Whether to animate when changing tabs.
-- `configureTransition` - a function that returns a configuration object that describes the animation between tabs.
+- `configureTransition` - a function that, given `currentTransitionProps` and `nextTransitionProps`, returns a configuration object that describes the animation between tabs.
 - `lazy` - Whether to lazily render tabs as needed as opposed to rendering them upfront.
 - `initialLayout` - Optional object containing the initial `height` and `width`, can be passed to prevent the one frame delay in [react-native-tab-view](https://github.com/react-native-community/react-native-tab-view#avoid-one-frame-delay) rendering.
 - `tabBarOptions` - Configure the tab bar, see below.

--- a/docs/api/navigators/TabNavigator.md
+++ b/docs/api/navigators/TabNavigator.md
@@ -87,6 +87,7 @@ The route configs object is a mapping from route name to a route config, which t
 - `tabBarPosition` - Position of the tab bar, can be `'top'` or `'bottom'`.
 - `swipeEnabled` - Whether to allow swiping between tabs.
 - `animationEnabled` - Whether to animate when changing tabs.
+- `configureTransition` - a function that returns a configuration object that describes the animation between tabs.
 - `lazy` - Whether to lazily render tabs as needed as opposed to rendering them upfront.
 - `initialLayout` - Optional object containing the initial `height` and `width`, can be passed to prevent the one frame delay in [react-native-tab-view](https://github.com/react-native-community/react-native-tab-view#avoid-one-frame-delay) rendering.
 - `tabBarOptions` - Configure the tab bar, see below.

--- a/examples/NavigationPlayground/js/App.js
+++ b/examples/NavigationPlayground/js/App.js
@@ -25,6 +25,7 @@ import StacksInTabs from './StacksInTabs';
 import StacksOverTabs from './StacksOverTabs';
 import SimpleStack from './SimpleStack';
 import SimpleTabs from './SimpleTabs';
+import TabAnimations from './TabAnimations';
 
 const ExampleRoutes = {
   SimpleStack: {
@@ -89,6 +90,11 @@ const ExampleRoutes = {
     description: 'Deep linking into a route in tab',
     screen: SimpleTabs,
     path: 'settings',
+  },
+  TabAnimations: {
+    name: 'Animated Tabs Example',
+    description: 'Tab transitions have custom animations',
+    screen: TabAnimations,
   },
 };
 

--- a/examples/NavigationPlayground/js/TabAnimations.js
+++ b/examples/NavigationPlayground/js/TabAnimations.js
@@ -1,0 +1,126 @@
+/**
+ * @flow
+ */
+
+import React from 'react';
+import { Button, ScrollView, Animated } from 'react-native';
+import { StackNavigator, TabNavigator } from 'react-navigation';
+
+import Ionicons from 'react-native-vector-icons/Ionicons';
+import SampleText from './SampleText';
+
+const MyNavScreen = ({ navigation, banner }) => (
+  <ScrollView>
+    <SampleText>{banner}</SampleText>
+    <Button
+      onPress={() => navigation.navigate('Profile', { name: 'Jordan' })}
+      title="Open profile screen"
+    />
+    <Button
+      onPress={() => navigation.navigate('NotifSettings')}
+      title="Open notifications screen"
+    />
+    <Button
+      onPress={() => navigation.navigate('SettingsTab')}
+      title="Go to settings tab"
+    />
+    <Button onPress={() => navigation.goBack(null)} title="Go back" />
+  </ScrollView>
+);
+
+const MyHomeScreen = ({ navigation }) => (
+  <MyNavScreen banner="Home Screen" navigation={navigation} />
+);
+
+const MyProfileScreen = ({ navigation }) => (
+  <MyNavScreen
+    banner={`${navigation.state.params.name}s Profile`}
+    navigation={navigation}
+  />
+);
+
+const MyNotificationsSettingsScreen = ({ navigation }) => (
+  <MyNavScreen banner="Notifications Screen" navigation={navigation} />
+);
+
+const MySettingsScreen = ({ navigation }) => (
+  <MyNavScreen banner="Settings Screen" navigation={navigation} />
+);
+
+const MainTab = StackNavigator({
+  Home: {
+    screen: MyHomeScreen,
+    path: '/',
+    navigationOptions: {
+      title: 'Welcome',
+    },
+  },
+  Profile: {
+    screen: MyProfileScreen,
+    path: '/people/:name',
+    navigationOptions: ({ navigation }) => ({
+      title: `${navigation.state.params.name}'s Profile!`,
+    }),
+  },
+});
+
+const SettingsTab = StackNavigator({
+  Settings: {
+    screen: MySettingsScreen,
+    path: '/',
+    navigationOptions: () => ({
+      title: 'Settings',
+    }),
+  },
+  NotifSettings: {
+    screen: MyNotificationsSettingsScreen,
+    navigationOptions: {
+      title: 'Notifications',
+    },
+  },
+});
+
+const TabAnimations = TabNavigator(
+  {
+    MainTab: {
+      screen: MainTab,
+      path: '/',
+      navigationOptions: {
+        tabBarLabel: 'Home',
+        tabBarIcon: ({ tintColor, focused }) => (
+          <Ionicons
+            name={focused ? 'ios-home' : 'ios-home-outline'}
+            size={26}
+            style={{ color: tintColor }}
+          />
+        ),
+      },
+    },
+    SettingsTab: {
+      screen: SettingsTab,
+      path: '/settings',
+      navigationOptions: {
+        tabBarLabel: 'Settings',
+        tabBarIcon: ({ tintColor, focused }) => (
+          <Ionicons
+            name={focused ? 'ios-settings' : 'ios-settings-outline'}
+            size={26}
+            style={{ color: tintColor }}
+          />
+        ),
+      },
+    },
+  },
+  {
+    tabBarPosition: 'bottom',
+    animationEnabled: true,
+    configureTransition: (currentTransitionProps,nextTransitionProps) => ({
+      timing: Animated.spring,
+      tension: 300,
+      friction: 35,
+    }),
+    swipeEnabled: false,
+  }
+);
+
+export default TabAnimations;

--- a/examples/NavigationPlayground/js/TabAnimations.js
+++ b/examples/NavigationPlayground/js/TabAnimations.js
@@ -116,7 +116,7 @@ const TabAnimations = TabNavigator(
     animationEnabled: true,
     configureTransition: (currentTransitionProps,nextTransitionProps) => ({
       timing: Animated.spring,
-      tension: 300,
+      tension: 1,
       friction: 35,
     }),
     swipeEnabled: false,

--- a/src/navigators/TabNavigator.js
+++ b/src/navigators/TabNavigator.js
@@ -48,6 +48,7 @@ const TabNavigator = (
     tabBarOptions,
     swipeEnabled,
     animationEnabled,
+    configureTransition,
     lazy,
     initialLayout,
     ...tabsConfig
@@ -68,6 +69,7 @@ const TabNavigator = (
       tabBarOptions={tabBarOptions}
       swipeEnabled={swipeEnabled}
       animationEnabled={animationEnabled}
+      configureTransition={configureTransition}
       lazy={lazy}
       initialLayout={initialLayout}
     />

--- a/src/views/TabView/TabView.js
+++ b/src/views/TabView/TabView.js
@@ -143,7 +143,6 @@ class TabView extends React.PureComponent<Props> {
       tabBarOptions,
       tabBarComponent: TabBarComponent,
       animationEnabled,
-      configureTransition,
     } = this.props;
     if (typeof TabBarComponent === 'undefined') {
       return null;
@@ -159,7 +158,6 @@ class TabView extends React.PureComponent<Props> {
         getOnPress={this._getOnPress}
         renderIcon={this._renderIcon}
         animationEnabled={animationEnabled}
-        configureTransition={configureTransition}
       />
     );
   };

--- a/src/views/TabView/TabView.js
+++ b/src/views/TabView/TabView.js
@@ -22,6 +22,10 @@ export type TabViewConfig = {
   tabBarOptions?: {},
   swipeEnabled?: boolean,
   animationEnabled?: boolean,
+  configureTransition?: (
+    currentTransitionProps: Object,
+    nextTransitionProps: Object
+  ) => Object,
   lazy?: boolean,
   initialLayout?: Layout,
 };
@@ -39,6 +43,10 @@ type Props = {
   tabBarOptions?: {},
   swipeEnabled?: boolean,
   animationEnabled?: boolean,
+  configureTransition?: (
+    currentTransitionProps: Object,
+    nextTransitionProps: Object
+  ) => Object,
   lazy?: boolean,
   initialLayout: Layout,
 
@@ -135,6 +143,7 @@ class TabView extends React.PureComponent<Props> {
       tabBarOptions,
       tabBarComponent: TabBarComponent,
       animationEnabled,
+      configureTransition,
     } = this.props;
     if (typeof TabBarComponent === 'undefined') {
       return null;
@@ -150,6 +159,7 @@ class TabView extends React.PureComponent<Props> {
         getOnPress={this._getOnPress}
         renderIcon={this._renderIcon}
         animationEnabled={animationEnabled}
+        configureTransition={configureTransition}
       />
     );
   };
@@ -162,6 +172,7 @@ class TabView extends React.PureComponent<Props> {
       tabBarComponent,
       tabBarPosition,
       animationEnabled,
+      configureTransition,
       swipeEnabled,
       lazy,
       initialLayout,
@@ -189,7 +200,10 @@ class TabView extends React.PureComponent<Props> {
       }
     }
 
-    if (animationEnabled === false && swipeEnabled === false) {
+    if (
+      (animationEnabled === false && swipeEnabled === false) ||
+      typeof configureTransition === 'function'
+    ) {
       renderPager = this._renderPager;
     }
 
@@ -197,6 +211,7 @@ class TabView extends React.PureComponent<Props> {
       lazy,
       initialLayout,
       animationEnabled,
+      configureTransition,
       swipeEnabled,
       renderPager,
       renderHeader,


### PR DESCRIPTION
**Motivation**
This is in response to https://github.com/react-community/react-navigation/issues/2202 .

This change is needed to allow the `configureTransition` option for `TabViewAnimated` to be passed through. This opens up the opportunity to customize the animation when switching between tabs. 

NOTE: I'm not sure why [this clause](https://github.com/react-community/react-navigation/compare/master...davidtrogers:master#diff-6f52f52094e1001dd754981e92d9f933L167) is needed but I left it in place so as to not cause a regression. If `renderPager` isn't passed in to `TabViewAnimated` then it will default to [`TabViewPagerScroll`](https://github.com/react-native-community/react-native-tab-view#tabviewpagerscroll-) (iOS) or [`TabViewPagerAndroid`](https://github.com/react-native-community/react-native-tab-view#tabviewpagerandroid-), neither of which allow customizable animations.

**Test plan (required)**

Here is the [NavigationPlayground expo project](https://expo.io/@davidtrogers/NavigationPlayground) with an added example for animated tabs, using `configureTransition`.

