### PR TITLE
Make goBack() behave the same as goBack(null)

### DIFF
--- a/docs/guides/Screen-Navigation-Prop.md
+++ b/docs/guides/Screen-Navigation-Prop.md
@@ -90,7 +90,7 @@ class ProfileScreen extends React.Component {
 
 ## `goBack` - Close the active screen and move back
 
-Optionally provide a key, which specifies the route to go back from. By default, goBack will close the route that it is called from. If the goal is to go back *anywhere*, without specifying what is getting closed, call `.goBack(null);`
+Optionally provide a key, which specifies the route to go back from. By default, goBack will close the currently active route (which most of the time is the route that it is called from).
 
 ```js
 class HomeScreen extends React.Component {
@@ -101,10 +101,6 @@ class HomeScreen extends React.Component {
         <Button
           onPress={() => goBack()}
           title="Go back from this HomeScreen"
-        />
-        <Button
-          onPress={() => goBack(null)}
-          title="Go back anywhere"
         />
         <Button
           onPress={() => goBack('screen-123')}

--- a/src/addNavigationHelpers.js
+++ b/src/addNavigationHelpers.js
@@ -18,7 +18,7 @@ export default function<S: *>(navigation: NavigationProp<S, NavigationAction>) {
     goBack: (key?: ?string): boolean =>
       navigation.dispatch(
         NavigationActions.back({
-          key: key === undefined ? navigation.state.key : key,
+          key: key,
         })
       ),
     navigate: (


### PR DESCRIPTION
Currently goBack has an optional param, which specifies the route to go back from. If there's no key provided, we'll use the key from the route that goBack is called from (which makes sense).
https://github.com/react-community/react-navigation/blob/f84fe152721f0f6f80f799dbcd9bcbf5f42d61d0/src/addNavigationHelpers.js#L21

The problem is that it doesn't work if we want to go back from a nested navigator to a parent navigator, but goBack(null) works. And this confuses a lot of people, including me. 
I have looked at the code and it seems that if we're in a StackNavigator with only 1 route or a TabNavigator with the first tab active, both goBack() and goBack(null) will result in the child navigator returning the same state, thus the parent navigator will handle the action. But with a non-null key, the navigator will try to find a child route with that key and go back from that, and it won't be able to find that route because it's from a nested navigator:
https://github.com/react-community/react-navigation/blob/f84fe152721f0f6f80f799dbcd9bcbf5f42d61d0/src/routers/StackRouter.js#L277

In the other hand, if the key is null, the parent navigator will just pop:
https://github.com/react-community/react-navigation/blob/f84fe152721f0f6f80f799dbcd9bcbf5f42d61d0/src/routers/StackRouter.js#L285

So if we don't provide a default key when calling goBack(), we'll be able to go back from a nested navigator. In the current implementation, we use the key from current route just to make sure that the app is not going to go back from a wrong route. But I think the change from this PR wouldn't cause any unexpected behaviors since navigators will let the active route handle the action first.

This will fix https://github.com/react-community/react-navigation/issues/1522