### PR TITLE
change dispatch to promise

### DIFF
--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -366,7 +366,7 @@ export type NavigationDrawerScreenOptions = {
  * Navigator Prop
  */
 
-export type NavigationDispatch<A> = (action: A) => boolean;
+export type NavigationDispatch<A> = (action: A) => Promise<any>;
 
 export type NavigationProp<S, A> = {
   state: S,
@@ -376,13 +376,13 @@ export type NavigationProp<S, A> = {
 export type NavigationScreenProp<S, A> = {
   state: S,
   dispatch: NavigationDispatch<A>,
-  goBack: (routeKey?: ?string) => boolean,
+  goBack: (routeKey?: ?string) => Promise<any>,
   navigate: (
     routeName: string,
     params?: NavigationParams,
     action?: NavigationAction
-  ) => boolean,
-  setParams: (newParams: NavigationParams) => boolean,
+  ) => Promise<any>,
+  setParams: (newParams: NavigationParams) => Promise<any>,
 };
 
 export type NavigationNavigatorProps<O, S> = {

--- a/src/__tests__/addNavigationHelpers-test.js
+++ b/src/__tests__/addNavigationHelpers-test.js
@@ -6,14 +6,14 @@ import addNavigationHelpers from '../addNavigationHelpers';
 describe('addNavigationHelpers', () => {
   it('handles Back action', () => {
     const mockedDispatch = jest
-      .fn(() => false)
-      .mockImplementationOnce(() => true);
+      .fn(() => Promise.reject())
+      .mockImplementationOnce(() => Promise.resolve());
     expect(
       addNavigationHelpers({
         state: { key: 'A', routeName: 'Home' },
         dispatch: mockedDispatch,
       }).goBack('A')
-    ).toEqual(true);
+    ).toEqual(Promise.resolve());
     expect(mockedDispatch).toBeCalledWith({
       type: NavigationActions.BACK,
       key: 'A',
@@ -23,28 +23,28 @@ describe('addNavigationHelpers', () => {
 
   it('handles Back action when the key is not defined', () => {
     const mockedDispatch = jest
-      .fn(() => false)
-      .mockImplementationOnce(() => true);
+      .fn(() => Promise.reject())
+      .mockImplementationOnce(() => Promise.resolve());
     expect(
       addNavigationHelpers({
         state: { routeName: 'Home' },
         dispatch: mockedDispatch,
       }).goBack()
-    ).toEqual(true);
+    ).toEqual(Promise.resolve());
     expect(mockedDispatch).toBeCalledWith({ type: NavigationActions.BACK });
     expect(mockedDispatch.mock.calls.length).toBe(1);
   });
 
   it('handles Navigate action', () => {
     const mockedDispatch = jest
-      .fn(() => false)
-      .mockImplementationOnce(() => true);
+      .fn(() => Promise.reject())
+      .mockImplementationOnce(() => Promise.resolve());
     expect(
       addNavigationHelpers({
         state: { routeName: 'Home' },
         dispatch: mockedDispatch,
       }).navigate('Profile', { name: 'Matt' })
-    ).toEqual(true);
+    ).toEqual(Promise.resolve());
     expect(mockedDispatch).toBeCalledWith({
       type: NavigationActions.NAVIGATE,
       params: { name: 'Matt' },
@@ -55,14 +55,14 @@ describe('addNavigationHelpers', () => {
 
   it('handles SetParams action', () => {
     const mockedDispatch = jest
-      .fn(() => false)
-      .mockImplementationOnce(() => true);
+      .fn(() => Promise.reject())
+      .mockImplementationOnce(() => Promise.resolve());
     expect(
       addNavigationHelpers({
         state: { key: 'B', routeName: 'Settings' },
         dispatch: mockedDispatch,
       }).setParams({ notificationsEnabled: 'yes' })
-    ).toEqual(true);
+    ).toEqual(Promise.resolve());
     expect(mockedDispatch).toBeCalledWith({
       type: NavigationActions.SET_PARAMS,
       key: 'B',

--- a/src/addNavigationHelpers.js
+++ b/src/addNavigationHelpers.js
@@ -15,7 +15,7 @@ import NavigationActions from './NavigationActions';
 export default function<S: *>(navigation: NavigationProp<S, NavigationAction>) {
   return {
     ...navigation,
-    goBack: (key?: ?string): boolean =>
+    goBack: (key?: ?string): Promise<any> =>
       navigation.dispatch(
         NavigationActions.back({
           key: key === undefined ? navigation.state.key : key,
@@ -25,7 +25,7 @@ export default function<S: *>(navigation: NavigationProp<S, NavigationAction>) {
       routeName: string,
       params?: NavigationParams,
       action?: NavigationAction
-    ): boolean =>
+    ): Promise<any> =>
       navigation.dispatch(
         NavigationActions.navigate({
           routeName,
@@ -38,7 +38,7 @@ export default function<S: *>(navigation: NavigationProp<S, NavigationAction>) {
      * buttons are based on the route params.
      * This means `setParams` can be used to update nav bar for example.
      */
-    setParams: (params: NavigationParams): boolean =>
+    setParams: (params: NavigationParams): Promise<any> =>
       navigation.dispatch(
         NavigationActions.setParams({
           params,

--- a/src/createNavigationContainer.js
+++ b/src/createNavigationContainer.js
@@ -171,16 +171,16 @@ export default function createNavigationContainer<S: *, O>(
       return new Promise((resolve: Function, reject: Function) => {
         const { state } = this;
         if (!this._isStateful()) {
-          return reject();
+          reject();
+          return;
         }
         const nav = Component.router.getStateForAction(action, state.nav);
         if (nav && nav !== state.nav) {
-          this.setState({ nav }, () =>
-            this._onNavigationStateChange(state.nav, nav, action)
-          );
-          return resolve();
+          this.setState({ nav }, () => {
+            this._onNavigationStateChange(state.nav, nav, action);
+            resolve();
+          });
         }
-        return reject();
       });
     };
 

--- a/src/createNavigationContainer.js
+++ b/src/createNavigationContainer.js
@@ -168,18 +168,20 @@ export default function createNavigationContainer<S: *, O>(
     }
 
     dispatch = (action: NavigationAction) => {
-      const { state } = this;
-      if (!this._isStateful()) {
-        return false;
-      }
-      const nav = Component.router.getStateForAction(action, state.nav);
-      if (nav && nav !== state.nav) {
-        this.setState({ nav }, () =>
-          this._onNavigationStateChange(state.nav, nav, action)
-        );
-        return true;
-      }
-      return false;
+      return new Promise((resolve: Function, reject: Function) => {
+        const { state } = this;
+        if (!this._isStateful()) {
+          return reject();
+        }
+        const nav = Component.router.getStateForAction(action, state.nav);
+        if (nav && nav !== state.nav) {
+          this.setState({ nav }, () =>
+            this._onNavigationStateChange(state.nav, nav, action)
+          );
+          return resolve();
+        }
+        return reject();
+      });
     };
 
     _navigation: ?NavigationScreenProp<NavigationRoute, NavigationAction>;

--- a/src/routers/__tests__/Routers-test.js
+++ b/src/routers/__tests__/Routers-test.js
@@ -50,19 +50,28 @@ Object.keys(ROUTERS).forEach((routerName: string) => {
       ];
       expect(
         router.getScreenOptions(
-          addNavigationHelpers({ state: routes[0], dispatch: () => false }),
+          addNavigationHelpers({
+            state: routes[0],
+            dispatch: () => Promise.reject(),
+          }),
           {}
         ).title
       ).toEqual(undefined);
       expect(
         router.getScreenOptions(
-          addNavigationHelpers({ state: routes[1], dispatch: () => false }),
+          addNavigationHelpers({
+            state: routes[1],
+            dispatch: () => Promise.reject(),
+          }),
           {}
         ).title
       ).toEqual('BarTitle');
       expect(
         router.getScreenOptions(
-          addNavigationHelpers({ state: routes[2], dispatch: () => false }),
+          addNavigationHelpers({
+            state: routes[2],
+            dispatch: () => Promise.reject(),
+          }),
           {}
         ).title
       ).toEqual('Baz-123');

--- a/src/routers/__tests__/createConfigGetter-test.js
+++ b/src/routers/__tests__/createConfigGetter-test.js
@@ -72,49 +72,73 @@ test('should get config for screen', () => {
 
   expect(
     getScreenOptions(
-      addNavigationHelpers({ state: routes[0], dispatch: () => false }),
+      addNavigationHelpers({
+        state: routes[0],
+        dispatch: () => Promise.reject(),
+      }),
       {}
     ).title
   ).toEqual('Welcome anonymous');
   expect(
     getScreenOptions(
-      addNavigationHelpers({ state: routes[1], dispatch: () => false }),
+      addNavigationHelpers({
+        state: routes[1],
+        dispatch: () => Promise.reject(),
+      }),
       {}
     ).title
   ).toEqual('Welcome jane');
   expect(
     getScreenOptions(
-      addNavigationHelpers({ state: routes[0], dispatch: () => false }),
+      addNavigationHelpers({
+        state: routes[0],
+        dispatch: () => Promise.reject(),
+      }),
       {}
     ).gesturesEnabled
   ).toEqual(true);
   expect(
     getScreenOptions(
-      addNavigationHelpers({ state: routes[2], dispatch: () => false }),
+      addNavigationHelpers({
+        state: routes[2],
+        dispatch: () => Promise.reject(),
+      }),
       {}
     ).title
   ).toEqual('Settings!!!');
   expect(
     getScreenOptions(
-      addNavigationHelpers({ state: routes[2], dispatch: () => false }),
+      addNavigationHelpers({
+        state: routes[2],
+        dispatch: () => Promise.reject(),
+      }),
       {}
     ).gesturesEnabled
   ).toEqual(false);
   expect(
     getScreenOptions(
-      addNavigationHelpers({ state: routes[3], dispatch: () => false }),
+      addNavigationHelpers({
+        state: routes[3],
+        dispatch: () => Promise.reject(),
+      }),
       {}
     ).title
   ).toEqual('10 new notifications');
   expect(
     getScreenOptions(
-      addNavigationHelpers({ state: routes[3], dispatch: () => false }),
+      addNavigationHelpers({
+        state: routes[3],
+        dispatch: () => Promise.reject(),
+      }),
       {}
     ).gesturesEnabled
   ).toEqual(true);
   expect(
     getScreenOptions(
-      addNavigationHelpers({ state: routes[4], dispatch: () => false }),
+      addNavigationHelpers({
+        state: routes[4],
+        dispatch: () => Promise.reject(),
+      }),
       {}
     ).gesturesEnabled
   ).toEqual(false);
@@ -137,7 +161,10 @@ test('should throw if the route does not exist', () => {
 
   expect(() =>
     getScreenOptions(
-      addNavigationHelpers({ state: routes[0], dispatch: () => false }),
+      addNavigationHelpers({
+        state: routes[0],
+        dispatch: () => Promise.reject(),
+      }),
       {}
     )
   ).toThrowError(
@@ -156,7 +183,10 @@ test('should throw if the screen is not defined under the route config', () => {
 
   expect(() =>
     getScreenOptions(
-      addNavigationHelpers({ state: routes[0], dispatch: () => false })
+      addNavigationHelpers({
+        state: routes[0],
+        dispatch: () => Promise.reject(),
+      })
     )
   ).toThrowError('Route Home must define a screen or a getScreen.');
 });


### PR DESCRIPTION
Change return type of dispatch from boolean to Promise, so now we can dispatch a chain of actions.
Currently if I want to replace current screen we can only use reset action which will affect previous screen. And we can't call `goBack` and `navigate` in a row. Therefore I turn the dispatch method into promise so I can call `goBack` then `navigate`.
Example code:
```
navigator.dispatch(backAction).then(() => navigator.dispatch(navigateAction))
```