### PR TITLE
Use react-native-config to read the REACT_NAV_LOGGING environment variable when running in React Native

### DIFF
--- a/docs/api/navigators/Navigators.md
+++ b/docs/api/navigators/Navigators.md
@@ -22,7 +22,7 @@ To learn how to create screens, read about:
 
 ### Calling Navigate on Top Level Component
 
-In case you want to use Navigator from the same level you declare it you can use react's [`ref`](https://facebook.github.io/react/docs/refs-and-the-dom.html#the-ref-callback-attribute) option:  
+In case you want to use Navigator from the same level you declare it you can use react's [`ref`](https://facebook.github.io/react/docs/refs-and-the-dom.html#the-ref-callback-attribute) option:
 ```js
 const AppNavigator = StackNavigator(SomeAppRouteConfigs);
 
@@ -38,7 +38,7 @@ class App extends React.Component {
   }
 }
 ```
-Please notice that this solution should only be used on the top level navigator.  
+Please notice that this solution should only be used on the top level navigator.
 
 ## Navigation Containers
 
@@ -48,11 +48,11 @@ When rendering one of the included navigators, the navigation prop is optional. 
 
 For the purpose of convenience, the built-in navigators have this ability because behind the scenes they use `createNavigationContainer`. Usually, navigators require a navigation prop in order to function.
 
-Top-level navigators accept the following props:  
+Top-level navigators accept the following props:
 
 ### `onNavigationStateChange(prevState, newState, action)`
 
-Function that gets called every time navigation state managed by the navigator changes. It receives the previous state, the new state of the navigation and the action that issued state change. By default it prints state changes to the console.
+Function that gets called every time navigation state managed by the navigator changes. It receives the previous state, the new state of the navigation and the action that issued state change. By default it prints state changes to the console if the `REACT_NAV_LOGGING` environment variable is set.
 
 ### `uriPrefix`
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "hoist-non-react-statics": "^2.2.0",
     "path-to-regexp": "^1.7.0",
     "prop-types": "^15.5.10",
+    "react-native-config": "^0.6.0",
     "react-native-drawer-layout-polyfill": "^1.3.2",
     "react-native-tab-view": "^0.0.67"
   },

--- a/src/PlatformHelpers.native.js
+++ b/src/PlatformHelpers.native.js
@@ -5,7 +5,9 @@ import {
   BackHandler as ModernBackHandler,
   Linking,
 } from 'react-native';
+import Config from 'react-native-config';
 
 const BackHandler = ModernBackHandler || DeprecatedBackAndroid;
+const isLoggingEnabled = !!Config.REACT_NAV_LOGGING;
 
-export { BackHandler, Linking };
+export { BackHandler, Linking, isLoggingEnabled };

--- a/src/PlatformHelpers.web.js
+++ b/src/PlatformHelpers.web.js
@@ -9,3 +9,5 @@ export const Linking = {
 export const BackHandler = {
   addEventListener: () => {},
 };
+
+export const isLoggingEnabled = !!process.env.REACT_NAV_LOGGING;

--- a/src/createNavigationContainer.js
+++ b/src/createNavigationContainer.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import invariant from './utils/invariant';
-import { BackHandler, Linking } from './PlatformHelpers';
+import { BackHandler, Linking, isLoggingEnabled } from './PlatformHelpers';
 import NavigationActions from './NavigationActions';
 import addNavigationHelpers from './addNavigationHelpers';
 
@@ -117,7 +117,7 @@ export default function createNavigationContainer<S: *, O>(
       if (
         typeof this.props.onNavigationStateChange === 'undefined' &&
         this._isStateful() &&
-        !!process.env.REACT_NAV_LOGGING
+        isLoggingEnabled
       ) {
         /* eslint-disable no-console */
         if (console.group) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4283,6 +4283,10 @@ react-devtools-core@^2.1.8:
     shell-quote "^1.6.1"
     ws "^2.0.3"
 
+react-native-config@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/react-native-config/-/react-native-config-0.6.0.tgz#0f71631ab5ac4b568637dcb8e9f6ab85ffb380ed"
+
 react-native-dismiss-keyboard@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/react-native-dismiss-keyboard/-/react-native-dismiss-keyboard-1.0.0.tgz#32886242b3f2317e121f3aeb9b0a585e2b879b49"


### PR DESCRIPTION
## Issue

Navigation state changes aren't logged when running on native.

## Cause

The conditional for enabling logging was using `process.env.REACT_NAV_LOGGING` which can't be set on native platforms. `process.env` will only ever contain `NODE_ENV`.

## Fix

The community accepted method of using environment variables in React Native is to use [`react-native-config`](https://github.com/luggit/react-native-config). This pull request adds `react-native-config` as a dependency and uses it only on native platforms, web will still use `process.env`.

I've also updated the docs to give some indication that this environment variable exists and needs to be set in order to enable logging.