### PR TITLE
Fix handle Android back button example in docs

### DIFF
--- a/docs/guides/Redux-Integration.md
+++ b/docs/guides/Redux-Integration.md
@@ -115,7 +115,7 @@ class ReduxNavigation extends React.Component {
     if (nav.index === 0) {
       return false;
     }
-    dispatch(NavigationActions.back());
+    this.props.dispatch(NavigationActions.back());
     return true;
   };
 


### PR DESCRIPTION
I was following the documentation to make the back button work on Android when react-navigation is integrated with redux.  The example code triggers an error!

`dispatch` isn't available in onBackPress, it comes from props!

**Test plan (required)**
I tested on Android. Before the fix, it showed an error. After, no more error!

