### PR TITLE
Fixes default drawerWidth to match Material UI patterns.

### DIFF
--- a/examples/NavigationPlayground/js/App.js
+++ b/examples/NavigationPlayground/js/App.js
@@ -1,6 +1,9 @@
 /* @flow */
 
 import React from 'react';
+import { ScreenOrientation } from 'expo';
+
+ScreenOrientation.allow(ScreenOrientation.Orientation.ALL);
 
 import {
   Platform,

--- a/src/navigators/DrawerNavigator.js
+++ b/src/navigators/DrawerNavigator.js
@@ -23,13 +23,16 @@ export type DrawerNavigatorConfig = {
 } & NavigationTabRouterConfig &
   DrawerViewConfig;
 
+const { height, width } = Dimensions.get('window');
+
+console.log(height, width, Math.min(height, width));
+
 const DefaultDrawerConfig = {
   /*
    * Default drawer width is screen width - header width
    * https://material.io/guidelines/patterns/navigation-drawer.html
    */
-  drawerWidth:
-    Dimensions.get('window').width - (Platform.OS === 'android' ? 56 : 64),
+  drawerWidth: Math.min(height, width) - (Platform.OS === 'android' ? 56 : 64),
   contentComponent: DrawerItems,
   drawerPosition: 'left',
   drawerBackgroundColor: 'white',

--- a/src/navigators/DrawerNavigator.js
+++ b/src/navigators/DrawerNavigator.js
@@ -25,8 +25,6 @@ export type DrawerNavigatorConfig = {
 
 const { height, width } = Dimensions.get('window');
 
-console.log(height, width, Math.min(height, width));
-
 const DefaultDrawerConfig = {
   /*
    * Default drawer width is screen width - header width


### PR DESCRIPTION
Previously: calculated based on device width regardless of orientation and did not recalculate when orientation changed. If an app was opened in landscape, the drawer would be too wide if the device was rotated to portrait.
Now: calculates based on minimum of device height/width, drawer width remains constant and is guaranteed to always fit screen regardless of orientation.

This is the expected behavior based on observing Google apps (e.g. Gmail). This is also better than recalculating on every orientation change, which would result in variable width drawers and awkward empty space when in landscape in most cases.

Also added support for rotating device in NavigationPlayground example app.