### PR TITLE
Add RNNavigation Links Repo to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,6 @@ We have an active channel on the [Reactiflux](https://www.reactiflux.com/) commu
 - [Routers](https://reactnavigation.org/docs/routers/)
 - [Views](https://reactnavigation.org/docs/views/)
 
+## Helpful Resources
+
+= [React Navigation Links](https://github.com/react-navigation/react-navigation-links)

--- a/README.md
+++ b/README.md
@@ -60,4 +60,4 @@ We have an active channel on the [Reactiflux](https://www.reactiflux.com/) commu
 
 ## Helpful Resources
 
-= [React Navigation Links](https://github.com/react-navigation/react-navigation-links)
+- [React Navigation Links](https://github.com/react-navigation/react-navigation-links)


### PR DESCRIPTION
This PR adds a link to the README for https://github.com/react-navigation/react-navigation-links. This is a list of curated links that are helpful for learning about react-navigation.

If you can come up with a more meaningful section title than "Helpful Resources", please comment 😄 