### PR TITLE
Fix ActiveScreen in custom navigation

### DIFF
--- a/examples/NavigationPlayground/js/CustomTabs.js
+++ b/examples/NavigationPlayground/js/CustomTabs.js
@@ -63,7 +63,7 @@ const CustomTabBar = ({ navigation }) => {
 
 const CustomTabView = ({ router, navigation }) => {
   const { routes, index } = navigation.state;
-  const ActiveScreen = router.getComponentForState(navigation.state);
+  const ActiveScreen = router.getComponentForRouteName(routes[index].routeName);
   return (
     <View style={styles.container}>
       <CustomTabBar navigation={navigation} />


### PR DESCRIPTION
The way as it was before was good, but when there are another Navigations, such as TabNavigation, inside this TabNavigation. The entire nested navigation won't get rendered.

I was sitting here for hours in the source code, but this finally made the move.