### PR TITLE
Set initialLayout in defaultProps on Android

### DIFF
--- a/src/views/TabView/TabView.js
+++ b/src/views/TabView/TabView.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import React, { PureComponent } from 'react';
-import { View, StyleSheet, Platform } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import { TabViewAnimated, TabViewPagerPan } from 'react-native-tab-view';
 import type { Layout } from 'react-native-tab-view/src/TabViewTypeDefinitions';
 import SceneView from '../SceneView';
@@ -20,7 +20,6 @@ export type TabViewConfig = {
   tabBarComponent?: ReactClass<*>,
   tabBarPosition?: 'top' | 'bottom',
   tabBarOptions?: {},
-  initialLayout?: { width: number, height: number },
   swipeEnabled?: boolean,
   animationEnabled?: boolean,
   lazy?: boolean,
@@ -38,7 +37,6 @@ type Props = {
   tabBarComponent?: ReactClass<*>,
   tabBarPosition?: 'top' | 'bottom',
   tabBarOptions?: {},
-  initialLayout?: { width: number, height: number },
   swipeEnabled?: boolean,
   animationEnabled?: boolean,
   lazy?: boolean,
@@ -208,9 +206,6 @@ class TabView extends PureComponent<void, Props, void> {
       screenProps: this.props.screenProps,
       style: styles.container,
     };
-    if (Platform.OS === 'android') {
-      props.initialLayout = { width: 1, height: 0 };
-    }
 
     return <TabViewAnimated {...props} />;
   }

--- a/src/views/TabView/TabView.js
+++ b/src/views/TabView/TabView.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import React, { PureComponent } from 'react';
-import { View, StyleSheet, Platform, Dimensions } from 'react-native';
+import { View, StyleSheet, Platform } from 'react-native';
 import { TabViewAnimated, TabViewPagerPan } from 'react-native-tab-view';
 import type { Layout } from 'react-native-tab-view/src/TabViewTypeDefinitions';
 import SceneView from '../SceneView';
@@ -54,16 +54,12 @@ type Props = {
   },
 };
 
-let defaultInitialLayout = undefined;
-if (Platform.OS === 'android') {
-  // fix for https://github.com/react-native-community/react-native-tab-view/issues/312
-  const { width, height } = Dimensions.get('window');
-  defaultInitialLayout = { width, height };
-}
-
 class TabView extends PureComponent<$Shape<Props>, Props, void> {
   static defaultProps = {
-    initialLayout: defaultInitialLayout,
+    // fix for https://github.com/react-native-community/react-native-tab-view/issues/312
+    initialLayout: Platform.select({
+      android: { width: 1, height: 0 },
+    }),
   };
 
   props: Props;

--- a/src/views/TabView/TabView.js
+++ b/src/views/TabView/TabView.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import React, { PureComponent } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View, StyleSheet, Platform, Dimensions } from 'react-native';
 import { TabViewAnimated, TabViewPagerPan } from 'react-native-tab-view';
 import type { Layout } from 'react-native-tab-view/src/TabViewTypeDefinitions';
 import SceneView from '../SceneView';
@@ -54,7 +54,18 @@ type Props = {
   },
 };
 
-class TabView extends PureComponent<void, Props, void> {
+let defaultInitialLayout = undefined;
+if (Platform.OS === 'android') {
+  // fix for https://github.com/react-native-community/react-native-tab-view/issues/312
+  const { width, height } = Dimensions.get('window');
+  defaultInitialLayout = { width, height };
+}
+
+class TabView extends PureComponent<$Shape<Props>, Props, void> {
+  static defaultProps = {
+    initialLayout: defaultInitialLayout,
+  };
+
   props: Props;
 
   _handlePageChanged = (index: number) => {


### PR DESCRIPTION
This is a follow-up of the last two PRs (#2733 and #2385) that adresses [this problem](https://github.com/react-native-community/react-native-tab-view/issues/312).

This:
* fixes the `initialLayout` prop conflicts
* sets the default `initialLayout` in `defaultProps` rather than on every render (and doesn't mutate props)
* uses the window's width and height to avoid the one frame delay

