### PR TITLE
Add flex:1 to show MainScreenNavigator in Guide-Nested.md

### DIFF
--- a/docs/guides/Guide-Nested.md
+++ b/docs/guides/Guide-Nested.md
@@ -88,7 +88,7 @@ In this case, the NavigatorWrappingScreen is not a navigator, but it renders a n
 class NavigatorWrappingScreen extends React.Component {
   render() {
     return (
-      <View>
+      <View style={{flex: 1}}>
         <SomeComponent/>
         <MainScreenNavigator/>
       </View>


### PR DESCRIPTION
NavigatorWrappingScreen is not displayed without flex.
