### PR TITLE
Trivial: cleanup warnings in test suite

### DIFF
--- a/src/routers/__tests__/StackRouter-test.js
+++ b/src/routers/__tests__/StackRouter-test.js
@@ -869,6 +869,7 @@ describe('StackRouter', () => {
   });
 
   test('Maps old actions (uses "Handles the reset action" test)', () => {
+    global.console.warn = jest.fn();
     const router = StackRouter({
       Foo: {
         screen: () => <div />,
@@ -895,5 +896,6 @@ describe('StackRouter', () => {
     expect(state2 && state2.routes[0].params).toEqual({ bar: '42' });
     expect(state2 && state2.routes[0].routeName).toEqual('Foo');
     expect(state2 && state2.routes[1].routeName).toEqual('Bar');
+    expect(console.warn).toBeCalled();
   });
 });

--- a/src/routers/__tests__/StackRouter-test.js
+++ b/src/routers/__tests__/StackRouter-test.js
@@ -896,6 +896,6 @@ describe('StackRouter', () => {
     expect(state2 && state2.routes[0].params).toEqual({ bar: '42' });
     expect(state2 && state2.routes[0].routeName).toEqual('Foo');
     expect(state2 && state2.routes[1].routeName).toEqual('Bar');
-    expect(console.warn).toBeCalled();
+    expect(console.warn).toBeCalledWith(expect.stringContaining("The action type 'Init' has been renamed to 'Navigation/INIT'"));
   });
 });

--- a/src/routers/__tests__/TabRouter-test.js
+++ b/src/routers/__tests__/TabRouter-test.js
@@ -562,7 +562,7 @@ describe('TabRouter', () => {
       state
     );
     expect(state2).toEqual(null);
-    expect(console.warn).toBeCalled();
+    expect(console.warn).toBeCalledWith(expect.stringContaining("The action type 'Init' has been renamed to 'Navigation/INIT'"));
   });
 
   test('Can navigate to other tab (no router) with params', () => {

--- a/src/routers/__tests__/TabRouter-test.js
+++ b/src/routers/__tests__/TabRouter-test.js
@@ -549,6 +549,7 @@ describe('TabRouter', () => {
   });
 
   test('Maps old actions (uses "getStateForAction returns null when navigating to same tab" test)', () => {
+    global.console.warn = jest.fn();
     const router = TabRouter(
       { Foo: BareLeafRouteConfig, Bar: BareLeafRouteConfig },
       { initialRouteName: 'Bar' }
@@ -561,6 +562,7 @@ describe('TabRouter', () => {
       state
     );
     expect(state2).toEqual(null);
+    expect(console.warn).toBeCalled();
   });
 
   test('Can navigate to other tab (no router) with params', () => {


### PR DESCRIPTION
### Before
<img width="760" alt="screen shot 2017-09-14 at 4 47 41 pm" src="https://user-images.githubusercontent.com/18076/30415730-b06ba1c6-996c-11e7-8c50-ee45627aaa68.png">

### After
<img width="661" alt="screen shot 2017-09-14 at 4 47 24 pm" src="https://user-images.githubusercontent.com/18076/30415739-bb68e2a0-996c-11e7-8a52-61fd63dd544a.png">

### Test plan (required)

1. Run `jest` without this diff and see noisey warnings
2. Run `jest` with this diff and don’t see noisey warnings