### PR TITLE
HeaderTitle - wrap non-text titles in a View (Android fix)

### DIFF
--- a/src/views/Header/HeaderTitle.js
+++ b/src/views/Header/HeaderTitle.js
@@ -16,14 +16,25 @@ type Props = {
 };
 
 const AnimatedText = Animated.Text;
+const AnimatedView = Animated.View;
 
-const HeaderTitle = ({ style, ...rest }: Props) =>
-  <AnimatedText
-    numberOfLines={1}
-    {...rest}
-    style={[styles.title, style]}
-    accessibilityTraits="header"
-  />;
+const HeaderTitle = ({ style, ...rest }: Props) => {
+  if (typeof rest.children == 'text') {
+    return <AnimatedText
+      numberOfLines={1}
+      {...rest}
+      style={[styles.title, style]}
+      accessibilityTraits="header"
+    />;
+  }
+  else {
+    return <AnimatedView
+      {...rest}
+      style={[style]}
+      accessibilityTraits="header"
+    />;
+  }
+}
 
 const styles = StyleSheet.create({
   title: {


### PR DESCRIPTION
Embedding a View inside a Text isn't supported in Android
