### PR TITLE
Added property inside drawerConfig to backgroundColor

### DIFF
--- a/src/navigators/DrawerNavigator.js
+++ b/src/navigators/DrawerNavigator.js
@@ -32,6 +32,7 @@ const DefaultDrawerConfig = {
     Dimensions.get('window').width - (Platform.OS === 'android' ? 56 : 64),
   contentComponent: DrawerItems,
   drawerPosition: 'left',
+  drawerBackgroundColor: 'white',
   useNativeAnimations: true,
 };
 
@@ -48,6 +49,7 @@ const DrawerNavigator = (
     contentOptions,
     drawerPosition,
     useNativeAnimations,
+    drawerBackgroundColor,
     ...tabsConfig
   } = mergedConfig;
 
@@ -83,6 +85,7 @@ const DrawerNavigator = (
   )((props: *) => (
     <DrawerView
       {...props}
+      drawerBackgroundColor={drawerBackgroundColor}
       drawerLockMode={drawerLockMode}
       useNativeAnimations={useNativeAnimations}
       drawerWidth={drawerWidth}

--- a/src/views/Drawer/DrawerSidebar.js
+++ b/src/views/Drawer/DrawerSidebar.js
@@ -125,6 +125,5 @@ export default withCachedChildNavigation(DrawerSidebar);
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#fff',
   },
 });

--- a/src/views/Drawer/DrawerView.js
+++ b/src/views/Drawer/DrawerView.js
@@ -36,6 +36,7 @@ export type DrawerViewConfig = {
   contentOptions?: {},
   style?: ViewStyleProp,
   useNativeAnimations?: boolean,
+  drawerBackgroundColor?: String,
 };
 
 type Props = DrawerViewConfig & {
@@ -160,6 +161,7 @@ export default class DrawerView<T: *> extends PureComponent<void, Props, void> {
           (this.props.screenProps && this.props.screenProps.drawerLockMode) ||
           (config && config.drawerLockMode)
         }
+        drawerBackgroundColor={this.props.drawerBackgroundColor}
         drawerWidth={this.props.drawerWidth}
         onDrawerOpen={this._handleDrawerOpen}
         onDrawerClose={this._handleDrawerClose}


### PR DESCRIPTION
**DrawerNavigator**

I added a property to **drawerConfig**, which is **drawerBackgroundColor**, because I needed to use the transparent background to make a shadow and I could not.

example:

`const drawerConfig = {
  drawerBackgroundColor: 'transparent'
};`

