### PR TITLE
Expose useNativeAnimations for Drawer navigator

### DIFF
--- a/src/navigators/DrawerNavigator.js
+++ b/src/navigators/DrawerNavigator.js
@@ -32,7 +32,7 @@ const DefaultDrawerConfig = {
     Dimensions.get('window').width - (Platform.OS === 'android' ? 56 : 64),
   contentComponent: DrawerItems,
   drawerPosition: 'left',
-  useNativeAnimations: false,
+  useNativeAnimations: true,
 };
 
 const DrawerNavigator = (

--- a/src/navigators/DrawerNavigator.js
+++ b/src/navigators/DrawerNavigator.js
@@ -32,6 +32,7 @@ const DefaultDrawerConfig = {
     Dimensions.get('window').width - (Platform.OS === 'android' ? 56 : 64),
   contentComponent: DrawerItems,
   drawerPosition: 'left',
+  useNativeAnimations: false,
 };
 
 const DrawerNavigator = (
@@ -45,6 +46,7 @@ const DrawerNavigator = (
     contentComponent,
     contentOptions,
     drawerPosition,
+    useNativeAnimations,
     ...tabsConfig
   } = mergedConfig;
 
@@ -80,6 +82,7 @@ const DrawerNavigator = (
   )((props: *) =>
     <DrawerView
       {...props}
+      useNativeAnimations={useNativeAnimations}
       drawerWidth={drawerWidth}
       contentComponent={contentComponent}
       contentOptions={contentOptions}

--- a/src/views/Drawer/DrawerView.js
+++ b/src/views/Drawer/DrawerView.js
@@ -34,6 +34,7 @@ export type DrawerViewConfig = {
   contentComponent: ReactClass<*>,
   contentOptions?: {},
   style?: ViewStyleProp,
+  useNativeAnimations: boolean,
 };
 
 type Props = DrawerViewConfig & {
@@ -145,6 +146,7 @@ export default class DrawerView<T: *> extends PureComponent<void, Props, void> {
         drawerWidth={this.props.drawerWidth}
         onDrawerOpen={this._handleDrawerOpen}
         onDrawerClose={this._handleDrawerClose}
+        useNativeAnimations={this.props.useNativeAnimations}
         renderNavigationView={this._renderNavigationView}
         drawerPosition={
           this.props.drawerPosition === 'right'


### PR DESCRIPTION
By enabling `useNativeAnimations` the drawer navigator is significantly quicker.

**Test plan (required)**

Option is opt in so shouldn't affect any current users.

