### PR TITLE
fix redirect bug in stacks in tab

### DIFF
--- a/src/routers/TabRouter.js
+++ b/src/routers/TabRouter.js
@@ -238,6 +238,10 @@ export default (
       });
       // console.log(`${order.join('-')}: Processed other tabs:`, {lastIndex: state.index, index});
 
+      // keep active tab index if action type is SET_PARAMS
+      index =
+        action.type === NavigationActions.SET_PARAMS ? state.index : index;
+
       if (index !== state.index || routes !== state.routes) {
         return {
           ...state,


### PR DESCRIPTION
Bug explain:
There's unwanted redirection if action with type `Navigation/SET_PARAMS` is dispatched in stacks in tab navigator. It was critical bug for our app. 

Bug demonstration: https://expo.io/@sujameslin/react-navigation-bug-reproduce
Like you see the bug demo, it was supposed to be showing the first tab, but its showing 2nd tab after load.
Source code: https://github.com/sujameslin/react-navigation-bug-reproduce/blob/master/App.js#L55-L57
