### PR TITLE
Allow action in navigate to determine tab position

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "path-to-regexp": "^1.7.0",
     "prop-types": "^15.5.10",
     "react-native-drawer-layout-polyfill": "^1.3.2",
-    "react-native-tab-view": "^0.0.69"
+    "react-native-tab-view": "momoDeako/react-native-tab-view"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/src/routers/TabRouter.js
+++ b/src/routers/TabRouter.js
@@ -141,6 +141,12 @@ export default (
       if (action.type === NavigationActions.NAVIGATE) {
         const navigateAction = ((action: *): NavigationNavigateAction);
         didNavigate = !!order.find((tabId: string, i: number) => {
+          if (navigateAction.action && navigateAction.action.routeName) {
+            if (tabId == navigateAction.action.routeName) {
+              activeTabIndex = i;
+              return true;
+            }
+          }
           if (tabId === navigateAction.routeName) {
             activeTabIndex = i;
             return true;

--- a/src/views/TabView/TabBarTop.js
+++ b/src/views/TabView/TabBarTop.js
@@ -31,6 +31,7 @@ type Props = {
   upperCaseLabel: boolean,
   position: Animated.Value,
   navigation: NavigationScreenProp<NavigationState, NavigationAction>,
+  getAccessibility: (scene: TabScene) => ?(React.Element<*> | string),
   getLabel: (scene: TabScene) => ?(React.Element<*> | string),
   renderIcon: (scene: TabScene) => React.Element<*>,
   labelStyle?: TextStyleProp,
@@ -127,6 +128,7 @@ export default class TabBarTop extends PureComponent<
     return (
       <TabBar
         {...props}
+        getAccessibilityLabel={this.props.getAccessibility}
         renderIcon={this._renderIcon}
         renderLabel={this._renderLabel}
       />

--- a/src/views/TabView/TabView.js
+++ b/src/views/TabView/TabView.js
@@ -95,6 +95,25 @@ class TabView extends PureComponent<void, Props, void> {
     return route.routeName;
   };
 
+  _getAccessibility = ({ route }: TabScene) => {
+    const options = this.props.router.getScreenOptions(
+      this.props.childNavigationProps[route.key],
+      this.props.screenProps || {}
+    );
+
+    if (options.accessibilityLabel) {
+      return typeof options.accessibilityLabel === 'function'
+        ? options.accessibilityLabel()
+        : options.accessibilityLabel;
+    }
+
+    if (typeof options.accessibilityLabel === 'string') {
+      return options.accessibilityLabel;
+    }
+
+    return route.routeName;
+  };
+
   _renderIcon = ({ focused, route, tintColor }: TabScene) => {
     const options = this.props.router.getScreenOptions(
       this.props.childNavigationProps[route.key],
@@ -123,6 +142,7 @@ class TabView extends PureComponent<void, Props, void> {
         {...tabBarOptions}
         screenProps={this.props.screenProps}
         navigation={this.props.navigation}
+        getAccessibility={this._getAccessibility}
         getLabel={this._getLabel}
         renderIcon={this._renderIcon}
         animationEnabled={animationEnabled}


### PR DESCRIPTION
Previously there was no good way (at least anything apparent to me) to navigate back to a specific tab when nested in multiple stack navigators. This allows us to reset back to our tab navigator with a specific tab selected.

I'm open to changing how this works, but i should be able to reset or navigate to my tab router without then later changing to a new tab.

Here's an example of this:

 ```
 const resetAction = NavigationActions.reset({
            index: 0,
            actions: [
                NavigationActions.navigate(
                    {
                        index: 0,
                        routeName: MainPages.Home,
                        action: NavigationActions.navigate({ routeName: HomePages.Scenes })
                    }
                ),
            ]
        });
        dispatch(resetAction)
```
