### PR TITLE
Feature/toggle

### DIFF
--- a/docs/api/navigators/DrawerNavigator.md
+++ b/docs/api/navigators/DrawerNavigator.md
@@ -68,6 +68,12 @@ To open and close drawer, navigate to `'DrawerOpen'` and `'DrawerClose'` respect
 this.props.navigation.navigate('DrawerOpen'); // open drawer
 this.props.navigation.navigate('DrawerClose'); // close drawer
 ```
+If you would like to toggle the drawer you can navigate to `'DrawerToggle'`, and this will choose which navigation is appropriate for you given the drawers current state.
+
+```js
+// fires 'DrawerOpen'/'DrawerClose' accordingly
+this.props.navigation.navigate('DrawerToggle');
+```
 
 ## API Definition
 
@@ -181,7 +187,7 @@ The navigator component created by `DrawerNavigator(...)` takes the following pr
    screenProps={/* this prop will get passed to the screen components and nav options as props.screenProps */}
  />
  ```
- 
+
  ### Nesting `DrawerNavigation`
- 
+
 Please bear in mind that if you nest the DrawerNavigation, the drawer will show below the parent navigation.

--- a/src/navigators/DrawerNavigator.js
+++ b/src/navigators/DrawerNavigator.js
@@ -63,6 +63,9 @@ const DrawerNavigator = (
       DrawerOpen: {
         screen: () => null,
       },
+      DrawerToggle: {
+        screen: () => null,
+      },
     },
     {
       initialRouteName: 'DrawerClose',

--- a/src/views/Drawer/DrawerView.js
+++ b/src/views/Drawer/DrawerView.js
@@ -63,6 +63,12 @@ export default class DrawerView<T: *> extends PureComponent<void, Props, void> {
       const { routes, index } = nextProps.navigation.state;
       if (routes[index].routeName === 'DrawerOpen') {
         this._drawer.openDrawer();
+      } else if (routes[index].routeName === 'DrawerToggle') {
+        if (this._drawer.state.drawerShown) {
+          this.props.navigation.navigate('DrawerClose');
+        } else {
+          this.props.navigation.navigate('DrawerOpen');
+        }
       } else {
         this._drawer.closeDrawer();
       }


### PR DESCRIPTION
Every drawer menu needs a toggle. Especially when navigating to a drawer 'DrawerOpen' twice can cause bugs/issues.  **To solve this currently** everyone needs to know about drawer state and structure, which causes code to look like so:

```js
    headerLeft: <Text onPress={() => {
      if (navigation.state.index === 0) {
        navigation.navigate('DrawerOpen')
      } else {
        navigation.navigate('DrawerClose')
      }
    }}>
      Toggle Drawer
    </Text>
```

This is not readable or future-proof.  Instead toggle should be a first class citizen of drawers.
```js
    headerLeft: <Text onPress={() => navigation.navigate('DrawerToggle')}/>
        Toggle Drawer
    </Text>
```

That is what this PR includes.  Also updates docs.

