### PR TITLE
Add iPhone X SafeAreaView

### DIFF
--- a/examples/NavigationPlayground/js/App.js
+++ b/examples/NavigationPlayground/js/App.js
@@ -58,12 +58,14 @@ const ExampleRoutes = {
     screen: CustomTransitioner,
   },
   ModalStack: {
-    name: Platform.OS === 'ios'
-      ? 'Modal Stack Example'
-      : 'Stack with Dynamic Header',
-    description: Platform.OS === 'ios'
-      ? 'Stack navigation with modals'
-      : 'Dynamically showing and hiding the header',
+    name:
+      Platform.OS === 'ios'
+        ? 'Modal Stack Example'
+        : 'Stack with Dynamic Header',
+    description:
+      Platform.OS === 'ios'
+        ? 'Stack navigation with modals'
+        : 'Dynamically showing and hiding the header',
     screen: ModalStack,
   },
   StacksInTabs: {
@@ -91,38 +93,32 @@ const ExampleRoutes = {
 };
 
 const MainScreen = ({ navigation }) => (
-  <SafeAreaView
-    forceInset={{ horizontal: 'never', bottom: 'never' }}
-    style={{ flex: 1 }}
-  >
-    <ScrollView style={{ flex: 1 }} contentInsetAdjustmentBehavior="automatic">
-      <Banner />
-      {Object.keys(ExampleRoutes).map((routeName: string) => (
-        <TouchableOpacity
-          key={routeName}
-          onPress={() => {
-            const { path, params, screen } = ExampleRoutes[routeName];
-            const { router } = screen;
-            const action =
-              path && router.getActionForPathAndParams(path, params);
-            navigation.navigate(routeName, {}, action);
-          }}
+  <ScrollView style={{ flex: 1 }} contentInsetAdjustmentBehavior="automatic">
+    <Banner />
+    {Object.keys(ExampleRoutes).map((routeName: string) => (
+      <TouchableOpacity
+        key={routeName}
+        onPress={() => {
+          const { path, params, screen } = ExampleRoutes[routeName];
+          const { router } = screen;
+          const action = path && router.getActionForPathAndParams(path, params);
+          navigation.navigate(routeName, {}, action);
+        }}
+      >
+        <SafeAreaView
+          style={styles.itemContainer}
+          forceInset={{ vertical: 'never' }}
         >
-          <SafeAreaView
-            style={styles.itemContainer}
-            forceInset={{ vertical: 'never' }}
-          >
-            <View style={styles.item}>
-              <Text style={styles.title}>{ExampleRoutes[routeName].name}</Text>
-              <Text style={styles.description}>
-                {ExampleRoutes[routeName].description}
-              </Text>
-            </View>
-          </SafeAreaView>
-        </TouchableOpacity>
-      ))}
-    </ScrollView>
-  </SafeAreaView>
+          <View style={styles.item}>
+            <Text style={styles.title}>{ExampleRoutes[routeName].name}</Text>
+            <Text style={styles.description}>
+              {ExampleRoutes[routeName].description}
+            </Text>
+          </View>
+        </SafeAreaView>
+      </TouchableOpacity>
+    ))}
+  </ScrollView>
 );
 
 const AppNavigator = StackNavigator(

--- a/examples/NavigationPlayground/js/App.js
+++ b/examples/NavigationPlayground/js/App.js
@@ -13,7 +13,7 @@ import {
   Text,
   View,
 } from 'react-native';
-import { StackNavigator } from 'react-navigation';
+import { SafeAreaView, StackNavigator } from 'react-navigation';
 
 import Banner from './Banner';
 import CustomTabs from './CustomTabs';
@@ -91,27 +91,38 @@ const ExampleRoutes = {
 };
 
 const MainScreen = ({ navigation }) => (
-  <ScrollView>
-    <Banner />
-    {Object.keys(ExampleRoutes).map((routeName: string) => (
-      <TouchableOpacity
-        key={routeName}
-        onPress={() => {
-          const { path, params, screen } = ExampleRoutes[routeName];
-          const { router } = screen;
-          const action = path && router.getActionForPathAndParams(path, params);
-          navigation.navigate(routeName, {}, action);
-        }}
-      >
-        <View style={styles.item}>
-          <Text style={styles.title}>{ExampleRoutes[routeName].name}</Text>
-          <Text style={styles.description}>
-            {ExampleRoutes[routeName].description}
-          </Text>
-        </View>
-      </TouchableOpacity>
-    ))}
-  </ScrollView>
+  <SafeAreaView
+    forceInset={{ horizontal: 'never', bottom: 'never' }}
+    style={{ flex: 1 }}
+  >
+    <ScrollView style={{ flex: 1 }} contentInsetAdjustmentBehavior="automatic">
+      <Banner />
+      {Object.keys(ExampleRoutes).map((routeName: string) => (
+        <TouchableOpacity
+          key={routeName}
+          onPress={() => {
+            const { path, params, screen } = ExampleRoutes[routeName];
+            const { router } = screen;
+            const action =
+              path && router.getActionForPathAndParams(path, params);
+            navigation.navigate(routeName, {}, action);
+          }}
+        >
+          <SafeAreaView
+            style={styles.itemContainer}
+            forceInset={{ vertical: 'never' }}
+          >
+            <View style={styles.item}>
+              <Text style={styles.title}>{ExampleRoutes[routeName].name}</Text>
+              <Text style={styles.description}>
+                {ExampleRoutes[routeName].description}
+              </Text>
+            </View>
+          </SafeAreaView>
+        </TouchableOpacity>
+      ))}
+    </ScrollView>
+  </SafeAreaView>
 );
 
 const AppNavigator = StackNavigator(
@@ -137,9 +148,11 @@ export default () => <AppNavigator />;
 
 const styles = StyleSheet.create({
   item: {
-    backgroundColor: '#fff',
     paddingHorizontal: 16,
     paddingVertical: 12,
+  },
+  itemContainer: {
+    backgroundColor: '#fff',
     borderBottomWidth: StyleSheet.hairlineWidth,
     borderBottomColor: '#ddd',
   },

--- a/examples/NavigationPlayground/js/Banner.js
+++ b/examples/NavigationPlayground/js/Banner.js
@@ -3,23 +3,30 @@
 import React from 'react';
 
 import { Image, Platform, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-navigation';
 
 const Banner = () => (
-  <View style={styles.banner}>
-    <Image source={require('./assets/NavLogo.png')} style={styles.image} />
-    <Text style={styles.title}>React Navigation Examples</Text>
-  </View>
+  <SafeAreaView
+    style={styles.bannerContainer}
+    forceInset={{ vertical: 'never' }}
+  >
+    <View style={styles.banner}>
+      <Image source={require('./assets/NavLogo.png')} style={styles.image} />
+      <Text style={styles.title}>React Navigation Examples</Text>
+    </View>
+  </SafeAreaView>
 );
 
 export default Banner;
 
 const styles = StyleSheet.create({
-  banner: {
+  bannerContainer: {
     backgroundColor: '#673ab7',
+  },
+  banner: {
     flexDirection: 'row',
     alignItems: 'center',
     padding: 16,
-    marginTop: Platform.OS === 'ios' ? 20 : 0,
   },
   image: {
     width: 36,

--- a/examples/NavigationPlayground/js/CustomTabs.js
+++ b/examples/NavigationPlayground/js/CustomTabs.js
@@ -15,6 +15,7 @@ import {
 import {
   createNavigator,
   createNavigationContainer,
+  SafeAreaView,
   TabRouter,
   addNavigationHelpers,
 } from 'react-navigation';
@@ -22,13 +23,15 @@ import SampleText from './SampleText';
 
 const MyNavScreen = ({ navigation, banner }) => (
   <ScrollView>
-    <SampleText>{banner}</SampleText>
-    <Button
-      onPress={() => {
-        navigation.goBack(null);
-      }}
-      title="Go back"
-    />
+    <SafeAreaView forceInset={{ horizontal: 'always' }}>
+      <SampleText>{banner}</SampleText>
+      <Button
+        onPress={() => {
+          navigation.goBack(null);
+        }}
+        title="Go back"
+      />
+    </SafeAreaView>
   </ScrollView>
 );
 
@@ -47,7 +50,7 @@ const MySettingsScreen = ({ navigation }) => (
 const CustomTabBar = ({ navigation }) => {
   const { routes } = navigation.state;
   return (
-    <View style={styles.tabContainer}>
+    <SafeAreaView style={styles.tabContainer}>
       {routes.map(route => (
         <TouchableOpacity
           onPress={() => navigation.navigate(route.routeName)}
@@ -57,7 +60,7 @@ const CustomTabBar = ({ navigation }) => {
           <Text>{route.routeName}</Text>
         </TouchableOpacity>
       ))}
-    </View>
+    </SafeAreaView>
   );
 };
 
@@ -65,7 +68,7 @@ const CustomTabView = ({ router, navigation }) => {
   const { routes, index } = navigation.state;
   const ActiveScreen = router.getComponentForRouteName(routes[index].routeName);
   return (
-    <View style={styles.container}>
+    <SafeAreaView forceInset={{ top: 'always' }}>
       <CustomTabBar navigation={navigation} />
       <ActiveScreen
         navigation={addNavigationHelpers({
@@ -73,7 +76,7 @@ const CustomTabView = ({ router, navigation }) => {
           state: routes[index],
         })}
       />
-    </View>
+    </SafeAreaView>
   );
 };
 
@@ -103,9 +106,6 @@ const CustomTabs = createNavigationContainer(
 );
 
 const styles = StyleSheet.create({
-  container: {
-    marginTop: Platform.OS === 'ios' ? 20 : 0,
-  },
   tabContainer: {
     flexDirection: 'row',
     height: 48,

--- a/examples/NavigationPlayground/js/CustomTransitioner.js
+++ b/examples/NavigationPlayground/js/CustomTransitioner.js
@@ -10,28 +10,27 @@ import {
 } from 'react-native';
 import {
   Transitioner,
+  SafeAreaView,
   StackRouter,
   createNavigationContainer,
   addNavigationHelpers,
-  createNavigator
+  createNavigator,
 } from 'react-navigation';
 import SampleText from './SampleText';
 
 const MyNavScreen = ({ navigation, banner }) => (
-  <View>
+  <SafeAreaView forceInset={{ top: 'always' }}>
     <SampleText>{banner}</SampleText>
-    {navigation.state && navigation.state.routeName !== 'Settings' &&
-      <Button
-        onPress={() => navigation.navigate('Settings')}
-        title="Go to a settings screen"
-      />
-    }
-    
-    <Button
-      onPress={() => navigation.goBack(null)}
-      title="Go back"
-    />
-  </View>
+    {navigation.state &&
+      navigation.state.routeName !== 'Settings' && (
+        <Button
+          onPress={() => navigation.navigate('Settings')}
+          title="Go to a settings screen"
+        />
+      )}
+
+    <Button onPress={() => navigation.goBack(null)} title="Go back" />
+  </SafeAreaView>
 );
 
 const MyHomeScreen = ({ navigation }) => (
@@ -63,13 +62,11 @@ class CustomNavigationView extends Component {
   }
 
   _render = (transitionProps, prevTransitionProps) => {
-    const scenes = transitionProps.scenes.map(scene => this._renderScene(transitionProps, scene));
-    return (
-      <View style={{ flex: 1 }}>
-        {scenes}
-      </View>
+    const scenes = transitionProps.scenes.map(scene =>
+      this._renderScene(transitionProps, scene)
     );
-  }
+    return <View style={{ flex: 1 }}>{scenes}</View>;
+  };
 
   _renderScene = (transitionProps, scene) => {
     const { navigation, router } = this.props;
@@ -84,9 +81,7 @@ class CustomNavigationView extends Component {
 
     const animation = {
       opacity: animatedValue,
-      transform: [
-        { scale: animatedValue },
-      ],
+      transform: [{ scale: animatedValue }],
     };
 
     // The prop `router` is populated when we call `createNavigator`.
@@ -100,8 +95,8 @@ class CustomNavigationView extends Component {
           })}
         />
       </Animated.View>
-    )
-  }
+    );
+  };
 }
 
 const CustomRouter = StackRouter({
@@ -116,9 +111,6 @@ const CustomTransitioner = createNavigationContainer(
 export default CustomTransitioner;
 
 const styles = StyleSheet.create({
-  container: {
-    marginTop: Platform.OS === 'ios' ? 20 : 0,
-  },
   view: {
     position: 'absolute',
     left: 0,

--- a/examples/NavigationPlayground/js/Drawer.js
+++ b/examples/NavigationPlayground/js/Drawer.js
@@ -3,19 +3,21 @@
  */
 
 import React from 'react';
-import { Button, Platform, ScrollView, StyleSheet } from 'react-native';
-import { DrawerNavigator } from 'react-navigation';
+import { Button, Platform, ScrollView } from 'react-native';
+import { DrawerNavigator, SafeAreaView } from 'react-navigation';
 import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
 import SampleText from './SampleText';
 
 const MyNavScreen = ({ navigation, banner }) => (
-  <ScrollView style={styles.container}>
-    <SampleText>{banner}</SampleText>
-    <Button
-      onPress={() => navigation.navigate('DrawerOpen')}
-      title="Open drawer"
-    />
-    <Button onPress={() => navigation.goBack(null)} title="Go back" />
+  <ScrollView>
+    <SafeAreaView forceInset={{ top: 'always' }}>
+      <SampleText>{banner}</SampleText>
+      <Button
+        onPress={() => navigation.navigate('DrawerOpen')}
+        title="Open drawer"
+      />
+      <Button onPress={() => navigation.goBack(null)} title="Go back" />
+    </SafeAreaView>
   </ScrollView>
 );
 
@@ -61,11 +63,5 @@ const DrawerExample = DrawerNavigator(
     },
   }
 );
-
-const styles = StyleSheet.create({
-  container: {
-    marginTop: Platform.OS === 'ios' ? 20 : 0,
-  },
-});
 
 export default DrawerExample;

--- a/examples/NavigationPlayground/js/ModalStack.js
+++ b/examples/NavigationPlayground/js/ModalStack.js
@@ -4,30 +4,38 @@
 
 import React from 'react';
 import { Button, ScrollView, Text } from 'react-native';
-import { StackNavigator } from 'react-navigation';
+import { SafeAreaView, StackNavigator } from 'react-navigation';
 import SampleText from './SampleText';
 
 const MyNavScreen = ({ navigation, banner }) => (
-  <ScrollView>
-    <SampleText>{banner}</SampleText>
-    <Button
-      onPress={() => navigation.navigate('Profile', { name: 'Jane' })}
-      title="Go to a profile screen"
-    />
-    <Button
-      onPress={() => navigation.navigate('HeaderTest')}
-      title="Go to a header toggle screen"
-    />
-    {navigation.state.routeName === 'HeaderTest' &&
+  <ScrollView contentInsetAdjustmentBehavior="automatic">
+    <SafeAreaView
+      forceInset={{
+        top: navigation.state.routeName === 'HeaderTest' ? 'always' : 'never',
+      }}
+    >
+      <SampleText>{banner}</SampleText>
       <Button
-        title="Toggle Header"
-        onPress={() =>
-          navigation.setParams({
-            headerVisible: !navigation.state.params ||
-              !navigation.state.params.headerVisible,
-          })}
-      />}
-    <Button onPress={() => navigation.goBack(null)} title="Go back" />
+        onPress={() => navigation.navigate('Profile', { name: 'Jane' })}
+        title="Go to a profile screen"
+      />
+      <Button
+        onPress={() => navigation.navigate('HeaderTest')}
+        title="Go to a header toggle screen"
+      />
+      {navigation.state.routeName === 'HeaderTest' && (
+        <Button
+          title="Toggle Header"
+          onPress={() =>
+            navigation.setParams({
+              headerVisible:
+                !navigation.state.params ||
+                !navigation.state.params.headerVisible,
+            })}
+        />
+      )}
+      <Button onPress={() => navigation.goBack(null)} title="Go back" />
+    </SafeAreaView>
   </ScrollView>
 );
 

--- a/examples/NavigationPlayground/js/SimpleStack.js
+++ b/examples/NavigationPlayground/js/SimpleStack.js
@@ -4,11 +4,11 @@
 
 import React from 'react';
 import { Button, ScrollView } from 'react-native';
-import { StackNavigator } from 'react-navigation';
+import { StackNavigator, SafeAreaView } from 'react-navigation';
 import SampleText from './SampleText';
 
 const MyNavScreen = ({ navigation, banner }) => (
-  <ScrollView>
+  <SafeAreaView>
     <SampleText>{banner}</SampleText>
     <Button
       onPress={() => navigation.navigate('Profile', { name: 'Jane' })}
@@ -19,7 +19,7 @@ const MyNavScreen = ({ navigation, banner }) => (
       title="Go to a photos screen"
     />
     <Button onPress={() => navigation.goBack(null)} title="Go back" />
-  </ScrollView>
+  </SafeAreaView>
 );
 
 const MyHomeScreen = ({ navigation }) => (
@@ -41,7 +41,9 @@ MyPhotosScreen.navigationOptions = {
 
 const MyProfileScreen = ({ navigation }) => (
   <MyNavScreen
-    banner={`${navigation.state.params.mode === 'edit' ? 'Now Editing ' : ''}${navigation.state.params.name}'s Profile`}
+    banner={`${navigation.state.params.mode === 'edit'
+      ? 'Now Editing '
+      : ''}${navigation.state.params.name}'s Profile`}
     navigation={navigation}
   />
 );

--- a/examples/NavigationPlayground/js/SimpleTabs.js
+++ b/examples/NavigationPlayground/js/SimpleTabs.js
@@ -3,13 +3,13 @@
  */
 
 import React from 'react';
-import { Button, Platform, ScrollView, StyleSheet } from 'react-native';
-import { TabNavigator } from 'react-navigation';
+import { Button, Platform, ScrollView, View } from 'react-native';
+import { SafeAreaView, TabNavigator } from 'react-navigation';
 import Ionicons from 'react-native-vector-icons/Ionicons';
 import SampleText from './SampleText';
 
 const MyNavScreen = ({ navigation, banner }) => (
-  <ScrollView style={styles.container}>
+  <SafeAreaView forceInset={{ horizontal: 'always', top: 'always' }}>
     <SampleText>{banner}</SampleText>
     <Button
       onPress={() => navigation.navigate('Home')}
@@ -20,7 +20,7 @@ const MyNavScreen = ({ navigation, banner }) => (
       title="Go to settings tab"
     />
     <Button onPress={() => navigation.goBack(null)} title="Go back" />
-  </ScrollView>
+  </SafeAreaView>
 );
 
 const MyHomeScreen = ({ navigation }) => (
@@ -112,11 +112,5 @@ const SimpleTabs = TabNavigator(
     },
   }
 );
-
-const styles = StyleSheet.create({
-  container: {
-    marginTop: Platform.OS === 'ios' ? 20 : 0,
-  },
-});
 
 export default SimpleTabs;

--- a/examples/NavigationPlayground/js/StacksInTabs.js
+++ b/examples/NavigationPlayground/js/StacksInTabs.js
@@ -4,27 +4,29 @@
 
 import React from 'react';
 import { Button, ScrollView } from 'react-native';
-import { StackNavigator, TabNavigator } from 'react-navigation';
+import { SafeAreaView, StackNavigator, TabNavigator } from 'react-navigation';
 
 import Ionicons from 'react-native-vector-icons/Ionicons';
 import SampleText from './SampleText';
 
 const MyNavScreen = ({ navigation, banner }) => (
   <ScrollView>
-    <SampleText>{banner}</SampleText>
-    <Button
-      onPress={() => navigation.navigate('Profile', { name: 'Jordan' })}
-      title="Open profile screen"
-    />
-    <Button
-      onPress={() => navigation.navigate('NotifSettings')}
-      title="Open notifications screen"
-    />
-    <Button
-      onPress={() => navigation.navigate('SettingsTab')}
-      title="Go to settings tab"
-    />
-    <Button onPress={() => navigation.goBack(null)} title="Go back" />
+    <SafeAreaView forceInset={{ horizontal: 'always' }}>
+      <SampleText>{banner}</SampleText>
+      <Button
+        onPress={() => navigation.navigate('Profile', { name: 'Jordan' })}
+        title="Open profile screen"
+      />
+      <Button
+        onPress={() => navigation.navigate('NotifSettings')}
+        title="Open notifications screen"
+      />
+      <Button
+        onPress={() => navigation.navigate('SettingsTab')}
+        title="Go to settings tab"
+      />
+      <Button onPress={() => navigation.goBack(null)} title="Go back" />
+    </SafeAreaView>
   </ScrollView>
 );
 

--- a/examples/NavigationPlayground/js/StacksOverTabs.js
+++ b/examples/NavigationPlayground/js/StacksOverTabs.js
@@ -4,27 +4,29 @@
 
 import React from 'react';
 import { Button, ScrollView } from 'react-native';
-import { StackNavigator, TabNavigator } from 'react-navigation';
+import { SafeAreaView, StackNavigator, TabNavigator } from 'react-navigation';
 
 import Ionicons from 'react-native-vector-icons/Ionicons';
 import SampleText from './SampleText';
 
 const MyNavScreen = ({ navigation, banner }) => (
   <ScrollView>
-    <SampleText>{banner}</SampleText>
-    <Button
-      onPress={() => navigation.navigate('Profile', { name: 'Jordan' })}
-      title="Open profile screen"
-    />
-    <Button
-      onPress={() => navigation.navigate('NotifSettings')}
-      title="Open notifications screen"
-    />
-    <Button
-      onPress={() => navigation.navigate('SettingsTab')}
-      title="Go to settings tab"
-    />
-    <Button onPress={() => navigation.goBack(null)} title="Go back" />
+    <SafeAreaView forceInset={{ horizontal: 'always' }}>
+      <SampleText>{banner}</SampleText>
+      <Button
+        onPress={() => navigation.navigate('Profile', { name: 'Jordan' })}
+        title="Open profile screen"
+      />
+      <Button
+        onPress={() => navigation.navigate('NotifSettings')}
+        title="Open notifications screen"
+      />
+      <Button
+        onPress={() => navigation.navigate('SettingsTab')}
+        title="Go to settings tab"
+      />
+      <Button onPress={() => navigation.goBack(null)} title="Go back" />
+    </SafeAreaView>
   </ScrollView>
 );
 

--- a/examples/NavigationPlayground/js/TabsInDrawer.js
+++ b/examples/NavigationPlayground/js/TabsInDrawer.js
@@ -3,7 +3,7 @@
  */
 
 import React from 'react';
-import { Button, Platform, ScrollView, StyleSheet } from 'react-native';
+import { Button, Platform, ScrollView } from 'react-native';
 import { TabNavigator, DrawerNavigator } from 'react-navigation';
 import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
 import SimpleTabs from './SimpleTabs';
@@ -39,12 +39,6 @@ const TabsInDrawer = DrawerNavigator({
         ),
       }),
     },
-  },
-});
-
-const styles = StyleSheet.create({
-  container: {
-    marginTop: Platform.OS === 'ios' ? 20 : 0,
   },
 });
 

--- a/examples/NavigationPlayground/package.json
+++ b/examples/NavigationPlayground/package.json
@@ -23,7 +23,7 @@
     "jest": "^21.0.1",
     "jest-expo": "^22.0.0",
     "react-addons-test-utils": "16.0.0-alpha.3",
-    "react-native-scripts": "^1.3.1",
+    "react-native-scripts": "^1.5.0",
     "react-test-renderer": "16.0.0-alpha.12"
   },
   "jest": {

--- a/examples/NavigationPlayground/yarn.lock
+++ b/examples/NavigationPlayground/yarn.lock
@@ -26,7 +26,7 @@
     babel-runtime "^6.23.0"
     exec-async "^2.2.0"
 
-"@expo/schemer@^1.0.28":
+"@expo/schemer@1.0.44":
   version "1.0.44"
   resolved "https://registry.yarnpkg.com/@expo/schemer/-/schemer-1.0.44.tgz#d74a94ba0217f160c1a86ce1c6a42f581485a542"
   dependencies:
@@ -2596,7 +2596,7 @@ invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
 
-ip@^1.1.3, ip@^1.1.4, ip@^1.1.5:
+ip@^1.1.4, ip@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
 
@@ -4598,9 +4598,9 @@ react-native-safe-module@^1.1.0:
   dependencies:
     dedent "^0.6.0"
 
-react-native-scripts@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/react-native-scripts/-/react-native-scripts-1.3.1.tgz#58de56f4f8b4b298c5c8c5bd3890c187f92307ec"
+react-native-scripts@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/react-native-scripts/-/react-native-scripts-1.5.0.tgz#4f05b3620ef010d154286c46d70c7bfc2d11d725"
   dependencies:
     "@expo/bunyan" "1.8.10"
     babel-runtime "^6.9.2"
@@ -4609,13 +4609,14 @@ react-native-scripts@^1.3.1:
     fs-extra "^3.0.1"
     indent-string "^3.0.0"
     inquirer "^3.0.1"
+    lodash "^4.17.4"
     match-require "^2.0.0"
     minimist "^1.2.0"
     path-exists "^3.0.0"
     progress "^2.0.0"
     qrcode-terminal "^0.11.0"
     rimraf "^2.6.1"
-    xdl "44.0.0"
+    xdl "45.0.0"
 
 react-native-svg@5.4.2:
   version "5.4.2"
@@ -5938,14 +5939,14 @@ xcode@^0.9.1:
     simple-plist "^0.2.1"
     uuid "3.0.1"
 
-xdl@44.0.0:
-  version "44.0.0"
-  resolved "https://registry.yarnpkg.com/xdl/-/xdl-44.0.0.tgz#72ef1231c12d88348141814076c96c54ad0903a0"
+xdl@45.0.0:
+  version "45.0.0"
+  resolved "https://registry.yarnpkg.com/xdl/-/xdl-45.0.0.tgz#427b7f5e22151ed3124aba7b8e01989601fa43ee"
   dependencies:
     "@expo/bunyan" "^1.8.10"
     "@expo/json-file" "^5.3.0"
     "@expo/osascript" "^1.8.0"
-    "@expo/schemer" "^1.0.28"
+    "@expo/schemer" "1.0.44"
     "@expo/spawn-async" "^1.2.8"
     analytics-node "^2.1.0"
     auth0 "^2.7.0"
@@ -5965,7 +5966,6 @@ xdl@44.0.0:
     home-dir "^1.0.0"
     indent-string "^3.1.0"
     instapromise "2.0.7-rc.1"
-    ip "^1.1.3"
     joi "^10.0.2"
     jsonfile "^2.3.1"
     jsonschema "^1.1.0"

--- a/src/navigators/__tests__/__snapshots__/DrawerNavigator-test.js.snap
+++ b/src/navigators/__tests__/__snapshots__/DrawerNavigator-test.js.snap
@@ -92,74 +92,96 @@ exports[`DrawerNavigator renders successfully 1`] = `
       }
     >
       <View
+        onLayout={[Function]}
         style={
           Array [
-            Object {
-              "marginTop": 20,
-              "paddingVertical": 4,
-            },
             undefined,
+            Object {
+              "paddingBottom": 0,
+              "paddingLeft": 0,
+              "paddingRight": 0,
+              "paddingTop": 20,
+            },
           ]
         }
       >
         <View
-          accessibilityComponentType={undefined}
-          accessibilityLabel={undefined}
-          accessibilityTraits={undefined}
-          accessible={true}
-          collapsable={undefined}
-          hitSlop={undefined}
-          isTVSelectable={true}
-          nativeID={undefined}
-          onLayout={undefined}
-          onResponderGrant={[Function]}
-          onResponderMove={[Function]}
-          onResponderRelease={[Function]}
-          onResponderTerminate={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
           style={
-            Object {
-              "opacity": 1,
-            }
+            Array [
+              Object {
+                "paddingVertical": 4,
+              },
+              undefined,
+            ]
           }
-          testID={undefined}
-          tvParallaxProperties={undefined}
         >
           <View
+            accessibilityComponentType={undefined}
+            accessibilityLabel={undefined}
+            accessibilityTraits={undefined}
+            accessible={true}
+            collapsable={undefined}
+            hitSlop={undefined}
+            isTVSelectable={true}
+            nativeID={undefined}
+            onLayout={undefined}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
             style={
-              Array [
-                Object {
-                  "alignItems": "center",
-                  "flexDirection": "row",
-                },
-                Object {
-                  "backgroundColor": "rgba(0, 0, 0, .04)",
-                },
-                undefined,
-              ]
+              Object {
+                "opacity": 1,
+              }
             }
+            testID={undefined}
+            tvParallaxProperties={undefined}
           >
-            <Text
-              accessible={true}
-              allowFontScaling={true}
-              disabled={false}
-              ellipsizeMode="tail"
+            <View
+              onLayout={[Function]}
               style={
                 Array [
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                    },
+                    Object {
+                      "backgroundColor": "rgba(0, 0, 0, .04)",
+                    },
+                  ],
                   Object {
-                    "fontWeight": "bold",
-                    "margin": 16,
+                    "paddingBottom": 0,
+                    "paddingLeft": 0,
+                    "paddingRight": 0,
+                    "paddingTop": 20,
                   },
-                  Object {
-                    "color": "#2196f3",
-                  },
-                  undefined,
                 ]
               }
             >
-              Welcome anonymous
-            </Text>
+              <Text
+                accessible={true}
+                allowFontScaling={true}
+                disabled={false}
+                ellipsizeMode="tail"
+                style={
+                  Array [
+                    Object {
+                      "fontWeight": "bold",
+                      "margin": 16,
+                    },
+                    Object {
+                      "color": "#2196f3",
+                    },
+                    undefined,
+                  ]
+                }
+              >
+                Welcome anonymous
+              </Text>
+            </View>
           </View>
         </View>
       </View>

--- a/src/navigators/__tests__/__snapshots__/DrawerNavigator-test.js.snap
+++ b/src/navigators/__tests__/__snapshots__/DrawerNavigator-test.js.snap
@@ -151,6 +151,7 @@ exports[`DrawerNavigator renders successfully 1`] = `
                     Object {
                       "backgroundColor": "rgba(0, 0, 0, .04)",
                     },
+                    undefined,
                   ],
                   Object {
                     "paddingBottom": 0,

--- a/src/navigators/__tests__/__snapshots__/DrawerNavigator-test.js.snap
+++ b/src/navigators/__tests__/__snapshots__/DrawerNavigator-test.js.snap
@@ -143,16 +143,9 @@ exports[`DrawerNavigator renders successfully 1`] = `
               onLayout={[Function]}
               style={
                 Array [
-                  Array [
-                    Object {
-                      "alignItems": "center",
-                      "flexDirection": "row",
-                    },
-                    Object {
-                      "backgroundColor": "rgba(0, 0, 0, .04)",
-                    },
-                    undefined,
-                  ],
+                  Object {
+                    "backgroundColor": "rgba(0, 0, 0, .04)",
+                  },
                   Object {
                     "paddingBottom": 0,
                     "paddingLeft": 0,
@@ -162,26 +155,38 @@ exports[`DrawerNavigator renders successfully 1`] = `
                 ]
               }
             >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                disabled={false}
-                ellipsizeMode="tail"
+              <View
                 style={
                   Array [
                     Object {
-                      "fontWeight": "bold",
-                      "margin": 16,
-                    },
-                    Object {
-                      "color": "#2196f3",
+                      "alignItems": "center",
+                      "flexDirection": "row",
                     },
                     undefined,
                   ]
                 }
               >
-                Welcome anonymous
-              </Text>
+                <Text
+                  accessible={true}
+                  allowFontScaling={true}
+                  disabled={false}
+                  ellipsizeMode="tail"
+                  style={
+                    Array [
+                      Object {
+                        "fontWeight": "bold",
+                        "margin": 16,
+                      },
+                      Object {
+                        "color": "#2196f3",
+                      },
+                      undefined,
+                    ]
+                  }
+                >
+                  Welcome anonymous
+                </Text>
+              </View>
             </View>
           </View>
         </View>

--- a/src/navigators/__tests__/__snapshots__/StackNavigator-test.js.snap
+++ b/src/navigators/__tests__/__snapshots__/StackNavigator-test.js.snap
@@ -106,116 +106,6 @@ exports[`StackNavigator applies correct values when headerRight is present 1`] =
             "isMeasured": false,
             "width": 0,
           }
-        >
-          <View
-            collapsable={undefined}
-            pointerEvents="box-none"
-            style={
-              Object {
-                "alignItems": "center",
-                "backgroundColor": "transparent",
-                "bottom": 0,
-                "justifyContent": "center",
-                "left": 70,
-                "opacity": 1,
-                "position": "absolute",
-                "right": 70,
-                "top": 0,
-                "transform": Array [
-                  Object {
-                    "translateX": 0,
-                  },
-                ],
-              }
-            }
-          >
-            <Text
-              accessibilityTraits="header"
-              accessible={true}
-              allowFontScaling={true}
-              collapsable={undefined}
-              disabled={false}
-              ellipsizeMode="tail"
-              numberOfLines={1}
-              onLayout={[Function]}
-              style={
-                Object {
-                  "color": "rgba(0, 0, 0, .9)",
-                  "fontSize": 17,
-                  "fontWeight": "600",
-                  "marginHorizontal": 16,
-                  "textAlign": "center",
-                }
-              }
-            >
-              Welcome anonymous
-            </Text>
-          </View>
-          <View
-            collapsable={undefined}
-            pointerEvents="box-none"
-            style={
-              Object {
-                "alignItems": "center",
-                "backgroundColor": "transparent",
-                "bottom": 0,
-                "justifyContent": "center",
-                "opacity": 1,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-              }
-            }
-          >
-            <View />
-          </View>
-        </View>
-      </View>
-    </View>
-  </View>
-</View>
-`;
-
-exports[`StackNavigator renders successfully 1`] = `
-<View
-  onLayout={[Function]}
-  style={
-    Array [
-      Object {
-        "flex": 1,
-      },
-    ]
-  }
->
-  <View
-    onMoveShouldSetResponder={[Function]}
-    onMoveShouldSetResponderCapture={[Function]}
-    onResponderEnd={[Function]}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderReject={[Function]}
-    onResponderRelease={[Function]}
-    onResponderStart={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
-    onStartShouldSetResponderCapture={[Function]}
-    style={
-      Array [
-        Object {
-          "flex": 1,
-          "flexDirection": "column-reverse",
-        },
-        Object {
-          "backgroundColor": "#000",
-        },
-      ]
-    }
-  >
-    <View
-      style={
-        Object {
-          "flex": 1,
         }
         mode="float"
         navigation={
@@ -354,7 +244,6 @@ exports[`StackNavigator renders successfully 1`] = `
       Object {
         "flex": 1,
       },
-      undefined,
     ]
   }
 >

--- a/src/navigators/__tests__/__snapshots__/StackNavigator-test.js.snap
+++ b/src/navigators/__tests__/__snapshots__/StackNavigator-test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`StackNavigator applies correct values when headerRight is present 1`] = `
+exports[`StackNavigator renders successfully 1`] = `
 <View
   onLayout={[Function]}
   style={
@@ -75,81 +75,36 @@ exports[`StackNavigator applies correct values when headerRight is present 1`] =
       />
     </View>
     <View
-      cardStyle={undefined}
-      collapsable={undefined}
-      getScreenDetails={[Function]}
-      headerMode={undefined}
-      index={0}
-      layout={
-        Object {
-          "height": 0,
-          "initHeight": 0,
-          "initWidth": 0,
-          "isMeasured": false,
-          "width": 0,
-        }
-      }
-      mode="float"
-      navigation={
-        Object {
-          "dispatch": [Function],
-          "goBack": [Function],
-          "navigate": [Function],
-          "setParams": [Function],
-          "state": Object {
-            "index": 0,
-            "routes": Array [
-              Object {
-                "key": "Init-id-0-1",
-                "routeName": "Home",
-              },
-            ],
-          },
-        }
-      }
-      router={
-        Object {
-          "getActionForPathAndParams": [Function],
-          "getComponentForRouteName": [Function],
-          "getComponentForState": [Function],
-          "getPathAndParamsForState": [Function],
-          "getScreenConfig": [Function],
-          "getScreenOptions": [Function],
-          "getStateForAction": [Function],
-        }
-      }
+      onLayout={[Function]}
       style={
-        Object {
-          "backgroundColor": "#F7F7F7",
-          "borderBottomColor": "rgba(0, 0, 0, .3)",
-          "borderBottomWidth": 0.5,
-          "height": 64,
-          "paddingTop": 20,
-        }
+        Array [
+          Object {
+            "backgroundColor": "#F7F7F7",
+            "borderBottomColor": "rgba(0, 0, 0, .3)",
+            "borderBottomWidth": 0.5,
+          },
+          Object {
+            "paddingBottom": 0,
+            "paddingLeft": 0,
+            "paddingRight": 0,
+            "paddingTop": 20,
+          },
+        ]
       }
-      transitionConfig={undefined}
     >
       <View
-        style={
+        cardStyle={undefined}
+        collapsable={undefined}
+        getScreenDetails={[Function]}
+        headerMode={undefined}
+        index={0}
+        layout={
           Object {
-            "flex": 1,
-          }
-        }
-      >
-        <View
-          style={
-            Array [
-              Object {
-                "bottom": 0,
-                "left": 0,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-              },
-              Object {
-                "flexDirection": "row",
-              },
-            ]
+            "height": 0,
+            "initHeight": 0,
+            "initWidth": 0,
+            "isMeasured": false,
+            "width": 0,
           }
         >
           <View
@@ -262,160 +217,109 @@ exports[`StackNavigator renders successfully 1`] = `
         Object {
           "flex": 1,
         }
-      }
-    >
-      <View
-        collapsable={undefined}
-        pointerEvents="auto"
-        style={
+        mode="float"
+        navigation={
           Object {
-            "backgroundColor": "#E9E9EF",
-            "bottom": 0,
-            "left": 0,
-            "opacity": 1,
-            "position": "absolute",
-            "right": 0,
-            "shadowColor": "black",
-            "shadowOffset": Object {
-              "height": 0,
-              "width": 0,
+            "dispatch": [Function],
+            "goBack": [Function],
+            "navigate": [Function],
+            "setParams": [Function],
+            "state": Object {
+              "index": 0,
+              "routes": Array [
+                Object {
+                  "key": "Init-id-0-0",
+                  "routeName": "Home",
+                },
+              ],
             },
-            "shadowOpacity": 0.2,
-            "shadowRadius": 5,
-            "top": 0,
-            "transform": Array [
-              Object {
-                "translateX": 0,
-              },
-              Object {
-                "translateY": 0,
-              },
-            ],
           }
         }
-      />
-    </View>
-    <View
-      cardStyle={undefined}
-      collapsable={undefined}
-      getScreenDetails={[Function]}
-      headerMode={undefined}
-      index={0}
-      layout={
-        Object {
-          "height": 0,
-          "initHeight": 0,
-          "initWidth": 0,
-          "isMeasured": false,
-          "width": 0,
+        router={
+          Object {
+            "getActionForPathAndParams": [Function],
+            "getComponentForRouteName": [Function],
+            "getComponentForState": [Function],
+            "getPathAndParamsForState": [Function],
+            "getScreenConfig": [Function],
+            "getScreenOptions": [Function],
+            "getStateForAction": [Function],
+          }
         }
-      }
-      mode="float"
-      navigation={
-        Object {
-          "dispatch": [Function],
-          "goBack": [Function],
-          "navigate": [Function],
-          "setParams": [Function],
-          "state": Object {
-            "index": 0,
-            "routes": Array [
-              Object {
-                "key": "Init-id-0-0",
-                "routeName": "Home",
-              },
-            ],
-          },
-        }
-      }
-      router={
-        Object {
-          "getActionForPathAndParams": [Function],
-          "getComponentForRouteName": [Function],
-          "getComponentForState": [Function],
-          "getPathAndParamsForState": [Function],
-          "getScreenConfig": [Function],
-          "getScreenOptions": [Function],
-          "getStateForAction": [Function],
-        }
-      }
-      style={
-        Object {
-          "backgroundColor": "#F7F7F7",
-          "borderBottomColor": "rgba(0, 0, 0, .3)",
-          "borderBottomWidth": 0.5,
-          "height": 64,
-          "paddingTop": 20,
-        }
-      }
-      transitionConfig={undefined}
-    >
-      <View
         style={
           Object {
-            "flex": 1,
+            "height": 44,
           }
         }
+        transitionConfig={undefined}
       >
         <View
           style={
-            Array [
-              Object {
-                "bottom": 0,
-                "left": 0,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-              },
-              Object {
-                "flexDirection": "row",
-              },
-            ]
+            Object {
+              "flex": 1,
+            }
           }
         >
           <View
-            collapsable={undefined}
-            pointerEvents="box-none"
             style={
-              Object {
-                "alignItems": "center",
-                "backgroundColor": "transparent",
-                "bottom": 0,
-                "justifyContent": "center",
-                "left": 0,
-                "opacity": 1,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-                "transform": Array [
-                  Object {
-                    "translateX": 0,
-                  },
-                ],
-              }
+              Array [
+                Object {
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                },
+                Object {
+                  "flexDirection": "row",
+                },
+              ]
             }
           >
-            <Text
-              accessibilityTraits="header"
-              accessible={true}
-              allowFontScaling={true}
+            <View
               collapsable={undefined}
-              disabled={false}
-              ellipsizeMode="tail"
-              numberOfLines={1}
-              onLayout={[Function]}
+              pointerEvents="box-none"
               style={
                 Object {
-                  "color": "rgba(0, 0, 0, .9)",
-                  "fontSize": 17,
-                  "fontWeight": "600",
-                  "marginHorizontal": 16,
-                  "textAlign": "center",
+                  "alignItems": "center",
+                  "backgroundColor": "transparent",
+                  "bottom": 0,
+                  "justifyContent": "center",
+                  "left": 70,
+                  "opacity": 1,
+                  "position": "absolute",
+                  "right": 70,
+                  "top": 0,
+                  "transform": Array [
+                    Object {
+                      "translateX": 0,
+                    },
+                  ],
                 }
               }
             >
-              Welcome anonymous
-            </Text>
+              <Text
+                accessibilityTraits="header"
+                accessible={true}
+                allowFontScaling={true}
+                collapsable={undefined}
+                disabled={false}
+                ellipsizeMode="tail"
+                numberOfLines={1}
+                onLayout={[Function]}
+                style={
+                  Object {
+                    "color": "rgba(0, 0, 0, .9)",
+                    "fontSize": 17,
+                    "fontWeight": "600",
+                    "marginHorizontal": 16,
+                    "textAlign": "center",
+                  }
+                }
+              >
+                Welcome anonymous
+              </Text>
+            </View>
           </View>
         </View>
       </View>

--- a/src/navigators/__tests__/__snapshots__/StackNavigator-test.js.snap
+++ b/src/navigators/__tests__/__snapshots__/StackNavigator-test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`StackNavigator renders successfully 1`] = `
+exports[`StackNavigator applies correct values when headerRight is present 1`] = `
 <View
   onLayout={[Function]}
   style={
@@ -228,7 +228,7 @@ exports[`StackNavigator renders successfully 1`] = `
               "index": 0,
               "routes": Array [
                 Object {
-                  "key": "Init-id-0-0",
+                  "key": "Init-id-0-1",
                   "routeName": "Home",
                 },
               ],
@@ -289,6 +289,243 @@ exports[`StackNavigator renders successfully 1`] = `
                   "opacity": 1,
                   "position": "absolute",
                   "right": 70,
+                  "top": 0,
+                  "transform": Array [
+                    Object {
+                      "translateX": 0,
+                    },
+                  ],
+                }
+              }
+            >
+              <Text
+                accessibilityTraits="header"
+                accessible={true}
+                allowFontScaling={true}
+                collapsable={undefined}
+                disabled={false}
+                ellipsizeMode="tail"
+                numberOfLines={1}
+                onLayout={[Function]}
+                style={
+                  Object {
+                    "color": "rgba(0, 0, 0, .9)",
+                    "fontSize": 17,
+                    "fontWeight": "600",
+                    "marginHorizontal": 16,
+                    "textAlign": "center",
+                  }
+                }
+              >
+                Welcome anonymous
+              </Text>
+            </View>
+            <View
+              collapsable={undefined}
+              pointerEvents="box-none"
+              style={
+                Object {
+                  "alignItems": "center",
+                  "backgroundColor": "transparent",
+                  "bottom": 0,
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                }
+              }
+            >
+              <View />
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`StackNavigator renders successfully 1`] = `
+<View
+  onLayout={[Function]}
+  style={
+    Array [
+      Object {
+        "flex": 1,
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    onMoveShouldSetResponder={[Function]}
+    onMoveShouldSetResponderCapture={[Function]}
+    onResponderEnd={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderReject={[Function]}
+    onResponderRelease={[Function]}
+    onResponderStart={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    onStartShouldSetResponderCapture={[Function]}
+    style={
+      Array [
+        Object {
+          "flex": 1,
+          "flexDirection": "column-reverse",
+        },
+        Object {
+          "backgroundColor": "#000",
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        Object {
+          "flex": 1,
+        }
+      }
+    >
+      <View
+        collapsable={undefined}
+        pointerEvents="auto"
+        style={
+          Object {
+            "backgroundColor": "#E9E9EF",
+            "bottom": 0,
+            "left": 0,
+            "opacity": 1,
+            "position": "absolute",
+            "right": 0,
+            "shadowColor": "black",
+            "shadowOffset": Object {
+              "height": 0,
+              "width": 0,
+            },
+            "shadowOpacity": 0.2,
+            "shadowRadius": 5,
+            "top": 0,
+            "transform": Array [
+              Object {
+                "translateX": 0,
+              },
+              Object {
+                "translateY": 0,
+              },
+            ],
+          }
+        }
+      />
+    </View>
+    <View
+      onLayout={[Function]}
+      style={
+        Array [
+          Object {
+            "backgroundColor": "#F7F7F7",
+            "borderBottomColor": "rgba(0, 0, 0, .3)",
+            "borderBottomWidth": 0.5,
+          },
+          Object {
+            "paddingBottom": 0,
+            "paddingLeft": 0,
+            "paddingRight": 0,
+            "paddingTop": 20,
+          },
+        ]
+      }
+    >
+      <View
+        cardStyle={undefined}
+        collapsable={undefined}
+        getScreenDetails={[Function]}
+        headerMode={undefined}
+        index={0}
+        layout={
+          Object {
+            "height": 0,
+            "initHeight": 0,
+            "initWidth": 0,
+            "isMeasured": false,
+            "width": 0,
+          }
+        }
+        mode="float"
+        navigation={
+          Object {
+            "dispatch": [Function],
+            "goBack": [Function],
+            "navigate": [Function],
+            "setParams": [Function],
+            "state": Object {
+              "index": 0,
+              "routes": Array [
+                Object {
+                  "key": "Init-id-0-0",
+                  "routeName": "Home",
+                },
+              ],
+            },
+          }
+        }
+        router={
+          Object {
+            "getActionForPathAndParams": [Function],
+            "getComponentForRouteName": [Function],
+            "getComponentForState": [Function],
+            "getPathAndParamsForState": [Function],
+            "getScreenConfig": [Function],
+            "getScreenOptions": [Function],
+            "getStateForAction": [Function],
+          }
+        }
+        style={
+          Object {
+            "height": 44,
+          }
+        }
+        transitionConfig={undefined}
+      >
+        <View
+          style={
+            Object {
+              "flex": 1,
+            }
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                },
+                Object {
+                  "flexDirection": "row",
+                },
+              ]
+            }
+          >
+            <View
+              collapsable={undefined}
+              pointerEvents="box-none"
+              style={
+                Object {
+                  "alignItems": "center",
+                  "backgroundColor": "transparent",
+                  "bottom": 0,
+                  "justifyContent": "center",
+                  "left": 0,
+                  "opacity": 1,
+                  "position": "absolute",
+                  "right": 0,
                   "top": 0,
                   "transform": Array [
                     Object {

--- a/src/navigators/__tests__/__snapshots__/TabNavigator-test.js.snap
+++ b/src/navigators/__tests__/__snapshots__/TabNavigator-test.js.snap
@@ -65,100 +65,116 @@ exports[`TabNavigator renders successfully 1`] = `
     </View>
   </View>
   <View
-    collapsable={undefined}
+    onLayout={[Function]}
     style={
-      Object {
-        "backgroundColor": "#F7F7F7",
-        "borderTopColor": "rgba(0, 0, 0, .3)",
-        "borderTopWidth": 0.5,
-        "flexDirection": "row",
-        "height": 49,
-      }
+      Array [
+        Object {
+          "backgroundColor": "#F7F7F7",
+          "borderTopColor": "rgba(0, 0, 0, .3)",
+          "borderTopWidth": 0.5,
+        },
+        Object {
+          "paddingBottom": 0,
+          "paddingLeft": 0,
+          "paddingRight": 0,
+          "paddingTop": 20,
+        },
+      ]
     }
   >
     <View
-      accessibilityComponentType={undefined}
-      accessibilityLabel={undefined}
-      accessibilityTraits={undefined}
-      accessible={true}
       collapsable={undefined}
-      hitSlop={undefined}
-      nativeID={undefined}
-      onLayout={undefined}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       style={
         Object {
-          "alignItems": "center",
-          "backgroundColor": "rgba(0, 0, 0, 0)",
-          "flex": 1,
-          "justifyContent": "flex-end",
+          "flexDirection": "row",
+          "height": 49,
         }
       }
-      testID={undefined}
     >
       <View
-        style={
-          Object {
-            "flexGrow": 1,
-          }
-        }
-      >
-        <View
-          collapsable={undefined}
-          style={
-            Object {
-              "alignItems": "center",
-              "bottom": 0,
-              "justifyContent": "center",
-              "left": 0,
-              "opacity": 1,
-              "position": "absolute",
-              "right": 0,
-              "top": 0,
-            }
-          }
-        />
-        <View
-          collapsable={undefined}
-          style={
-            Object {
-              "alignItems": "center",
-              "bottom": 0,
-              "justifyContent": "center",
-              "left": 0,
-              "opacity": 0,
-              "position": "absolute",
-              "right": 0,
-              "top": 0,
-            }
-          }
-        />
-      </View>
-      <Text
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
         accessible={true}
-        allowFontScaling={true}
         collapsable={undefined}
-        disabled={false}
-        ellipsizeMode="tail"
+        hitSlop={undefined}
+        nativeID={undefined}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
-            "backgroundColor": "transparent",
-            "color": "rgba(52, 120, 246, 1)",
-            "fontSize": 10,
-            "marginBottom": 1.5,
-            "marginLeft": 0,
-            "marginTop": 0,
-            "textAlign": "center",
+            "alignItems": "center",
+            "backgroundColor": "rgba(0, 0, 0, 0)",
+            "flex": 1,
+            "justifyContent": "flex-end",
           }
         }
+        testID={undefined}
       >
-        Welcome anonymous
-      </Text>
+        <View
+          style={
+            Object {
+              "flexGrow": 1,
+            }
+          }
+        >
+          <View
+            collapsable={undefined}
+            style={
+              Object {
+                "alignItems": "center",
+                "bottom": 0,
+                "justifyContent": "center",
+                "left": 0,
+                "opacity": 1,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              }
+            }
+          />
+          <View
+            collapsable={undefined}
+            style={
+              Object {
+                "alignItems": "center",
+                "bottom": 0,
+                "justifyContent": "center",
+                "left": 0,
+                "opacity": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              }
+            }
+          />
+        </View>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          collapsable={undefined}
+          disabled={false}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "backgroundColor": "transparent",
+              "color": "rgba(52, 120, 246, 1)",
+              "fontSize": 10,
+              "marginBottom": 1.5,
+              "marginLeft": 0,
+              "marginTop": 0,
+              "textAlign": "center",
+            }
+          }
+        >
+          Welcome anonymous
+        </Text>
+      </View>
     </View>
   </View>
 </View>

--- a/src/react-navigation.js
+++ b/src/react-navigation.js
@@ -54,6 +54,9 @@ module.exports = {
   get Card() {
     return require('./views/CardStack/Card').default;
   },
+  get SafeAreaView() {
+    return require('./views/SafeAreaView').default;
+  },
 
   // Header
   get Header() {

--- a/src/views/Drawer/DrawerNavigatorItems.js
+++ b/src/views/Drawer/DrawerNavigatorItems.js
@@ -71,27 +71,29 @@ const DrawerNavigatorItems = ({
             delayPressIn={0}
           >
             <SafeAreaView
-              style={[styles.item, { backgroundColor }, itemStyle]}
+              style={{ backgroundColor }}
               forceInset={{ horizontal: 'always' }}
             >
-              {icon ? (
-                <View
-                  style={[
-                    styles.icon,
-                    focused ? null : styles.inactiveIcon,
-                    iconContainerStyle,
-                  ]}
-                >
-                  {icon}
-                </View>
-              ) : null}
-              {typeof label === 'string' ? (
-                <Text style={[styles.label, { color }, labelStyle]}>
-                  {label}
-                </Text>
-              ) : (
-                label
-              )}
+              <View style={[styles.item, itemStyle]}>
+                {icon ? (
+                  <View
+                    style={[
+                      styles.icon,
+                      focused ? null : styles.inactiveIcon,
+                      iconContainerStyle,
+                    ]}
+                  >
+                    {icon}
+                  </View>
+                ) : null}
+                {typeof label === 'string' ? (
+                  <Text style={[styles.label, { color }, labelStyle]}>
+                    {label}
+                  </Text>
+                ) : (
+                  label
+                )}
+              </View>
             </SafeAreaView>
           </TouchableItem>
         );
@@ -110,7 +112,6 @@ DrawerNavigatorItems.defaultProps = {
 
 const styles = StyleSheet.create({
   container: {
-    // marginTop: Platform.OS === 'ios' ? 20 : 0,
     paddingVertical: 4,
   },
   item: {

--- a/src/views/Drawer/DrawerNavigatorItems.js
+++ b/src/views/Drawer/DrawerNavigatorItems.js
@@ -51,7 +51,7 @@ const DrawerNavigatorItems = ({
   labelStyle,
   iconContainerStyle,
 }: Props) => (
-  <SafeAreaView forceInset={{ horizontal: 'never' }}>
+  <SafeAreaView forceInset={{ horizontal: 'never', top: 'always' }}>
     <View style={[styles.container, itemsContainerStyle]}>
       {items.map((route: NavigationRoute, index: number) => {
         const focused = activeItemKey === route.key;
@@ -70,7 +70,10 @@ const DrawerNavigatorItems = ({
             }}
             delayPressIn={0}
           >
-            <SafeAreaView style={[styles.item, { backgroundColor }, itemStyle]}>
+            <SafeAreaView
+              style={[styles.item, { backgroundColor }, itemStyle]}
+              forceInset={{ horizontal: 'always' }}
+            >
               {icon ? (
                 <View
                   style={[

--- a/src/views/Drawer/DrawerNavigatorItems.js
+++ b/src/views/Drawer/DrawerNavigatorItems.js
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import { View, Text, Platform, StyleSheet } from 'react-native';
 
+import SafeAreaView from '../SafeAreaView';
 import TouchableItem from '../TouchableItem';
 
 import type {
@@ -50,46 +51,53 @@ const DrawerNavigatorItems = ({
   labelStyle,
   iconContainerStyle,
 }: Props) => (
-  <View style={[styles.container, itemsContainerStyle]}>
-    {items.map((route: NavigationRoute, index: number) => {
-      const focused = activeItemKey === route.key;
-      const color = focused ? activeTintColor : inactiveTintColor;
-      const backgroundColor = focused
-        ? activeBackgroundColor
-        : inactiveBackgroundColor;
-      const scene = { route, index, focused, tintColor: color };
-      const icon = renderIcon(scene);
-      const label = getLabel(scene);
-      return (
-        <TouchableItem
-          key={route.key}
-          onPress={() => {
-            onItemPress({ route, focused });
-          }}
-          delayPressIn={0}
-        >
-          <View style={[styles.item, { backgroundColor }, itemStyle]}>
-            {icon ? (
-              <View
-                style={[
-                  styles.icon,
-                  focused ? null : styles.inactiveIcon,
-                  iconContainerStyle,
-                ]}
-              >
-                {icon}
-              </View>
-            ) : null}
-            {typeof label === 'string' ? (
-              <Text style={[styles.label, { color }, labelStyle]}>{label}</Text>
-            ) : (
-              label
-            )}
-          </View>
-        </TouchableItem>
-      );
-    })}
-  </View>
+  <SafeAreaView insetOverride={{ horizontal: 0 }}>
+    <View style={[styles.container, itemsContainerStyle]}>
+      {items.map((route: NavigationRoute, index: number) => {
+        const focused = activeItemKey === route.key;
+        const color = focused ? activeTintColor : inactiveTintColor;
+        const backgroundColor = focused
+          ? activeBackgroundColor
+          : inactiveBackgroundColor;
+        const scene = { route, index, focused, tintColor: color };
+        const icon = renderIcon(scene);
+        const label = getLabel(scene);
+        return (
+          <TouchableItem
+            key={route.key}
+            onPress={() => {
+              onItemPress({ route, focused });
+            }}
+            delayPressIn={0}
+          >
+            <SafeAreaView
+              style={[styles.item, { backgroundColor }, itemStyle]}
+              insetOverride={{ vertical: 0 }}
+            >
+              {icon ? (
+                <View
+                  style={[
+                    styles.icon,
+                    focused ? null : styles.inactiveIcon,
+                    iconContainerStyle,
+                  ]}
+                >
+                  {icon}
+                </View>
+              ) : null}
+              {typeof label === 'string' ? (
+                <Text style={[styles.label, { color }, labelStyle]}>
+                  {label}
+                </Text>
+              ) : (
+                label
+              )}
+            </SafeAreaView>
+          </TouchableItem>
+        );
+      })}
+    </View>
+  </SafeAreaView>
 );
 
 /* Material design specs - https://material.io/guidelines/patterns/navigation-drawer.html#navigation-drawer-specs */
@@ -102,7 +110,7 @@ DrawerNavigatorItems.defaultProps = {
 
 const styles = StyleSheet.create({
   container: {
-    marginTop: Platform.OS === 'ios' ? 20 : 0,
+    // marginTop: Platform.OS === 'ios' ? 20 : 0,
     paddingVertical: 4,
   },
   item: {

--- a/src/views/Drawer/DrawerNavigatorItems.js
+++ b/src/views/Drawer/DrawerNavigatorItems.js
@@ -51,7 +51,7 @@ const DrawerNavigatorItems = ({
   labelStyle,
   iconContainerStyle,
 }: Props) => (
-  <SafeAreaView insetOverride={{ horizontal: 0 }}>
+  <SafeAreaView forceInset={{ horizontal: 'never' }}>
     <View style={[styles.container, itemsContainerStyle]}>
       {items.map((route: NavigationRoute, index: number) => {
         const focused = activeItemKey === route.key;
@@ -70,10 +70,7 @@ const DrawerNavigatorItems = ({
             }}
             delayPressIn={0}
           >
-            <SafeAreaView
-              style={[styles.item, { backgroundColor }, itemStyle]}
-              insetOverride={{ vertical: 0 }}
-            >
+            <SafeAreaView style={[styles.item, { backgroundColor }, itemStyle]}>
               {icon ? (
                 <View
                   style={[

--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -315,7 +315,10 @@ class Header extends React.PureComponent<Props, State> {
     ];
 
     return (
-      <SafeAreaView style={styles.container}>
+      <SafeAreaView
+        style={styles.container}
+        forceInset={{ top: 'always', bottom: 'never' }}
+      >
         <Animated.View {...rest} style={containerStyles}>
           <View style={styles.appBar}>{appBar}</View>
         </Animated.View>

--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -44,7 +44,6 @@ type State = {
 };
 
 const APPBAR_HEIGHT = Platform.OS === 'ios' ? 44 : 56;
-const STATUSBAR_HEIGHT = Platform.OS === 'ios' ? 0 : 0;
 const TITLE_OFFSET = Platform.OS === 'ios' ? 70 : 56;
 
 type Props = HeaderProps & { isLandscape: boolean };
@@ -304,12 +303,10 @@ class Header extends React.PureComponent<Props, State> {
 
     const { options } = this.props.getScreenDetails(scene);
     const headerStyle = options.headerStyle;
-    const landscapeAwareStatusBarHeight = isLandscape ? 0 : STATUSBAR_HEIGHT;
     const appBarHeight = Platform.OS === 'ios' ? (isLandscape ? 32 : 44) : 56;
     const containerStyles = [
       {
-        // paddingTop: landscapeAwareStatusBarHeight,
-        height: appBarHeight, // + landscapeAwareStatusBarHeight,
+        height: appBarHeight,
       },
       headerStyle,
     ];

--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -6,6 +6,7 @@ import * as React from 'react';
 
 import {
   Animated,
+  Dimensions,
   Platform,
   StyleSheet,
   View,
@@ -15,6 +16,7 @@ import {
 import HeaderTitle from './HeaderTitle';
 import HeaderBackButton from './HeaderBackButton';
 import HeaderStyleInterpolator from './HeaderStyleInterpolator';
+import SafeAreaView from '../SafeAreaView';
 import withOrientation from '../withOrientation';
 
 import type {
@@ -42,13 +44,11 @@ type State = {
 };
 
 const APPBAR_HEIGHT = Platform.OS === 'ios' ? 44 : 56;
-const STATUSBAR_HEIGHT = Platform.OS === 'ios' ? 20 : 0;
+const STATUSBAR_HEIGHT = Platform.OS === 'ios' ? 0 : 0;
 const TITLE_OFFSET = Platform.OS === 'ios' ? 70 : 56;
 
 type Props = HeaderProps & { isLandscape: boolean };
 class Header extends React.PureComponent<Props, State> {
-  static HEIGHT = APPBAR_HEIGHT + STATUSBAR_HEIGHT;
-
   state = {
     widths: {},
   };
@@ -305,19 +305,21 @@ class Header extends React.PureComponent<Props, State> {
     const { options } = this.props.getScreenDetails(scene);
     const headerStyle = options.headerStyle;
     const landscapeAwareStatusBarHeight = isLandscape ? 0 : STATUSBAR_HEIGHT;
+    const appBarHeight = Platform.OS === 'ios' ? (isLandscape ? 32 : 44) : 56;
     const containerStyles = [
-      styles.container,
       {
-        paddingTop: landscapeAwareStatusBarHeight,
-        height: APPBAR_HEIGHT + landscapeAwareStatusBarHeight,
+        // paddingTop: landscapeAwareStatusBarHeight,
+        height: appBarHeight, // + landscapeAwareStatusBarHeight,
       },
       headerStyle,
     ];
 
     return (
-      <Animated.View {...rest} style={containerStyles}>
-        <View style={styles.appBar}>{appBar}</View>
-      </Animated.View>
+      <SafeAreaView style={styles.container}>
+        <Animated.View {...rest} style={containerStyles}>
+          <View style={styles.appBar}>{appBar}</View>
+        </Animated.View>
+      </SafeAreaView>
     );
   }
 }

--- a/src/views/SafeAreaView.js
+++ b/src/views/SafeAreaView.js
@@ -14,7 +14,8 @@ const { isIPhoneX_deprecated } = DeviceInfo;
 const X_WIDTH = 375;
 const X_HEIGHT = 812;
 
-const { minor } = NativeModules.PlatformConstants.reactNativeVersion;
+const { PlatformConstants = {} } = NativeModules;
+const { minor = 0 } = PlatformConstants.reactNativeVersion || {};
 
 const isIPhoneX = (() => {
   if (minor >= 50) {

--- a/src/views/SafeAreaView.js
+++ b/src/views/SafeAreaView.js
@@ -122,20 +122,16 @@ class SafeView extends Component {
       let realY = winY;
       let realX = winX;
 
-      while (realY >= HEIGHT) {
-        realY -= HEIGHT;
+      if (realY >= HEIGHT) {
+        realY = realY % HEIGHT;
+      } else if (realY < 0) {
+        realY = realY % HEIGHT + HEIGHT;
       }
 
-      while (realX >= WIDTH) {
-        realX -= WIDTH;
-      }
-
-      while (realY < 0) {
-        realY += HEIGHT;
-      }
-
-      while (realX < 0) {
-        realX += WIDTH;
+      if (realX >= WIDTH) {
+        realX = realX % WIDTH;
+      } else if (realX < 0) {
+        realX = realX % WIDTH + WIDTH;
       }
 
       const touchesTop = realY === 0;

--- a/src/views/SafeAreaView.js
+++ b/src/views/SafeAreaView.js
@@ -47,32 +47,6 @@ class SafeView extends Component {
         const touchesLeft = x === 0;
         const touchesRight = x + width === WIDTH;
 
-        if (verbose) {
-          console.log('\n');
-          console.log(
-            'x',
-            lx,
-            x,
-            '\ny',
-            ly,
-            y,
-            '\nwidth',
-            lwidth,
-            width,
-            '\nheight',
-            lheight,
-            height
-          );
-          console.log(
-            isLandscape ? 'landscape' : 'portrait',
-            `\ny:${y.toFixed(2)} + height:${height.toFixed(2)} = ${(y + height
-            ).toFixed(2)} =? ${HEIGHT}`,
-            `\nx:${x.toFixed(2)} + width:${width.toFixed(2)} = ${(x + width
-            ).toFixed(2)} =? ${WIDTH}`
-          );
-          console.log('\n');
-        }
-
         this.setState({ touchesTop, touchesBottom, touchesLeft, touchesRight });
       });
     }

--- a/src/views/SafeAreaView.js
+++ b/src/views/SafeAreaView.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { DeviceInfo, SafeAreaView, View } from 'react-native';
+import { DeviceInfo, View } from 'react-native';
 import withOrientation from './withOrientation';
 
 const { isIPhoneX_deprecated: isIPhoneX } = DeviceInfo;
@@ -26,6 +26,24 @@ class SafeView extends Component {
     };
   };
 
+  getInset = key => {
+    const { isLandscape } = this.props;
+    switch (key) {
+      case 'horizontal':
+      case 'right':
+      case 'left': {
+        return isLandscape ? 44 : 0;
+      }
+      case 'vertical':
+      case 'top': {
+        return isLandscape ? 0 : 44;
+      }
+      case 'bottom': {
+        return isLandscape ? 24 : 34;
+      }
+    }
+  };
+
   render() {
     const { insetOverride, isLandscape, children, style } = this.props;
 
@@ -37,31 +55,34 @@ class SafeView extends Component {
 
     if (insetOverride) {
       Object.keys(insetOverride).forEach(key => {
+        let inset = insetOverride[key];
+
+        if (inset === 'always') {
+          inset = this.getInset(key);
+        }
+
+        if (inset === 'never') {
+          inset = 0;
+        }
+
         switch (key) {
           case 'horizontal': {
-            safeAreaStyle.paddingLeft = insetOverride[key];
-            safeAreaStyle.paddingRight = insetOverride[key];
+            safeAreaStyle.paddingLeft = inset;
+            safeAreaStyle.paddingRight = inset;
             break;
           }
           case 'vertical': {
-            safeAreaStyle.paddingTop = insetOverride[key];
-            safeAreaStyle.paddingBottom = insetOverride[key];
+            safeAreaStyle.paddingTop = inset;
+            safeAreaStyle.paddingBottom = inset;
             break;
           }
-          case 'left': {
-            safeAreaStyle.paddingLeft = insetOverride[key];
-            break;
-          }
-          case 'right': {
-            safeAreaStyle.paddingRight = insetOverride[key];
-            break;
-          }
-          case 'top': {
-            safeAreaStyle.paddingTop = insetOverride[key];
-            break;
-          }
+          case 'left':
+          case 'right':
+          case 'top':
           case 'bottom': {
-            safeAreaStyle.paddingBottom = insetOverride[key];
+            const [first] = key;
+            const padding = `padding${first.toUpperCase()}${key.slice(1)}`;
+            safeAreaStyle[padding] = inset;
             break;
           }
         }
@@ -69,7 +90,11 @@ class SafeView extends Component {
     }
 
     return (
-      <View onLayout={this._onLayout} style={[style, safeAreaStyle]}>
+      <View
+        onLayout={this._onLayout}
+        style={[style, safeAreaStyle]}
+        //ref={c => (this.view = c)}
+      >
         {this.props.children}
       </View>
     );
@@ -81,16 +106,28 @@ class SafeView extends Component {
     const WIDTH = isLandscape ? DEVICE_HEIGHT : DEVICE_WIDTH;
     const HEIGHT = isLandscape ? DEVICE_WIDTH : DEVICE_HEIGHT;
 
+    // if (this.view) {
+    // this.view.measure((x, y, width, height) => {
     const touchesTop = y === 0;
     const touchesBottom = y + height === HEIGHT;
     const touchesLeft = x === 0;
     const touchesRight = x + width === WIDTH;
 
     if (verbose) {
-      console.log(isLandscape, y, height, y + height, HEIGHT);
+      // console.log(this.view);
+      console.log(
+        isLandscape ? 'landscape' : 'portrait',
+        `\ny:${y.toFixed(2)} + height:${height.toFixed(2)} = ${(y + height
+        ).toFixed(2)} =? ${HEIGHT}`,
+        `\nx:${x.toFixed(2)} + width:${width.toFixed(2)} = ${(x + width
+        ).toFixed(2)} =? ${WIDTH}\n`
+      );
+      // console.log(pageX, pageY);
     }
 
     this.setState({ touchesTop, touchesBottom, touchesLeft, touchesRight });
+    // });
+    // }
   };
 }
 

--- a/src/views/SafeAreaView.js
+++ b/src/views/SafeAreaView.js
@@ -1,0 +1,97 @@
+import React, { Component } from 'react';
+import { DeviceInfo, SafeAreaView, View } from 'react-native';
+import withOrientation from './withOrientation';
+
+const { isIPhoneX_deprecated: isIPhoneX } = DeviceInfo;
+const DEVICE_WIDTH = 375;
+const DEVICE_HEIGHT = 812;
+
+class SafeView extends Component {
+  state = {
+    touchesTop: true,
+    touchesBottom: true,
+    touchesLeft: true,
+    touchesRight: true,
+  };
+
+  defaultSafeAreaStyle = () => {
+    const { touchesTop, touchesBottom, touchesLeft, touchesRight } = this.state;
+    const { isLandscape } = this.props;
+
+    return {
+      paddingTop: touchesTop ? (isLandscape ? 0 : 44) : 0,
+      paddingBottom: touchesBottom ? (isLandscape ? 24 : 34) : 0,
+      paddingLeft: touchesLeft ? (isLandscape ? 44 : 0) : 0,
+      paddingRight: touchesRight ? (isLandscape ? 44 : 0) : 0,
+    };
+  };
+
+  render() {
+    const { insetOverride, isLandscape, children, style } = this.props;
+
+    if (!isIPhoneX) {
+      return <View style={style}>{this.props.children}</View>;
+    }
+
+    const safeAreaStyle = this.defaultSafeAreaStyle();
+
+    if (insetOverride) {
+      Object.keys(insetOverride).forEach(key => {
+        switch (key) {
+          case 'horizontal': {
+            safeAreaStyle.paddingLeft = insetOverride[key];
+            safeAreaStyle.paddingRight = insetOverride[key];
+            break;
+          }
+          case 'vertical': {
+            safeAreaStyle.paddingTop = insetOverride[key];
+            safeAreaStyle.paddingBottom = insetOverride[key];
+            break;
+          }
+          case 'left': {
+            safeAreaStyle.paddingLeft = insetOverride[key];
+            break;
+          }
+          case 'right': {
+            safeAreaStyle.paddingRight = insetOverride[key];
+            break;
+          }
+          case 'top': {
+            safeAreaStyle.paddingTop = insetOverride[key];
+            break;
+          }
+          case 'bottom': {
+            safeAreaStyle.paddingBottom = insetOverride[key];
+            break;
+          }
+        }
+      });
+    }
+
+    return (
+      <View onLayout={this._onLayout} style={[style, safeAreaStyle]}>
+        {this.props.children}
+      </View>
+    );
+  }
+
+  _onLayout = ({ nativeEvent: { layout: { x, y, width, height } } }) => {
+    const { isLandscape, verbose } = this.props;
+
+    const WIDTH = isLandscape ? DEVICE_HEIGHT : DEVICE_WIDTH;
+    const HEIGHT = isLandscape ? DEVICE_WIDTH : DEVICE_HEIGHT;
+
+    const touchesTop = y === 0;
+    const touchesBottom = y + height === HEIGHT;
+    const touchesLeft = x === 0;
+    const touchesRight = x + width === WIDTH;
+
+    if (verbose) {
+      console.log(isLandscape, y, height, y + height, HEIGHT);
+    }
+
+    this.setState({ touchesTop, touchesBottom, touchesLeft, touchesRight });
+  };
+}
+
+export default withOrientation(SafeView);

--- a/src/views/TabView/TabBarBottom.js
+++ b/src/views/TabView/TabBarBottom.js
@@ -9,6 +9,7 @@ import {
   Platform,
 } from 'react-native';
 import TabBarIcon from './TabBarIcon';
+import SafeAreaView from '../SafeAreaView';
 import withOrientation from '../withOrientation';
 
 import type {
@@ -168,51 +169,63 @@ class TabBarBottom extends React.PureComponent<Props> {
     const { routes } = navigation.state;
     // Prepend '-1', so there are always at least 2 items in inputRange
     const inputRange = [-1, ...routes.map((x: *, i: number) => i)];
+
+    const tabBarStyle = [
+      styles.tabBar,
+      isLandscape ? styles.tabBarLandscape : styles.tabBarPortrait,
+      style,
+    ];
+
     return (
-      <Animated.View style={[styles.tabBar, style]}>
-        {routes.map((route: NavigationRoute, index: number) => {
-          const focused = index === navigation.state.index;
-          const scene = { route, index, focused };
-          const onPress = getOnPress(scene);
-          const outputRange = inputRange.map(
-            (inputIndex: number) =>
-              inputIndex === index
-                ? activeBackgroundColor
-                : inactiveBackgroundColor
-          );
-          const backgroundColor = position.interpolate({
-            inputRange,
-            outputRange: (outputRange: Array<string>),
-          });
+      <SafeAreaView
+        style={styles.tabBarContainer}
+        insetOverride={{ bottom: 'always' }}
+      >
+        <Animated.View style={tabBarStyle}>
+          {routes.map((route: NavigationRoute, index: number) => {
+            const focused = index === navigation.state.index;
+            const scene = { route, index, focused };
+            const onPress = getOnPress(scene);
+            const outputRange = inputRange.map(
+              (inputIndex: number) =>
+                inputIndex === index
+                  ? activeBackgroundColor
+                  : inactiveBackgroundColor
+            );
+            const backgroundColor = position.interpolate({
+              inputRange,
+              outputRange: (outputRange: Array<string>),
+            });
 
-          const justifyContent = this.props.showIcon ? 'flex-end' : 'center';
-          const extraProps = this._renderTestIDProps(scene) || {};
-          const { testID, accessibilityLabel } = extraProps;
+            const justifyContent = this.props.showIcon ? 'flex-end' : 'center';
+            const extraProps = this._renderTestIDProps(scene) || {};
+            const { testID, accessibilityLabel } = extraProps;
 
-          return (
-            <TouchableWithoutFeedback
-              key={route.key}
-              testID={testID}
-              accessibilityLabel={accessibilityLabel}
-              onPress={() =>
-                onPress ? onPress(scene, jumpToIndex) : jumpToIndex(index)}
-            >
-              <Animated.View
-                style={[
-                  styles.tab,
-                  isLandscape && useHorizontalTabs && styles.tabLandscape,
-                  !isLandscape && useHorizontalTabs && styles.tabPortrait,
-                  { backgroundColor },
-                  tabStyle,
-                ]}
+            return (
+              <TouchableWithoutFeedback
+                key={route.key}
+                testID={testID}
+                accessibilityLabel={accessibilityLabel}
+                onPress={() =>
+                  onPress ? onPress(scene, jumpToIndex) : jumpToIndex(index)}
               >
-                {this._renderIcon(scene)}
-                {this._renderLabel(scene)}
-              </Animated.View>
-            </TouchableWithoutFeedback>
-          );
-        })}
-      </Animated.View>
+                <Animated.View
+                  style={[
+                    styles.tab,
+                    isLandscape && useHorizontalTabs && styles.tabLandscape,
+                    !isLandscape && useHorizontalTabs && styles.tabPortrait,
+                    { backgroundColor },
+                    tabStyle,
+                  ]}
+                >
+                  {this._renderIcon(scene)}
+                  {this._renderLabel(scene)}
+                </Animated.View>
+              </TouchableWithoutFeedback>
+            );
+          })}
+        </Animated.View>
+      </SafeAreaView>
     );
   }
 }
@@ -220,12 +233,20 @@ class TabBarBottom extends React.PureComponent<Props> {
 const LABEL_LEFT_MARGIN = 20;
 const LABEL_TOP_MARGIN = 15;
 const styles = StyleSheet.create({
-  tabBar: {
-    height: 49, // Default tab bar height in iOS 10+
-    flexDirection: 'row',
+  tabBarContainer: {
+    backgroundColor: '#F7F7F7', // Default background color in iOS 10
     borderTopWidth: StyleSheet.hairlineWidth,
     borderTopColor: 'rgba(0, 0, 0, .3)',
-    backgroundColor: '#F7F7F7', // Default background color in iOS 10+
+  },
+  tabBar: {
+    // height: 49, // Default tab bar height in iOS 10+
+    flexDirection: 'row',
+  },
+  tabBarLandscape: {
+    height: 29,
+  },
+  tabBarPortrait: {
+    height: 49,
   },
   tab: {
     flex: 1,

--- a/src/views/TabView/TabBarBottom.js
+++ b/src/views/TabView/TabBarBottom.js
@@ -179,7 +179,7 @@ class TabBarBottom extends React.PureComponent<Props> {
     return (
       <SafeAreaView
         style={styles.tabBarContainer}
-        insetOverride={{ bottom: 'always' }}
+        forceInset={{ bottom: 'always' }}
       >
         <Animated.View style={tabBarStyle}>
           {routes.map((route: NavigationRoute, index: number) => {

--- a/src/views/TabView/TabBarBottom.js
+++ b/src/views/TabView/TabBarBottom.js
@@ -172,7 +172,9 @@ class TabBarBottom extends React.PureComponent<Props> {
 
     const tabBarStyle = [
       styles.tabBar,
-      isLandscape ? styles.tabBarLandscape : styles.tabBarPortrait,
+      isLandscape && useHorizontalTabs
+        ? styles.tabBarLandscape
+        : styles.tabBarPortrait,
       style,
     ];
 

--- a/src/views/TabView/TabView.js
+++ b/src/views/TabView/TabView.js
@@ -6,6 +6,7 @@ import { TabViewAnimated, TabViewPagerPan } from 'react-native-tab-view';
 import type { Layout } from 'react-native-tab-view/src/TabViewTypeDefinitions';
 import SceneView from '../SceneView';
 import withCachedChildNavigation from '../../withCachedChildNavigation';
+import SafeAreaView from '../SafeAreaView';
 
 import type {
   NavigationScreenProp,

--- a/src/views/__tests__/__snapshots__/TabView-test.js.snap
+++ b/src/views/__tests__/__snapshots__/TabView-test.js.snap
@@ -21,100 +21,116 @@ exports[`TabBarBottom renders successfully 1`] = `
   }
 >
   <View
-    collapsable={undefined}
+    onLayout={[Function]}
     style={
-      Object {
-        "backgroundColor": "#F7F7F7",
-        "borderTopColor": "rgba(0, 0, 0, .3)",
-        "borderTopWidth": 0.5,
-        "flexDirection": "row",
-        "height": 49,
-      }
+      Array [
+        Object {
+          "backgroundColor": "#F7F7F7",
+          "borderTopColor": "rgba(0, 0, 0, .3)",
+          "borderTopWidth": 0.5,
+        },
+        Object {
+          "paddingBottom": 0,
+          "paddingLeft": 0,
+          "paddingRight": 0,
+          "paddingTop": 20,
+        },
+      ]
     }
   >
     <View
-      accessibilityComponentType={undefined}
-      accessibilityLabel={undefined}
-      accessibilityTraits={undefined}
-      accessible={true}
       collapsable={undefined}
-      hitSlop={undefined}
-      nativeID={undefined}
-      onLayout={undefined}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       style={
         Object {
-          "alignItems": "center",
-          "backgroundColor": "rgba(0, 0, 0, 0)",
-          "flex": 1,
-          "justifyContent": "flex-end",
+          "flexDirection": "row",
+          "height": 49,
         }
       }
-      testID={undefined}
     >
       <View
-        style={
-          Object {
-            "flexGrow": 1,
-          }
-        }
-      >
-        <View
-          collapsable={undefined}
-          style={
-            Object {
-              "alignItems": "center",
-              "bottom": 0,
-              "justifyContent": "center",
-              "left": 0,
-              "opacity": 1,
-              "position": "absolute",
-              "right": 0,
-              "top": 0,
-            }
-          }
-        />
-        <View
-          collapsable={undefined}
-          style={
-            Object {
-              "alignItems": "center",
-              "bottom": 0,
-              "justifyContent": "center",
-              "left": 0,
-              "opacity": 0,
-              "position": "absolute",
-              "right": 0,
-              "top": 0,
-            }
-          }
-        />
-      </View>
-      <Text
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
         accessible={true}
-        allowFontScaling={true}
         collapsable={undefined}
-        disabled={false}
-        ellipsizeMode="tail"
+        hitSlop={undefined}
+        nativeID={undefined}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           Object {
-            "backgroundColor": "transparent",
-            "color": "rgba(52, 120, 246, 1)",
-            "fontSize": 10,
-            "marginBottom": 1.5,
-            "marginLeft": 0,
-            "marginTop": 0,
-            "textAlign": "center",
+            "alignItems": "center",
+            "backgroundColor": "rgba(0, 0, 0, 0)",
+            "flex": 1,
+            "justifyContent": "flex-end",
           }
         }
+        testID={undefined}
       >
-        s1
-      </Text>
+        <View
+          style={
+            Object {
+              "flexGrow": 1,
+            }
+          }
+        >
+          <View
+            collapsable={undefined}
+            style={
+              Object {
+                "alignItems": "center",
+                "bottom": 0,
+                "justifyContent": "center",
+                "left": 0,
+                "opacity": 1,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              }
+            }
+          />
+          <View
+            collapsable={undefined}
+            style={
+              Object {
+                "alignItems": "center",
+                "bottom": 0,
+                "justifyContent": "center",
+                "left": 0,
+                "opacity": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              }
+            }
+          />
+        </View>
+        <Text
+          accessible={true}
+          allowFontScaling={true}
+          collapsable={undefined}
+          disabled={false}
+          ellipsizeMode="tail"
+          style={
+            Object {
+              "backgroundColor": "transparent",
+              "color": "rgba(52, 120, 246, 1)",
+              "fontSize": 10,
+              "marginBottom": 1.5,
+              "marginLeft": 0,
+              "marginTop": 0,
+              "textAlign": "center",
+            }
+          }
+        >
+          s1
+        </Text>
+      </View>
     </View>
   </View>
   <RCTScrollView


### PR DESCRIPTION
This adds support for iPhone X to react-navigation via SafeAreaView. 
- Uses a JS approach that can be used in RN v0.49 and lower. 
- Includes `forceInset` prop, which is not available on the native version that will be released in RN v0.50. 
- Adds SafeAreaView to Header, Drawer, and Tab views. 
- Updates NavigationPlayground to provide testing and examples of SafeAreaView use.

This essentially mimics the native version by adding padding on the side of the view that touches a screen edge. Ideally the API introduced here will eventually be migrated into the native version of SafeAreaView where performance will be much better.

### Native SafeAreaView shortcomings:
* Only available in RN v0.50, which will be released maybe a day or two before iPhone X is released.
* Inset is added as padding and cannot be customized as margin (e.g. padding on sides, margin on top).
* Inset cannot be overridden to disable inset on any side.
* Fails with react-navigation tab views (tab screens are laid end-to-end off the screen and SafeAreaView did not add inset properly).

### JS SafeAreaView benefits:
* Works on React Native v0.49 and earlier, devs can start adding iPhone X support now.
* Adds `forceInset` prop to customize the behavior of the inset.
    * Customize the size of the spacing to make it smaller or larger.
    * Disable inset on any side so you can nest SafeAreaViews for a padding + margin effect.
    * Force inset to always show on any side in case there is an unexpected behavior (e.g. animated views will weirdly animate the additional padding when a view hits an edge).
    * Adds the specified padding based on the orientation and disregards whether the view is touching a screen edge or not.

### Questions
#### Why don't we automatically wrap the screens in SafeAreaView to decrease dev workload?
This will behave like adding a margin to the screen. If background color matches, it won't be noticeable. If background color is different or any kind of scrolling view is used, the SafeAreaView padding will appear like a margin and cover the scrolling content.
#### What should I do about ScrollView and list views?
ScrollView now has `contentInsetAdjustmentBehavior`. See NavigationPlayground App.js for an example of this. https://facebook.github.io/react-native/docs/scrollview.html#contentinsetadjustmentbehavior