### PR TITLE
Update Guide-Intro.md to include missing code for the first example

### DIFF
--- a/docs/guides/Guide-Intro.md
+++ b/docs/guides/Guide-Intro.md
@@ -55,9 +55,9 @@ const SimpleApp = StackNavigator({
   Home: { screen: HomeScreen },
 });
 
-AppRegistry.registerComponent('SimpleApp', () => SimpleApp);
-
 export default SimpleApp;
+
+AppRegistry.registerComponent('SimpleApp', () => SimpleApp);
 ```
 
 The `title` of the screen is configurable on the [static `navigationOptions`](/docs/navigators/navigation-options), where many options can be set to configure the presentation of the screen in the navigator.

--- a/docs/guides/Guide-Intro.md
+++ b/docs/guides/Guide-Intro.md
@@ -56,6 +56,8 @@ const SimpleApp = StackNavigator({
 });
 
 AppRegistry.registerComponent('SimpleApp', () => SimpleApp);
+
+export default SimpleApp;
 ```
 
 The `title` of the screen is configurable on the [static `navigationOptions`](/docs/navigators/navigation-options), where many options can be set to configure the presentation of the screen in the navigator.


### PR DESCRIPTION
I was going through the first example on https://reactnavigation.org/docs/intro/, but I was getting an error because SimpleApp was not being exported.  Once I added this export, the app worked for me.  I was running this via expo. Not sure if that is important.
