### PR TITLE
 allow back button customization, more than just title change and tint.

### DIFF
--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -127,6 +127,10 @@ React Element to display on the right side of the header
 
 React Element to display on the left side of the header
 
+#### `headerBack`
+
+React Element to display on the left side of the header, that is wrapped to act as a back button.
+
 #### `headerStyle`
 
 Style object for the header

--- a/examples/NavigationPlayground/js/SimpleStack.js
+++ b/examples/NavigationPlayground/js/SimpleStack.js
@@ -3,7 +3,7 @@
  */
 
 import React from 'react';
-import { Button, ScrollView } from 'react-native';
+import { Button, ScrollView, Text } from 'react-native';
 import { StackNavigator, SafeAreaView } from 'react-navigation';
 import SampleText from './SampleText';
 
@@ -13,6 +13,10 @@ const MyNavScreen = ({ navigation, banner }) => (
     <Button
       onPress={() => navigation.navigate('Profile', { name: 'Jane' })}
       title="Go to a profile screen"
+    />
+    <Button
+      onPress={() => navigation.navigate('ProfileBackButton', { name: 'Jane' })}
+      title="Go to a profile screen with back button"
     />
     <Button
       onPress={() => navigation.navigate('Photos', { name: 'Jane' })}
@@ -56,6 +60,38 @@ MyProfileScreen.navigationOptions = props => {
     headerTitle: `${params.name}'s Profile!`,
     // Render a button on the right side of the header.
     // When pressed switches the screen to edit mode.
+
+    headerRight: (
+      <Button
+        title={params.mode === 'edit' ? 'Done' : 'Edit'}
+        onPress={() =>
+          setParams({ mode: params.mode === 'edit' ? '' : 'edit' })}
+      />
+    ),
+  };
+};
+
+const MyProfileBackButtonScreen = ({ navigation }) => (
+  <MyNavScreen
+    banner={`${navigation.state.params.mode === 'edit'
+      ? 'Now Editing '
+      : ''}${navigation.state.params.name}'s Profile`}
+    navigation={navigation}
+  />
+);
+
+MyProfileBackButtonScreen.navigationOptions = props => {
+  const { navigation } = props;
+  const { state, setParams } = navigation;
+  const { params } = state;
+  return {
+    headerTitle: `${params.name}'s Profile!`,
+    // Render a button on the right side of the header.
+    // When pressed switches the screen to edit mode.
+    headerBack: (
+      <Text>⬅ BACK</Text>
+    ),
+
     headerRight: (
       <Button
         title={params.mode === 'edit' ? 'Done' : 'Edit'}
@@ -73,6 +109,10 @@ const SimpleStack = StackNavigator({
   Profile: {
     path: 'people/:name',
     screen: MyProfileScreen,
+  },
+  ProfileBackButton: {
+    path: 'people/:name',
+    screen: MyProfileBackButtonScreen,
   },
   Photos: {
     path: 'photos/:name',

--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -354,6 +354,7 @@ export type NavigationStackScreenOptions = {|
   headerTitleAllowFontScaling?: boolean,
   headerTintColor?: string,
   headerLeft?: React.Node,
+  headerBack?: React.Node,
   headerBackTitle?: string,
   headerTruncatedBackTitle?: string,
   headerBackTitleStyle?: TextStyleProp,

--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -14,6 +14,7 @@ import {
 } from 'react-native';
 
 import HeaderTitle from './HeaderTitle';
+import HeaderBackButtonWrapper from './HeaderBackButtonWrapper';
 import HeaderBackButton from './HeaderBackButton';
 import HeaderStyleInterpolator from './HeaderStyleInterpolator';
 import SafeAreaView from '../SafeAreaView';
@@ -62,6 +63,29 @@ class Header extends React.PureComponent<Props, State> {
 
   _getLastScene(scene: NavigationScene): ?NavigationScene {
     return this.props.scenes.find((s: *) => s.index === scene.index - 1);
+  }
+
+  _getBackButtonElement(props: SceneProps): ?React.Node {
+    const options = this.props.getScreenDetails(props.scene).options
+    const width = this.state.widths[props.scene.key]
+      ? (this.props.layout.initWidth - this.state.widths[props.scene.key]) / 2
+      : undefined;
+
+    let backButtonElement = options.headerBack;
+    if (!!backButtonElement) return backButtonElement;
+
+    const backButtonTitle = this._getBackButtonTitleString(props.scene);
+    const truncatedBackButtonTitle = this._getTruncatedBackButtonTitle(props.scene);
+    backButtonElement = (
+      <HeaderBackButton
+        tintColor={options.headerTintColor}
+        title={backButtonTitle}
+        truncatedTitle={truncatedBackButtonTitle}
+        titleStyle={options.headerBackTitleStyle}
+        width={width}
+      />
+    );
+    return backButtonElement;
   }
 
   _getBackButtonTitleString(scene: NavigationScene): ?string {
@@ -134,23 +158,15 @@ class Header extends React.PureComponent<Props, State> {
     if (props.scene.index === 0) {
       return null;
     }
-    const backButtonTitle = this._getBackButtonTitleString(props.scene);
-    const truncatedBackButtonTitle = this._getTruncatedBackButtonTitle(
-      props.scene
-    );
-    const width = this.state.widths[props.scene.key]
-      ? (this.props.layout.initWidth - this.state.widths[props.scene.key]) / 2
-      : undefined;
+
+    const backButtonElement = this._getBackButtonElement(props);
     return (
-      <HeaderBackButton
+      <HeaderBackButtonWrapper
         onPress={this._navigateBack}
         pressColorAndroid={options.headerPressColorAndroid}
-        tintColor={options.headerTintColor}
-        title={backButtonTitle}
-        truncatedTitle={truncatedBackButtonTitle}
-        titleStyle={options.headerBackTitleStyle}
-        width={width}
-      />
+      >
+        {backButtonElement}
+      </HeaderBackButtonWrapper>
     );
   };
 

--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -66,7 +66,7 @@ class Header extends React.PureComponent<Props, State> {
   }
 
   _getBackButtonElement(props: SceneProps): ?React.Node {
-    const options = this.props.getScreenDetails(props.scene).options
+    const options = this.props.getScreenDetails(props.scene).options;
     const width = this.state.widths[props.scene.key]
       ? (this.props.layout.initWidth - this.state.widths[props.scene.key]) / 2
       : undefined;
@@ -75,7 +75,9 @@ class Header extends React.PureComponent<Props, State> {
     if (!!backButtonElement) return backButtonElement;
 
     const backButtonTitle = this._getBackButtonTitleString(props.scene);
-    const truncatedBackButtonTitle = this._getTruncatedBackButtonTitle(props.scene);
+    const truncatedBackButtonTitle = this._getTruncatedBackButtonTitle(
+      props.scene
+    );
     backButtonElement = (
       <HeaderBackButton
         tintColor={options.headerTintColor}

--- a/src/views/Header/HeaderBackButton.js
+++ b/src/views/Header/HeaderBackButton.js
@@ -44,13 +44,7 @@ class HeaderBackButton extends React.PureComponent<Props, State> {
   };
 
   render() {
-    const {
-      width,
-      title,
-      titleStyle,
-      tintColor,
-      truncatedTitle,
-    } = this.props;
+    const { width, title, titleStyle, tintColor, truncatedTitle } = this.props;
 
     const renderTruncated =
       this.state.initialTextWidth && width

--- a/src/views/Header/HeaderBackButton.js
+++ b/src/views/Header/HeaderBackButton.js
@@ -12,11 +12,7 @@ import {
 
 import type { LayoutEvent, TextStyleProp } from '../../TypeDefinition';
 
-import TouchableItem from '../TouchableItem';
-
 type Props = {
-  onPress?: () => void,
-  pressColorAndroid?: string,
   title?: ?string,
   titleStyle?: ?TextStyleProp,
   tintColor?: ?string,
@@ -30,7 +26,6 @@ type State = {
 
 class HeaderBackButton extends React.PureComponent<Props, State> {
   static defaultProps = {
-    pressColorAndroid: 'rgba(0, 0, 0, .32)',
     tintColor: Platform.select({
       ios: '#037aff',
     }),
@@ -50,8 +45,6 @@ class HeaderBackButton extends React.PureComponent<Props, State> {
 
   render() {
     const {
-      onPress,
-      pressColorAndroid,
       width,
       title,
       titleStyle,
@@ -70,42 +63,30 @@ class HeaderBackButton extends React.PureComponent<Props, State> {
     const asset = require('../assets/back-icon.png');
 
     return (
-      <TouchableItem
-        accessibilityComponentType="button"
-        accessibilityLabel={backButtonTitle}
-        accessibilityTraits="button"
-        testID="header-back"
-        delayPressIn={0}
-        onPress={onPress}
-        pressColor={pressColorAndroid}
-        style={styles.container}
-        borderless
-      >
-        <View style={styles.container}>
-          <Image
-            style={[
-              styles.icon,
-              !!title && styles.iconWithTitle,
-              !!tintColor && { tintColor },
-            ]}
-            source={asset}
-          />
-          {Platform.OS === 'ios' &&
-            title && (
-              <Text
-                onLayout={this._onTextLayout}
-                style={[
-                  styles.title,
-                  !!tintColor && { color: tintColor },
-                  titleStyle,
-                ]}
-                numberOfLines={1}
-              >
-                {backButtonTitle}
-              </Text>
-            )}
-        </View>
-      </TouchableItem>
+      <View style={styles.container}>
+        <Image
+          style={[
+            styles.icon,
+            !!title && styles.iconWithTitle,
+            !!tintColor && { tintColor },
+          ]}
+          source={asset}
+        />
+        {Platform.OS === 'ios' &&
+          title && (
+            <Text
+              onLayout={this._onTextLayout}
+              style={[
+                styles.title,
+                !!tintColor && { color: tintColor },
+                titleStyle,
+              ]}
+              numberOfLines={1}
+            >
+              {backButtonTitle}
+            </Text>
+          )}
+      </View>
     );
   }
 }

--- a/src/views/Header/HeaderBackButtonWrapper.js
+++ b/src/views/Header/HeaderBackButtonWrapper.js
@@ -1,12 +1,7 @@
 /* @flow */
 
 import * as React from 'react';
-import {
-  I18nManager,
-  View,
-  Platform,
-  StyleSheet,
-} from 'react-native';
+import { I18nManager, View, Platform, StyleSheet } from 'react-native';
 
 import TouchableItem from '../TouchableItem';
 
@@ -24,7 +19,11 @@ type DefaultProps = {
 
 type State = {};
 
-class HeaderBackButtonWrapper extends React.PureComponent<DefaultProps, Props, State> {
+class HeaderBackButtonWrapper extends React.PureComponent<
+  DefaultProps,
+  Props,
+  State
+> {
   static defaultProps = {
     pressColorAndroid: 'rgba(0, 0, 0, .32)',
     accessibilityLabel: 'Back',
@@ -52,9 +51,7 @@ class HeaderBackButtonWrapper extends React.PureComponent<DefaultProps, Props, S
         style={styles.container}
         borderless
       >
-        <View style={[styles.container, styles.backContainer]}>
-          {children}
-        </View>
+        <View style={[styles.container, styles.backContainer]}>{children}</View>
       </TouchableItem>
     );
   }
@@ -66,17 +63,18 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     backgroundColor: 'transparent',
   },
-  backContainer: Platform.OS === 'ios'
-    ? {
-        marginLeft: 10,
-        marginRight: 22,
-        marginVertical: 12,
-        transform: [{ scaleX: I18nManager.isRTL ? -1 : 1 }],
-      }
-    : {
-        margin: 16,
-        transform: [{ scaleX: I18nManager.isRTL ? -1 : 1 }],
-    },
+  backContainer:
+    Platform.OS === 'ios'
+      ? {
+          marginLeft: 10,
+          marginRight: 22,
+          marginVertical: 12,
+          transform: [{ scaleX: I18nManager.isRTL ? -1 : 1 }],
+        }
+      : {
+          margin: 16,
+          transform: [{ scaleX: I18nManager.isRTL ? -1 : 1 }],
+        },
 });
 
 export default HeaderBackButtonWrapper;

--- a/src/views/Header/HeaderBackButtonWrapper.js
+++ b/src/views/Header/HeaderBackButtonWrapper.js
@@ -13,23 +13,15 @@ type Props = {
 };
 
 type DefaultProps = {
-  pressColorAndroid: ?string,
+  pressColorAndroid: string,
   accessibilityLabel: string,
 };
 
-type State = {};
-
-class HeaderBackButtonWrapper extends React.PureComponent<
-  DefaultProps,
-  Props,
-  State
-> {
+class HeaderBackButtonWrapper extends React.PureComponent<DefaultProps, Props> {
   static defaultProps = {
     pressColorAndroid: 'rgba(0, 0, 0, .32)',
     accessibilityLabel: 'Back',
   };
-
-  state = {};
 
   render() {
     const {

--- a/src/views/Header/HeaderBackButtonWrapper.js
+++ b/src/views/Header/HeaderBackButtonWrapper.js
@@ -1,0 +1,82 @@
+/* @flow */
+
+import * as React from 'react';
+import {
+  I18nManager,
+  View,
+  Platform,
+  StyleSheet,
+} from 'react-native';
+
+import TouchableItem from '../TouchableItem';
+
+type Props = {
+  onPress?: () => void,
+  pressColorAndroid?: string,
+  accessibilityLabel?: string,
+  children: React.ChildrenArray<*>,
+};
+
+type DefaultProps = {
+  pressColorAndroid: ?string,
+  accessibilityLabel: string,
+};
+
+type State = {};
+
+class HeaderBackButtonWrapper extends React.PureComponent<DefaultProps, Props, State> {
+  static defaultProps = {
+    pressColorAndroid: 'rgba(0, 0, 0, .32)',
+    accessibilityLabel: 'Back',
+  };
+
+  state = {};
+
+  render() {
+    const {
+      onPress,
+      pressColorAndroid,
+      accessibilityLabel,
+      children,
+    } = this.props;
+
+    return (
+      <TouchableItem
+        accessibilityComponentType="button"
+        accessibilityLabel={accessibilityLabel}
+        accessibilityTraits="button"
+        testID="header-back"
+        delayPressIn={0}
+        onPress={onPress}
+        pressColor={pressColorAndroid}
+        style={styles.container}
+        borderless
+      >
+        <View style={[styles.container, styles.backContainer]}>
+          {children}
+        </View>
+      </TouchableItem>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    backgroundColor: 'transparent',
+  },
+  backContainer: Platform.OS === 'ios'
+    ? {
+        marginLeft: 10,
+        marginRight: 22,
+        marginVertical: 12,
+        transform: [{ scaleX: I18nManager.isRTL ? -1 : 1 }],
+      }
+    : {
+        margin: 16,
+        transform: [{ scaleX: I18nManager.isRTL ? -1 : 1 }],
+    },
+});
+
+export default HeaderBackButtonWrapper;


### PR DESCRIPTION
This PR allows the user to use any react element as a back button.
We can already use something like
```
const Navigator = StackNavigator(
  {
    Splash: { screen: SplashScreen },
    Login: { screen: LoginScreen },
    Main: { screen: MainScreen },
  },
  {
    initialRouteName: 'Splash',
    navigationOptions: {
      headerMode: 'screen',
      headerStyle: {
        backgroundColor: Colors.navBarBackground,
        borderBottomWidth: 1 / PixelRatio.get(),
        borderBottomColor: Colors.separator,
      },
      headerTitleStyle: {
        color: Colors.textBlue,
        fontFamily: Fonts.type.base,
      },
```
Now we can also add something like
```
    headerBack: <Image source={Images.iconBack} />,
```
or like
```
    headerBack: (
      <View style={{
        alignItems: 'center',
        flexDirection: 'row',
      }}>
        <Image source={Images.iconBack} />
        <Text style={{paddingRight: 10, }} numberOfLines={1}>BACK</Text>
      </View>
    ),
```
This will be wrapped and made into a button that goes back.
The difference with `headerLeft` is basically that `headerLeft` can be anything, and added in any screen. `headerBack` is always a button that goes back, that contains any custom element the user gives, and it will only appear on non-zero index screens.

Without a custom `headerBack` (regular back button, automatically rendered, as before):
![img_0052](https://cloud.githubusercontent.com/assets/100233/26007178/b1c8ee1e-373f-11e7-8f28-087338452b00.PNG)
(`PavlosTv` is the title of the previous screen)

With a custom `headerBack` (custom element, wrapped as a `goBack` button):
![img_0051](https://cloud.githubusercontent.com/assets/100233/26007123/8246ae42-373f-11e7-84de-cf0c71ec84a0.PNG)

With a custom `headerBack` (custom element, wrapped as a `goBack` button):
![img_0053](https://cloud.githubusercontent.com/assets/100233/26007154/a22ea2f0-373f-11e7-88e3-fd7cdc73f46d.PNG)


