### PR TITLE
[wip] Navbar height fix (fixes #2795)

### DIFF
--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -9,8 +9,8 @@ import { Animated, Platform, StyleSheet, View } from 'react-native';
 import HeaderTitle from './HeaderTitle';
 import HeaderBackButton from './HeaderBackButton';
 import HeaderStyleInterpolator from './HeaderStyleInterpolator';
-import withOrientation from '../withOrientation';
-
+import WithStatusBarHeight from './WithStatusBarHeight';
+import type { StatusBarHeightState } from './WithStatusBarHeight';
 import type {
   NavigationScene,
   NavigationStyleInterpolator,
@@ -35,12 +35,13 @@ type HeaderState = {
 };
 
 const APPBAR_HEIGHT = Platform.OS === 'ios' ? 44 : 56;
-const STATUSBAR_HEIGHT = Platform.OS === 'ios' ? 20 : 0;
 const TITLE_OFFSET = Platform.OS === 'ios' ? 70 : 56;
 
-class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
-  static HEIGHT = APPBAR_HEIGHT + STATUSBAR_HEIGHT;
-
+export default class Header extends React.PureComponent<
+  void,
+  HeaderProps,
+  HeaderState
+> {
   state = {
     widths: {},
   };
@@ -257,54 +258,59 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
   }
 
   render() {
-    let appBar;
-
-    if (this.props.mode === 'float') {
-      const scenesProps: Array<
-        SceneProps
-      > = this.props.scenes.map((scene: NavigationScene) => ({
-        position: this.props.position,
-        progress: this.props.progress,
-        scene,
-      }));
-      appBar = scenesProps.map(this._renderHeader, this);
-    } else {
-      appBar = this._renderHeader({
-        position: new Animated.Value(this.props.scene.index),
-        progress: new Animated.Value(0),
-        scene: this.props.scene,
-      });
-    }
-
-    // eslint-disable-next-line no-unused-vars
-    const {
-      scenes,
-      scene,
-      position,
-      screenProps,
-      progress,
-      style,
-      isLandscape,
-      ...rest
-    } = this.props;
-
-    const { options } = this.props.getScreenDetails(scene);
-    const headerStyle = options.headerStyle;
-    const landscapeAwareStatusBarHeight = isLandscape ? 0 : STATUSBAR_HEIGHT;
-    const containerStyles = [
-      styles.container,
-      {
-        paddingTop: landscapeAwareStatusBarHeight,
-        height: APPBAR_HEIGHT + landscapeAwareStatusBarHeight,
-      },
-      headerStyle,
-      style,
-    ];
-
     return (
-      <Animated.View {...rest} style={containerStyles}>
-        <View style={styles.appBar}>{appBar}</View>
-      </Animated.View>
+      <WithStatusBarHeight
+        render={({ statusBarTop, statusBarHeight }: StatusBarHeightState) => {
+          let appBar;
+
+          if (this.props.mode === 'float') {
+            const scenesProps: Array<
+              SceneProps
+            > = this.props.scenes.map((scene: NavigationScene) => ({
+              position: this.props.position,
+              progress: this.props.progress,
+              scene,
+            }));
+            appBar = scenesProps.map(this._renderHeader, this);
+          } else {
+            appBar = this._renderHeader({
+              position: new Animated.Value(this.props.scene.index),
+              progress: new Animated.Value(0),
+              scene: this.props.scene,
+            });
+          }
+
+          // eslint-disable-next-line no-unused-vars
+          const {
+            scenes,
+            scene,
+            position,
+            screenProps,
+            progress,
+            style,
+            ...rest
+          } = this.props;
+
+          const { options } = this.props.getScreenDetails(scene);
+          const headerStyle = options.headerStyle;
+          const totalStatusBarHeight = statusBarTop + statusBarHeight;
+          const containerStyles = [
+            styles.container,
+            {
+              paddingTop: totalStatusBarHeight,
+              height: APPBAR_HEIGHT + totalStatusBarHeight,
+            },
+            headerStyle,
+            style,
+          ];
+
+          return (
+            <Animated.View {...rest} style={containerStyles}>
+              <View style={styles.appBar}>{appBar}</View>
+            </Animated.View>
+          );
+        }}
+      />
     );
   }
 }
@@ -364,5 +370,3 @@ const styles = StyleSheet.create({
     position: 'absolute',
   },
 });
-
-export default withOrientation(Header);

--- a/src/views/Header/WithStatusBarHeight.js
+++ b/src/views/Header/WithStatusBarHeight.js
@@ -1,0 +1,74 @@
+// @flow
+
+import React from 'react';
+import { Platform, StatusBar, StatusBarIOS, NativeModules } from 'react-native';
+const isIos = Platform.OS === 'ios';
+const { StatusBarManager } = NativeModules;
+
+// TODO revisit this once https://github.com/facebook/react-native/pull/16478 is out
+type StatusBarFrame = {
+  y: number,
+  height: number,
+};
+
+type StatusBarDataType = {
+  frame: StatusBarFrame,
+};
+
+export type StatusBarHeightState = {
+  statusBarTop: number,
+  statusBarHeight: number,
+};
+
+type Props = {
+  render: StatusBarHeightState => React$Element<*>,
+};
+
+export default class WithStatusBarHeight extends React.Component<
+  Props,
+  T,
+  StatusBarHeightState
+> {
+  state: StatusBarHeightState;
+
+  constructor(props: Props) {
+    super(props);
+
+    const initialHeight = isIos ? 20 : StatusBar.currentHeight;
+    this.state = { statusBarTop: 0, statusBarHeight: initialHeight };
+    if (isIos) {
+      this.fetchInitialHeightIOS();
+    }
+  }
+
+  fetchInitialHeightIOS() {
+    StatusBarManager.getHeight(({ height }: { height: number }) => {
+      if (Math.abs(this.state.statusBarHeight - height) > 0.01) {
+        this.setState({ statusBarHeight: height });
+      }
+    });
+  }
+
+  componentDidMount() {
+    StatusBarIOS.addListener(
+      'statusBarFrameDidChange',
+      this.handleStatusBarHeightChange
+    );
+  }
+
+  componentWillUnmount() {
+    StatusBarIOS.removeEventListener(
+      'statusBarFrameDidChange',
+      this.handleStatusBarHeightChange
+    );
+  }
+
+  handleStatusBarHeightChange = (statusBarData: StatusBarDataType) => {
+    const { y, height } = statusBarData.frame;
+    this.setState({ statusBarTop: y, statusBarHeight: height });
+  };
+
+  render() {
+    return this.props.render(this.state);
+  }
+}

--- a/src/views/Header/WithStatusBarHeight.js
+++ b/src/views/Header/WithStatusBarHeight.js
@@ -1,19 +1,11 @@
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import { Platform, StatusBar, StatusBarIOS, NativeModules } from 'react-native';
 const isIos = Platform.OS === 'ios';
 const { StatusBarManager } = NativeModules;
 
 // TODO revisit this once https://github.com/facebook/react-native/pull/16478 is out
-type StatusBarFrame = {
-  y: number,
-  height: number,
-};
-
-type StatusBarDataType = {
-  frame: StatusBarFrame,
-};
 
 export type StatusBarHeightState = {
   statusBarTop: number,
@@ -24,11 +16,8 @@ type Props = {
   render: StatusBarHeightState => React$Element<*>,
 };
 
-export default class WithStatusBarHeight extends React.Component<
-  Props,
-  T,
-  StatusBarHeightState
-> {
+export default class WithStatusBarHeight extends React.Component {
+  props: Props;
   state: StatusBarHeightState;
 
   constructor(props: Props) {
@@ -36,37 +25,34 @@ export default class WithStatusBarHeight extends React.Component<
 
     const initialHeight = isIos ? 20 : 0;
     this.state = { statusBarTop: 0, statusBarHeight: initialHeight };
+
     if (isIos) {
-      this.fetchInitialHeightIOS();
+      this.fetchCurrentHeightIOS();
     }
   }
 
-  fetchInitialHeightIOS() {
+  fetchCurrentHeightIOS = () => {
+    // we always fetch current height because this is the only way ot works on iphoneX
     StatusBarManager.getHeight(({ height }: { height: number }) => {
       if (Math.abs(this.state.statusBarHeight - height) > 0.01) {
         this.setState({ statusBarHeight: height });
       }
     });
-  }
+  };
 
   componentDidMount() {
     StatusBarIOS.addListener(
-      'statusBarFrameDidChange',
-      this.handleStatusBarHeightChange
+      'statusBarFrameWillChange',
+      this.fetchCurrentHeightIOS
     );
   }
 
   componentWillUnmount() {
     StatusBarIOS.removeEventListener(
-      'statusBarFrameDidChange',
-      this.handleStatusBarHeightChange
+      'statusBarFrameWillChange',
+      this.fetchCurrentHeightIOS
     );
   }
-
-  handleStatusBarHeightChange = (statusBarData: StatusBarDataType) => {
-    const { y, height } = statusBarData.frame;
-    this.setState({ statusBarTop: y, statusBarHeight: height });
-  };
 
   render() {
     return this.props.render(this.state);

--- a/src/views/Header/WithStatusBarHeight.js
+++ b/src/views/Header/WithStatusBarHeight.js
@@ -34,7 +34,7 @@ export default class WithStatusBarHeight extends React.Component<
   constructor(props: Props) {
     super(props);
 
-    const initialHeight = isIos ? 20 : StatusBar.currentHeight;
+    const initialHeight = isIos ? 20 : 0;
     this.state = { statusBarTop: 0, statusBarHeight: initialHeight };
     if (isIos) {
       this.fetchInitialHeightIOS();


### PR DESCRIPTION
This should fix #2795 - the navbar height is currently only influenced by orientation.

Note that I've not used a HOC but a [render prop](https://cdb.reacttraining.com/use-a-render-prop-50de598f11ce) approach, because I find it better (see the link for reasons why). The diff is actually smaller than it seems, the body of the render function of `Header` was almost not touched.

todo: circle fails probably because of missing mock
related https://github.com/facebook/react-native/pull/16478

iphone 7:

<img src="https://user-images.githubusercontent.com/1566403/32076068-02b0c878-ba9f-11e7-8ae6-fa6b2ddde04f.png" width="800">


<img src="https://user-images.githubusercontent.com/1566403/32076092-14b3f87e-ba9f-11e7-93fe-d1005c5e7962.png" height="600">


iphone x:


<img src="https://user-images.githubusercontent.com/1566403/32076106-1f11f62c-ba9f-11e7-81e5-146a739656d4.png" width="800">

<img src="https://user-images.githubusercontent.com/1566403/32076105-1ef1c74e-ba9f-11e7-8f4d-817f44c483e4.png" height="600">

