### PR TITLE
Trivial: Ignore the jest setup file when calculating test coverage.

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,9 @@
     ],
     "coverageDirectory": "./coverage/",
     "collectCoverage": true,
+    "collectCoverageFrom": [
+      "src/**/*.js"
+    ],
     "coveragePathIgnorePatterns": [
       "jest-setup.js"
     ],

--- a/package.json
+++ b/package.json
@@ -91,6 +91,9 @@
     ],
     "coverageDirectory": "./coverage/",
     "collectCoverage": true,
+    "coveragePathIgnorePatterns": [
+      "jest-setup.js"
+    ],
     "modulePathIgnorePatterns": [
       "examples"
     ]


### PR DESCRIPTION
I’m interested in trying to tighten up the test suite and tooling to try and help support contribution and accessibility of the codebase.

This PR make a few really minor changes around the test suite and coverage collection. Namely it;

- excludes the runner setup file from coverage
- includes the actual library codebase in coverage to get a more realistic picture of coverage

I would love to get this merged as I’m interested in trying to work on some reliability and stability issues and IMO it’s critical for to have a test suite that is maintained.

Naturally this will result in a massive decrease in coverage, but at least that number is a real number and not a false indication of actual coverage.

### Before
<img width="663" alt="screen shot 2017-09-14 at 2 51 25 pm" src="https://user-images.githubusercontent.com/18076/30412758-1037211c-995d-11e7-90f3-39693572b1a7.png">

### After
<img width="671" alt="screen shot 2017-09-15 at 9 43 42 am" src="https://user-images.githubusercontent.com/18076/30460456-6de357ac-99fa-11e7-95f2-e01d61498900.png">

### Test plan (required)

1. Run `jest` without this diff and see the jest setup file included in coverage
2. Run `jest` with this diff and don’t see the jest setup file included in coverage and see the actual state of coverage by the test suite over the codebase.