### PR TITLE
Expose lib folder as main - solves flow syntax error issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-navigation",
   "version": "1.0.0-beta.12",
   "description": "React Navigation",
-  "main": "src/react-navigation.js",
+  "main": "lib/react-navigation.js",
   "sources": {
     "react-native-v1": "lib-rn/react-navigation.js",
     "web": "lib/react-navigation.web.js"


### PR DESCRIPTION
Currently 1.0.0-beta.12 fails when using react-native@0.43.4 (and maybe other versions). 

It fails with a syntax error:
```
 bundling: SyntaxError: ...node_modules/react-navigation/src/views/CardStack/Card.js: Unexpected token (12:2)
  10 |
  11 | type Props = {
> 12 |   ...$Exact<NavigationSceneRendererProps>
```

Related to:
- https://github.com/react-community/react-navigation/issues/2207 
- https://github.com/react-community/react-navigation/issues/2508
- https://github.com/react-community/react-navigation/issues/1594

It seems the problem is that the bundler is using the `src` and not `lib` folder. Wondering why `src` has been used here... Maybe @skevy knows.

**Test plan**

I've tested locally that my apps now build using `1.0.0-beta.12`. 
