### PR TITLE
Fix "drawerLockMode" typo in DrawerNavigator docs

### DIFF
--- a/docs/api/navigators/DrawerNavigator.md
+++ b/docs/api/navigators/DrawerNavigator.md
@@ -173,7 +173,7 @@ React Element or a function, that given `{ focused: boolean, tintColor: string }
 
 #### `drawerLockMode`
 
-Specifies the [lock mode](https://facebook.github.io/react-native/docs/drawerlayoutandroid.html#drawerlockmode) of the drawer. This can also update dynamically by using screenProps.lockMode on your top level router.
+Specifies the [lock mode](https://facebook.github.io/react-native/docs/drawerlayoutandroid.html#drawerlockmode) of the drawer. This can also update dynamically by using screenProps.drawerLockMode on your top level router.
 
 ### Navigator Props
 


### PR DESCRIPTION
There's a typo in the docs -- when specifying drawerLockMode in screenProps, it should be "screenProps.drawerLockMode", not "screenProps.lockMode". 

Tested on iOS and Android.