### PR TITLE
Add toString() with type for each NavigationAction

### DIFF
--- a/docs/guides/Navigation-Actions.md
+++ b/docs/guides/Navigation-Actions.md
@@ -11,6 +11,8 @@ The following actions are supported:
 * [Set Params](#SetParams) - Set Params for given route
 * [Init](#Init) - Used to initialize first state if state is undefined
 
+The action creator functions define `toString()` to return the action type, which enables easy usage with third-party Redux libraries, including redux-actions and redux-saga.
+
 ### Navigate
 The `Navigate` action will update the current state with the result of a `Navigate` action.
 

--- a/src/NavigationActions.js
+++ b/src/NavigationActions.js
@@ -22,60 +22,81 @@ const RESET = 'Navigation/RESET';
 const SET_PARAMS = 'Navigation/SET_PARAMS';
 const URI = 'Navigation/URI';
 
-const back = (payload: { key?: ?string } = {}): NavigationBackAction => ({
-  type: BACK,
-  key: payload.key,
-});
-const init = (
-  payload: { params?: NavigationParams } = {}
-): NavigationInitAction => {
-  const action: NavigationInitAction = {
-    type: INIT,
-  };
-  if (payload.params) {
-    action.params = payload.params;
-  }
-  return action;
+const createAction = (type: string, fn: any) => {
+  fn.toString = () => type;
+  return fn;
 };
-const navigate = (payload: {
-  routeName: string,
-  params?: ?NavigationParams,
-  action?: ?NavigationNavigateAction,
-}): NavigationNavigateAction => {
-  const action: NavigationNavigateAction = {
-    type: NAVIGATE,
-    routeName: payload.routeName,
-  };
-  if (payload.params) {
-    action.params = payload.params;
+
+const back = createAction(
+  BACK,
+  (payload: { key?: ?string } = {}): NavigationBackAction => ({
+    type: BACK,
+    key: payload.key,
+  })
+);
+const init = createAction(
+  INIT,
+  (payload: { params?: NavigationParams } = {}): NavigationInitAction => {
+    const action: NavigationInitAction = {
+      type: INIT,
+    };
+    if (payload.params) {
+      action.params = payload.params;
+    }
+    return action;
   }
-  if (payload.action) {
-    action.action = payload.action;
+);
+const navigate = createAction(
+  NAVIGATE,
+  (payload: {
+    routeName: string,
+    params?: ?NavigationParams,
+    action?: ?NavigationNavigateAction,
+  }): NavigationNavigateAction => {
+    const action: NavigationNavigateAction = {
+      type: NAVIGATE,
+      routeName: payload.routeName,
+    };
+    if (payload.params) {
+      action.params = payload.params;
+    }
+    if (payload.action) {
+      action.action = payload.action;
+    }
+    return action;
   }
-  return action;
-};
-const reset = (payload: {
-  index: number,
-  key?: ?string,
-  actions: Array<NavigationNavigateAction>,
-}): NavigationResetAction => ({
-  type: RESET,
-  index: payload.index,
-  key: payload.key,
-  actions: payload.actions,
-});
-const setParams = (payload: {
-  key: string,
-  params: NavigationParams,
-}): NavigationSetParamsAction => ({
-  type: SET_PARAMS,
-  key: payload.key,
-  params: payload.params,
-});
-const uri = (payload: { uri: string }): NavigationUriAction => ({
-  type: URI,
-  uri: payload.uri,
-});
+);
+const reset = createAction(
+  RESET,
+  (payload: {
+    index: number,
+    key?: ?string,
+    actions: Array<NavigationNavigateAction>,
+  }): NavigationResetAction => ({
+    type: RESET,
+    index: payload.index,
+    key: payload.key,
+    actions: payload.actions,
+  })
+);
+const setParams = createAction(
+  SET_PARAMS,
+  (payload: {
+    key: string,
+    params: NavigationParams,
+  }): NavigationSetParamsAction => ({
+    type: SET_PARAMS,
+    key: payload.key,
+    params: payload.params,
+  })
+);
+const uri = createAction(
+  URI,
+  (payload: { uri: string }): NavigationUriAction => ({
+    type: URI,
+    uri: payload.uri,
+  })
+);
 
 const mapDeprecatedNavigateAction = (
   action: NavigationNavigateAction | DeprecatedNavigationNavigateAction

--- a/src/__tests__/NavigationActions-test.js
+++ b/src/__tests__/NavigationActions-test.js
@@ -7,6 +7,7 @@ describe('actions', () => {
   const navigateAction = NavigationActions.navigate({ routeName: 'another' });
 
   it('exports back action and type', () => {
+    expect(NavigationActions.back.toString()).toEqual(NavigationActions.BACK);
     expect(NavigationActions.back()).toEqual({ type: NavigationActions.BACK });
     expect(NavigationActions.back({ key: 'test' })).toEqual({
       type: NavigationActions.BACK,
@@ -15,6 +16,7 @@ describe('actions', () => {
   });
 
   it('exports init action and type', () => {
+    expect(NavigationActions.init.toString()).toEqual(NavigationActions.INIT);
     expect(NavigationActions.init()).toEqual({ type: NavigationActions.INIT });
     expect(NavigationActions.init({ params })).toEqual({
       type: NavigationActions.INIT,
@@ -23,6 +25,9 @@ describe('actions', () => {
   });
 
   it('exports navigate action and type', () => {
+    expect(NavigationActions.navigate.toString()).toEqual(
+      NavigationActions.NAVIGATE
+    );
     expect(NavigationActions.navigate({ routeName: 'test' })).toEqual({
       type: NavigationActions.NAVIGATE,
       routeName: 'test',
@@ -45,6 +50,7 @@ describe('actions', () => {
   });
 
   it('exports reset action and type', () => {
+    expect(NavigationActions.reset.toString()).toEqual(NavigationActions.RESET);
     expect(NavigationActions.reset({ index: 0, actions: [] })).toEqual({
       type: NavigationActions.RESET,
       index: 0,
@@ -70,6 +76,9 @@ describe('actions', () => {
   });
 
   it('exports setParams action and type', () => {
+    expect(NavigationActions.setParams.toString()).toEqual(
+      NavigationActions.SET_PARAMS
+    );
     expect(
       NavigationActions.setParams({
         key: 'test',
@@ -83,6 +92,7 @@ describe('actions', () => {
   });
 
   it('exports uri action and type', () => {
+    expect(NavigationActions.uri.toString()).toEqual(NavigationActions.URI);
     expect(NavigationActions.uri({ uri: 'http://google.com' })).toEqual({
       type: NavigationActions.URI,
       uri: 'http://google.com',


### PR DESCRIPTION
There's a [growing](https://github.com/redux-saga/redux-saga/issues/732) [trend](https://github.com/reactjs/redux/issues/628#issuecomment-135077511) of defining a custom `toString` to return the type of a given action creator function. This is a convenience that alleviates the need to import both an action creator and type constant.

This simple PR adds a custom `toString` to the action creator factory, and adds basic tests to avoid regressing this behavior in the future.