### PR TITLE
[Work in Progress] Add Support for iPhoneX

### DIFF
--- a/src/utils/device.js
+++ b/src/utils/device.js
@@ -1,0 +1,17 @@
+/* @flow */
+import { Dimensions, Platform } from 'react-native';
+
+const { width, height } = Dimensions.get('window');
+
+export const isIphoneX = (): boolean => {
+  return (
+    Platform.OS === 'ios' &&
+    !Platform.isPad &&
+    !Platform.isTVOS &&
+    (height === 812 || width === 812)
+  );
+};
+
+export const isLandscape = (): boolean => {
+  return width > height;
+};

--- a/src/utils/device.js
+++ b/src/utils/device.js
@@ -12,6 +12,7 @@ export const isIphoneX = (): boolean => {
   );
 };
 
-export const isLandscape = (): boolean => {
+export const isLandscape = (d: ?object): boolean => {
+  if (d) return d.window.width > d.window.height;
   return width > height;
 };

--- a/src/views/TabView/TabBarBottom.js
+++ b/src/views/TabView/TabBarBottom.js
@@ -14,6 +14,7 @@ import type {
 } from '../../TypeDefinition';
 
 import type { TabScene } from './TabView';
+import { isIphoneX } from '../../utils/device';
 
 type DefaultProps = {
   activeTintColor: string,
@@ -182,13 +183,15 @@ export default class TabBarBottom extends PureComponent<
   }
 }
 
+const HOME_ACTIVITY_INDICATOR = isIphoneX() ? 34 : 0;
 const styles = StyleSheet.create({
   tabBar: {
-    height: 49, // Default tab bar height in iOS 10
+    height: 49 + HOME_ACTIVITY_INDICATOR, // Default tab bar height in iOS 10
     flexDirection: 'row',
     borderTopWidth: StyleSheet.hairlineWidth,
     borderTopColor: 'rgba(0, 0, 0, .3)',
     backgroundColor: '#F7F7F7', // Default background color in iOS 10
+    paddingBottom: HOME_ACTIVITY_INDICATOR,
   },
   tab: {
     flex: 1,

--- a/src/views/TabView/TabBarBottom.js
+++ b/src/views/TabView/TabBarBottom.js
@@ -14,7 +14,7 @@ import type {
 } from '../../TypeDefinition';
 
 import type { TabScene } from './TabView';
-import { isIphoneX } from '../../utils/device';
+import { isIphoneX, isLandscape } from '../../utils/device';
 
 type DefaultProps = {
   activeTintColor: string,


### PR DESCRIPTION
**Work in Progress/Proof of Concept**

## Motivation

Apple is changing things with their newest iPhone. This helps React Navigation work/look right on the new device. It will resolves #2589.

It may be easier to add another PR that helps support new patterns in iOS11 (tabbar, navbar, etc.)

## Test plan

```
react-native init iPhoneXTest
cd iPhoneXTest
yarn add react-navigation@spencercarli/react-navigation#iphonex-support
yarn add react-native-vector-icons
react-native link react-native-vector-icons
```

Then copy the `js` directory from the [NavigationPlayground](https://github.com/react-community/react-navigation/tree/master/examples/NavigationPlayground) to the new app. Register `js/App` and then go to the look at any of the examples in the app that use default header and/or tabbar.

## Tasks

- [x] Use the right status bar height depending on device
- [x] Change status bar height on orientation change
- [x] Give ample room for home activity indicator, if it exists
- [ ] New large text in navigation bar (iOS11 update?)
- [ ] Icon & text in row in landscape/on iPad (what should the tab bar height be?)

![iphonex](https://user-images.githubusercontent.com/1105429/30616860-4870be1c-9d59-11e7-90d8-4486ee3f1f3d.gif)

**Note:** Not sure why icons were missing in the header in the gif. They should show up when you test it.