### PR TITLE
Update wrong URLs on the docs

### DIFF
--- a/docs/api/views/Views.md
+++ b/docs/api/views/Views.md
@@ -6,9 +6,9 @@ Navigation views are controlled React components that can present the current na
 
 ## Built in Views
 
-- [CardStack](https://github.com/react-community/react-navigation/blob/master/src/views/CardStack.js) - Present a stack that looks suitable on any platform
-    + [Card](https://github.com/react-community/react-navigation/blob/master/src/views/Card.js) - Present one card from the card stack, with gestures
-    + [Header](https://github.com/react-community/react-navigation/blob/master/src/views/Header.js) - The header view for the card stack
+- [CardStack](https://github.com/react-community/react-navigation/blob/master/src/views/CardStack/CardStack.js) - Present a stack that looks suitable on any platform
+    + [Card](https://github.com/react-community/react-navigation/blob/master/src/views/CardStack/Card.js) - Present one card from the card stack, with gestures
+    + [Header](https://github.com/react-community/react-navigation/blob/master/src/views/Header/Header.js) - The header view for the card stack
 - [Tabs](https://github.com/react-community/react-navigation/blob/master/src/views/TabView) - A configurable tab switcher / pager
 - [Drawer](https://github.com/react-community/react-navigation/tree/master/src/views/Drawer) - A view with a drawer that slides from the left
 

--- a/docs/api/views/Views.md
+++ b/docs/api/views/Views.md
@@ -6,11 +6,11 @@ Navigation views are controlled React components that can present the current na
 
 ## Built in Views
 
-- [CardStack](https://github.com/react-community/react-navigation/blob/master/src/views/CardStack) - Present a stack that looks suitable on any platform
+- [CardStack](https://github.com/react-community/react-navigation/blob/master/src/views/CardStack/CardStack.js) - Present a stack that looks suitable on any platform
     + [Card](https://github.com/react-community/react-navigation/blob/master/src/views/CardStack/Card.js) - Present one card from the card stack, with gestures
-- [Header](https://github.com/react-community/react-navigation/blob/master/src/views/Header) - The header view for the card stack
-- [Tabs](https://github.com/react-community/react-navigation/blob/master/src/views/TabView) - A configurable tab switcher / pager
-- [Drawer](https://github.com/react-community/react-navigation/tree/master/src/views/Drawer) - A view with a drawer that slides from the left
+- [Header](https://github.com/react-community/react-navigation/blob/master/src/views/Header/Header.js) - The header view for the card stack
+- [Tabs](https://github.com/react-community/react-navigation/blob/master/src/views/TabView/TabView.js) - A configurable tab switcher / pager
+- [Drawer](https://github.com/react-community/react-navigation/blob/master/src/views/Drawer/DrawerView.js) - A view with a drawer that slides from the left
 
 ## [Transitioner](/docs/views/transitioner)
 

--- a/docs/api/views/Views.md
+++ b/docs/api/views/Views.md
@@ -6,9 +6,9 @@ Navigation views are controlled React components that can present the current na
 
 ## Built in Views
 
-- [CardStack](https://github.com/react-community/react-navigation/blob/master/src/views/CardStack/CardStack.js) - Present a stack that looks suitable on any platform
+- [CardStack](https://github.com/react-community/react-navigation/blob/master/src/views/CardStack) - Present a stack that looks suitable on any platform
     + [Card](https://github.com/react-community/react-navigation/blob/master/src/views/CardStack/Card.js) - Present one card from the card stack, with gestures
-    + [Header](https://github.com/react-community/react-navigation/blob/master/src/views/Header/Header.js) - The header view for the card stack
+- [Header](https://github.com/react-community/react-navigation/blob/master/src/views/Header) - The header view for the card stack
 - [Tabs](https://github.com/react-community/react-navigation/blob/master/src/views/TabView) - A configurable tab switcher / pager
 - [Drawer](https://github.com/react-community/react-navigation/tree/master/src/views/Drawer) - A view with a drawer that slides from the left
 


### PR DESCRIPTION
Some of the links and the markdown structure at the Views' page are wrong (https://reactnavigation.org/docs/views/). This PR update and fix the missing links to the doc.