### PR TITLE
Remove @providesModule declarations in src/utils to avoid Flow conflicts with fbjs package

### DIFF
--- a/src/utils/invariant.js
+++ b/src/utils/invariant.js
@@ -5,8 +5,6 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @providesModule invariant
  */
 
 'use strict';

--- a/src/utils/shallowEqual.js
+++ b/src/utils/shallowEqual.js
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @providesModule shallowEqual
  * @typechecks
  * @flow
  */


### PR DESCRIPTION
See #2658. These `@providesModule` ("Haste") declarations are not necessary since every file imports these modules using the full path. We're removing them because they declare the same modules as the fbjs packages do (the files are actually copied in from there), so Flow gets confused and doesn't know which to use.