### PR TITLE
[iOS 11] Handle landscape tabbar correctly.

### DIFF
--- a/src/views/TabView/TabBarBottom.js
+++ b/src/views/TabView/TabBarBottom.js
@@ -6,6 +6,7 @@ import {
   TouchableWithoutFeedback,
   StyleSheet,
   View,
+  Platform,
 } from 'react-native';
 import TabBarIcon from './TabBarIcon';
 import withOrientation from '../withOrientation';
@@ -50,6 +51,8 @@ type Props = {
   isLandscape: boolean,
 };
 
+const majorVersionIOS = parseInt(Platform.Version, 10);
+
 class TabBarBottom extends PureComponent<DefaultProps, Props, void> {
   // See https://developer.apple.com/library/content/documentation/UserExperience/Conceptual/UIKitUICatalog/UITabBar.html
   static defaultProps = {
@@ -93,11 +96,11 @@ class TabBarBottom extends PureComponent<DefaultProps, Props, void> {
     const tintColor = scene.focused ? activeTintColor : inactiveTintColor;
     const label = this.props.getLabel({ ...scene, tintColor });
     let marginLeft = 0;
-    if (isLandscape && showIcon) {
+    if (isLandscape && showIcon && majorVersionIOS >= 11) {
       marginLeft = LABEL_LEFT_MARGIN;
     }
     let marginTop = 0;
-    if (!isLandscape && showIcon) {
+    if (!isLandscape && showIcon && majorVersionIOS >= 11) {
       marginTop = LABEL_TOP_MARGIN;
     }
 

--- a/src/views/TabView/TabBarBottom.js
+++ b/src/views/TabView/TabBarBottom.js
@@ -150,7 +150,7 @@ class TabBarBottom extends PureComponent<DefaultProps, Props, void> {
         inactiveTintColor={inactiveTintColor}
         renderIcon={renderIcon}
         scene={scene}
-        style={showLabel ? {} : styles.icon}
+        style={showLabel && majorVersionIOS >= 11 ? {} : styles.icon}
       />
     );
   };
@@ -209,7 +209,8 @@ class TabBarBottom extends PureComponent<DefaultProps, Props, void> {
               <Animated.View
                 style={[
                   styles.tab,
-                  isLandscape ? styles.tabLandscape : styles.tabPortrait,
+                  isLandscape && majorVersionIOS >= 11 && styles.tabLandscape,
+                  !isLandscape && majorVersionIOS >= 11 && styles.tabPortrait,
                   { backgroundColor },
                   tabStyle,
                 ]}

--- a/src/views/TabView/TabBarBottom.js
+++ b/src/views/TabView/TabBarBottom.js
@@ -193,11 +193,11 @@ class TabBarBottom extends PureComponent<DefaultProps, Props, void> {
             inputRange,
             outputRange: (outputRange: Array<string>),
           });
-      
+
           const justifyContent = this.props.showIcon ? 'flex-end' : 'center';
           const extraProps = this._renderTestIDProps(scene) || {};
           const { testID, accessibilityLabel } = extraProps;
-      
+
           return (
             <TouchableWithoutFeedback
               key={route.key}

--- a/src/views/TabView/TabBarBottom.js
+++ b/src/views/TabView/TabBarBottom.js
@@ -1,8 +1,14 @@
 /* @flow */
 
 import React, { PureComponent } from 'react';
-import { Animated, TouchableWithoutFeedback, StyleSheet } from 'react-native';
+import {
+  Animated,
+  TouchableWithoutFeedback,
+  StyleSheet,
+  View,
+} from 'react-native';
 import TabBarIcon from './TabBarIcon';
+import withOrientation from '../withOrientation';
 
 import type {
   NavigationAction,
@@ -41,13 +47,10 @@ type Props = {
   labelStyle?: TextStyleProp,
   tabStyle?: ViewStyleProp,
   showIcon: boolean,
+  isLandscape: boolean,
 };
 
-export default class TabBarBottom extends PureComponent<
-  DefaultProps,
-  Props,
-  void
-> {
+class TabBarBottom extends PureComponent<DefaultProps, Props, void> {
   // See https://developer.apple.com/library/content/documentation/UserExperience/Conceptual/UIKitUICatalog/UITabBar.html
   static defaultProps = {
     activeTintColor: '#3478f6', // Default active tint color in iOS 10
@@ -68,6 +71,8 @@ export default class TabBarBottom extends PureComponent<
       inactiveTintColor,
       labelStyle,
       showLabel,
+      showIcon,
+      isLandscape,
     } = this.props;
     if (showLabel === false) {
       return null;
@@ -87,9 +92,20 @@ export default class TabBarBottom extends PureComponent<
 
     const tintColor = scene.focused ? activeTintColor : inactiveTintColor;
     const label = this.props.getLabel({ ...scene, tintColor });
+    let marginLeft = 0;
+    if (isLandscape && showIcon) {
+      marginLeft = LABEL_LEFT_MARGIN;
+    }
+    let marginTop = 0;
+    if (!isLandscape && showIcon) {
+      marginTop = LABEL_TOP_MARGIN;
+    }
+
     if (typeof label === 'string') {
       return (
-        <Animated.Text style={[styles.label, { color }, labelStyle]}>
+        <Animated.Text
+          style={[styles.label, { color, marginLeft, marginTop }, labelStyle]}
+        >
           {label}
         </Animated.Text>
       );
@@ -137,6 +153,7 @@ export default class TabBarBottom extends PureComponent<
       inactiveBackgroundColor,
       style,
       tabStyle,
+      isLandscape,
     } = this.props;
     const { routes } = navigation.state;
     // Prepend '-1', so there are always at least 2 items in inputRange
@@ -157,7 +174,7 @@ export default class TabBarBottom extends PureComponent<
             inputRange,
             outputRange: (outputRange: Array<string>),
           });
-          const justifyContent = this.props.showIcon ? 'flex-end' : 'center';
+
           return (
             <TouchableWithoutFeedback
               key={route.key}
@@ -167,7 +184,8 @@ export default class TabBarBottom extends PureComponent<
               <Animated.View
                 style={[
                   styles.tab,
-                  { backgroundColor, justifyContent },
+                  isLandscape ? styles.tabLandscape : styles.tabPortrait,
+                  { backgroundColor },
                   tabStyle,
                 ]}
               >
@@ -182,22 +200,30 @@ export default class TabBarBottom extends PureComponent<
   }
 }
 
+const LABEL_LEFT_MARGIN = 20;
+const LABEL_TOP_MARGIN = 15;
 const styles = StyleSheet.create({
   tabBar: {
-    height: 49, // Default tab bar height in iOS 10
+    height: 49, // Default tab bar height in iOS 10+
     flexDirection: 'row',
     borderTopWidth: StyleSheet.hairlineWidth,
     borderTopColor: 'rgba(0, 0, 0, .3)',
-    backgroundColor: '#F7F7F7', // Default background color in iOS 10
+    backgroundColor: '#F7F7F7', // Default background color in iOS 10+
   },
   tab: {
     flex: 1,
-    alignItems: 'stretch',
+    alignItems: 'center',
     justifyContent: 'flex-end',
   },
-  icon: {
-    flexGrow: 1,
+  tabPortrait: {
+    justifyContent: 'flex-end',
+    flexDirection: 'column',
   },
+  tabLandscape: {
+    justifyContent: 'center',
+    flexDirection: 'row',
+  },
+  icon: {},
   label: {
     textAlign: 'center',
     fontSize: 10,
@@ -205,3 +231,5 @@ const styles = StyleSheet.create({
     backgroundColor: 'transparent',
   },
 });
+
+export default withOrientation(TabBarBottom);

--- a/src/views/TabView/TabBarBottom.js
+++ b/src/views/TabView/TabBarBottom.js
@@ -126,6 +126,7 @@ class TabBarBottom extends PureComponent<DefaultProps, Props, void> {
       inactiveTintColor,
       renderIcon,
       showIcon,
+      showLabel,
     } = this.props;
     if (showIcon === false) {
       return null;
@@ -138,7 +139,7 @@ class TabBarBottom extends PureComponent<DefaultProps, Props, void> {
         inactiveTintColor={inactiveTintColor}
         renderIcon={renderIcon}
         scene={scene}
-        style={styles.icon}
+        style={showLabel ? {} : styles.icon}
       />
     );
   };
@@ -223,7 +224,9 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     flexDirection: 'row',
   },
-  icon: {},
+  icon: {
+    flexGrow: 1,
+  },
   label: {
     textAlign: 'center',
     fontSize: 10,

--- a/src/views/__tests__/TabView-test.js
+++ b/src/views/__tests__/TabView-test.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { View } from 'react-native';
+import renderer from 'react-test-renderer';
+import TabRouter from '../../routers/TabRouter';
+
+import TabView from '../TabView/TabView';
+import TabBarBottom from '../TabView/TabBarBottom';
+
+describe('TabBarBottom', () => {
+  it('renders successfully', () => {
+    const navigation = {
+      state: {
+        index: 0,
+        routes: [{ key: 's1', routeName: 's1' }],
+      },
+    };
+    const router = TabRouter({ s1: { screen: View } });
+
+    const rendered = renderer
+      .create(
+        <TabView
+          tabBarComponent={TabBarBottom}
+          navigation={navigation}
+          router={router}
+        />
+      )
+      .toJSON();
+
+    expect(rendered).toMatchSnapshot();
+  });
+});

--- a/src/views/__tests__/__snapshots__/TabView-test.js.snap
+++ b/src/views/__tests__/__snapshots__/TabView-test.js.snap
@@ -105,7 +105,7 @@ exports[`TabBarBottom renders successfully 1`] = `
             "fontSize": 10,
             "marginBottom": 1.5,
             "marginLeft": 0,
-            "marginTop": 15,
+            "marginTop": 0,
             "textAlign": "center",
           }
         }

--- a/src/views/__tests__/__snapshots__/TabView-test.js.snap
+++ b/src/views/__tests__/__snapshots__/TabView-test.js.snap
@@ -52,14 +52,17 @@ exports[`TabBarBottom renders successfully 1`] = `
           "alignItems": "center",
           "backgroundColor": "rgba(0, 0, 0, 0)",
           "flex": 1,
-          "flexDirection": "column",
           "justifyContent": "flex-end",
         }
       }
       testID={undefined}
     >
       <View
-        style={Object {}}
+        style={
+          Object {
+            "flexGrow": 1,
+          }
+        }
       >
         <View
           collapsable={undefined}

--- a/src/views/__tests__/__snapshots__/TabView-test.js.snap
+++ b/src/views/__tests__/__snapshots__/TabView-test.js.snap
@@ -1,0 +1,225 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TabBarBottom renders successfully 1`] = `
+<View
+  loaded={
+    Array [
+      0,
+    ]
+  }
+  onLayout={[Function]}
+  style={
+    Array [
+      Object {
+        "flex": 1,
+        "overflow": "hidden",
+      },
+      Object {
+        "flex": 1,
+      },
+    ]
+  }
+>
+  <View
+    collapsable={undefined}
+    style={
+      Object {
+        "backgroundColor": "#F7F7F7",
+        "borderTopColor": "rgba(0, 0, 0, .3)",
+        "borderTopWidth": 0.5,
+        "flexDirection": "row",
+        "height": 49,
+      }
+    }
+  >
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel={undefined}
+      accessibilityTraits={undefined}
+      accessible={true}
+      collapsable={undefined}
+      hitSlop={undefined}
+      nativeID={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "rgba(0, 0, 0, 0)",
+          "flex": 1,
+          "flexDirection": "column",
+          "justifyContent": "flex-end",
+        }
+      }
+      testID={undefined}
+    >
+      <View
+        style={Object {}}
+      >
+        <View
+          collapsable={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "bottom": 0,
+              "justifyContent": "center",
+              "left": 0,
+              "opacity": 1,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            }
+          }
+        />
+        <View
+          collapsable={undefined}
+          style={
+            Object {
+              "alignItems": "center",
+              "bottom": 0,
+              "justifyContent": "center",
+              "left": 0,
+              "opacity": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            }
+          }
+        />
+      </View>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        collapsable={undefined}
+        disabled={false}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "backgroundColor": "transparent",
+            "color": "rgba(52, 120, 246, 1)",
+            "fontSize": 10,
+            "marginBottom": 1.5,
+            "marginLeft": 0,
+            "marginTop": 15,
+            "textAlign": "center",
+          }
+        }
+      >
+        s1
+      </Text>
+    </View>
+  </View>
+  <RCTScrollView
+    DEPRECATED_sendUpdatedChildFrames={false}
+    alwaysBounceHorizontal={false}
+    alwaysBounceVertical={false}
+    automaticallyAdjustContentInsets={false}
+    bounces={false}
+    contentContainerStyle={
+      Object {
+        "flexGrow": 1,
+      }
+    }
+    contentOffset={
+      Object {
+        "x": 0,
+        "y": 0,
+      }
+    }
+    directionalLockEnabled={true}
+    horizontal={true}
+    keyboardDismissMode="on-drag"
+    keyboardShouldPersistTaps="always"
+    onContentSizeChange={null}
+    onMomentumScrollBegin={[Function]}
+    onMomentumScrollEnd={[Function]}
+    onResponderGrant={[Function]}
+    onResponderReject={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={undefined}
+    onResponderTerminationRequest={[Function]}
+    onScroll={[Function]}
+    onScrollBeginDrag={[Function]}
+    onScrollEndDrag={[Function]}
+    onScrollShouldSetResponder={[Function]}
+    onStartShouldSetResponder={[Function]}
+    onStartShouldSetResponderCapture={[Function]}
+    onTouchEnd={[Function]}
+    onTouchMove={[Function]}
+    onTouchStart={[Function]}
+    pagingEnabled={true}
+    scrollEnabled={undefined}
+    scrollEventThrottle={16}
+    scrollsToTop={false}
+    sendMomentumEvents={true}
+    showsHorizontalScrollIndicator={false}
+    style={
+      Array [
+        Object {
+          "flexDirection": "row",
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "overflow": "scroll",
+        },
+        Object {
+          "flexGrow": 1,
+        },
+      ]
+    }
+  >
+    <RCTScrollContentView
+      collapsable={false}
+      removeClippedSubviews={undefined}
+      style={
+        Array [
+          Object {
+            "flexDirection": "row",
+          },
+          Object {
+            "flexGrow": 1,
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          Object {
+            "flex": 1,
+            "overflow": "hidden",
+          }
+        }
+        testID={undefined}
+      >
+        <View
+          style={
+            Object {
+              "flex": 1,
+              "overflow": "hidden",
+            }
+          }
+        >
+          <View
+            navigation={
+              Object {
+                "goBack": [Function],
+                "navigate": [Function],
+                "setParams": [Function],
+                "state": Object {
+                  "key": "s1",
+                  "routeName": "s1",
+                },
+              }
+            }
+            screenProps={undefined}
+          />
+        </View>
+      </View>
+    </RCTScrollContentView>
+  </RCTScrollView>
+</View>
+`;


### PR DESCRIPTION
## Motivation

I saw that the behavior of the tabbar has changed in iOS11 - it no longer stacks the icon and label on top of itself in landscape. 

## Test Plan

Install `react-navigation` from `spencercarli/react-navigation#ios-11-tab-bar` into an app with tab bar. I don't think this should affect customizations much (if at all).

I can't get the NavigationPlayground example to detect it's in landscape (limitation of CRNA?) so you'll need to create a new app. You can use [this](https://github.com/react-community/react-navigation/blob/master/examples/NavigationPlayground/js/StacksInTabs.js) as a start point. Should be copy and paste as long as you have `react-native-vector-icons` installed.
