### PR TITLE
Override `forceInset` on DrawerItems.

### DIFF
--- a/docs/api/navigators/DrawerNavigator.md
+++ b/docs/api/navigators/DrawerNavigator.md
@@ -145,6 +145,7 @@ const styles = StyleSheet.create({
 - `inactiveTintColor` - label and icon color of the inactive label
 - `inactiveBackgroundColor` - background color of the inactive label
 - `onItemPress(route)` - function to be invoked when an item is pressed
+- `itemsContainerForceInset` - override default forceInset on the SafeAreaView that wraps the items container component
 - `itemsContainerStyle` - style object for the content section
 - `itemStyle` - style object for the single item, which can contain an Icon and/or a Label
 - `labelStyle` - style object to overwrite `Text` style inside content section, when your label is a string

--- a/src/views/Drawer/DrawerNavigatorItems.js
+++ b/src/views/Drawer/DrawerNavigatorItems.js
@@ -26,6 +26,7 @@ type Props = {
   getLabel: (scene: DrawerScene) => ?(React.Node | string),
   renderIcon: (scene: DrawerScene) => ?React.Node,
   onItemPress: (info: DrawerItem) => void,
+  itemsContainerForceInset?: Object,
   itemsContainerStyle?: ViewStyleProp,
   itemStyle?: ViewStyleProp,
   labelStyle?: TextStyleProp,
@@ -46,12 +47,13 @@ const DrawerNavigatorItems = ({
   getLabel,
   renderIcon,
   onItemPress,
+  itemsContainerForceInset = { horizontal: 'never', top: 'always' },
   itemsContainerStyle,
   itemStyle,
   labelStyle,
   iconContainerStyle,
 }: Props) => (
-  <SafeAreaView forceInset={{ horizontal: 'never', top: 'always' }}>
+  <SafeAreaView forceInset={itemsContainerForceInset}>
     <View style={[styles.container, itemsContainerStyle]}>
       {items.map((route: NavigationRoute, index: number) => {
         const focused = activeItemKey === route.key;


### PR DESCRIPTION
Fixes second part of issue #2854.
`itemsContainerForceInset` takes the same object as `forceInset` on SafeAreaView. It overrides the SafeAreaView container in DrawerItems.