### PR TITLE
Fix Querystring params not set for nested URI (issue #2251)

### DIFF
--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -360,7 +360,7 @@ export default (
       if (childRouters[matchedRouteName]) {
         nestedAction = childRouters[matchedRouteName].getActionForPathAndParams(
           /* $FlowFixMe */
-          pathMatch.slice(pathMatchKeys.length).join('/')
+          pathMatch.slice(pathMatchKeys.length).join('/') + '?' + queryString
         );
       }
 

--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -357,10 +357,11 @@ export default (
       // get the action for the path AFTER the matched path for this
       // router
       let nestedAction;
+      let nestedQueryString = queryString ? '?' + queryString : '';
       if (childRouters[matchedRouteName]) {
         nestedAction = childRouters[matchedRouteName].getActionForPathAndParams(
           /* $FlowFixMe */
-          pathMatch.slice(pathMatchKeys.length).join('/') + '?' + queryString
+          pathMatch.slice(pathMatchKeys.length).join('/') + nestedQueryString
         );
       }
 

--- a/src/routers/__tests__/StackRouter-test.js
+++ b/src/routers/__tests__/StackRouter-test.js
@@ -902,4 +902,66 @@ describe('StackRouter', () => {
       )
     );
   });
+
+  test('Querystring params get passed to nested deep link', () => {
+    // uri with two non-empty query param values
+    const uri = 'main/p/4/list/10259959195?code=test&foo=bar';
+    const action = TestStackRouter.getActionForPathAndParams(uri);
+    expect(action).toEqual({
+      type: NavigationActions.NAVIGATE,
+      routeName: 'main',
+      params: {
+        code: 'test',
+        foo: 'bar',
+      },
+      action: {
+        type: NavigationActions.NAVIGATE,
+        routeName: 'profile',
+        params: {
+          id: '4',
+          code: 'test',
+          foo: 'bar',
+        },
+        action: {
+          type: NavigationActions.NAVIGATE,
+          routeName: 'list',
+          params: {
+            id: '10259959195',
+            code: 'test',
+            foo: 'bar',
+          },
+        },
+      },
+    });
+
+    // uri with one empty and one non-empty query param value
+    const uri2 = 'main/p/4/list/10259959195?code=&foo=bar';
+    const action2 = TestStackRouter.getActionForPathAndParams(uri2);
+    expect(action2).toEqual({
+      type: NavigationActions.NAVIGATE,
+      routeName: 'main',
+      params: {
+        code: '',
+        foo: 'bar',
+      },
+      action: {
+        type: NavigationActions.NAVIGATE,
+        routeName: 'profile',
+        params: {
+          id: '4',
+          code: '',
+          foo: 'bar',
+        },
+        action: {
+          type: NavigationActions.NAVIGATE,
+          routeName: 'list',
+          params: {
+            id: '10259959195',
+            code: '',
+            foo: 'bar',
+          },
+        },
+      },
+    });
+  });
 });


### PR DESCRIPTION
This pull request solves issue #2251 by introducing a `nestedQueryString` variable that is either the original `queryString` or an empty string (when `queryString` is null), that gets passed as part of the path for retrieving the nested action in `StackRouter``s `getActionForPathAndParams`.

**Test plan (required)**
I modified `src/routers/__tests__/StackRouter-test.js` by adding an additional test case, starting on the line `test('Querystring params get passed to nested deep link', () => {`. It is mostly a combination of two existing tests:

1. The one with title `Correctly parses a path with arguments into an action chain` with uri value `'main/p/4/list/10259959195'`
2. The ones titled `Parses paths with a query` and `Parses paths with an empty query value` that make use of uris ending with `?code=test&foo=bar` and `?code=&foo=bar`, respectively.

Video demonstrating the changes on iOS: [https://vimeo.com/236860581](https://vimeo.com/236860581)

For Android I tweaked the command slightly to open the deep link, due to [this StackOverflow question](https://stackoverflow.com/questions/35645414/android-deep-linking-with-multiple-query-parameters) explaining the situation where testing with multiple query params only includes the first one by default. All I had to do was include a backslash character (\\) before the ampersand (&).

Android video demonstration: [https://vimeo.com/236863226](https://vimeo.com/236863226).

On a somewhat related note, the current react-navigation [Deep Linking documentation](https://reactnavigation.org/docs/guides/linking) makes no reference to query params. I'd be more than glad to supplement that as well to cover the topic.