### PR TITLE
fix for breakage in 185289ad6658e07783c807ee7ac29b9e1244fa21.

### DIFF
--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -308,6 +308,7 @@ class Header extends React.PureComponent<Props, State> {
     } = options;
     const appBarHeight = Platform.OS === 'ios' ? (isLandscape ? 32 : 44) : 56;
     const containerStyles = [
+      styles.container,
       {
         height: appBarHeight,
       },
@@ -316,7 +317,7 @@ class Header extends React.PureComponent<Props, State> {
 
     return (
       <SafeAreaView
-        style={[styles.container, { backgroundColor: headerBackgroundColor }]}
+        style={{ backgroundColor: headerBackgroundColor }}
         forceInset={{ top: 'always', bottom: 'never' }}
       >
         <Animated.View {...rest} style={containerStyles}>


### PR DESCRIPTION
that commit broke the possibility to have any kind of different separator on the bottom of the header.
this commit restores that.

like before, you can have in `headerStyle` something like `borderBottomWidth: 3, borderBottomColor: 'red'` for a custom separator, or `borderBottomWidth: 0` for no separator.


Please provide enough information so that others can review your pull request:

Explain the **motivation** for making this change. What existing problem does the pull request solve?

fixes a regression introduced in 185289ad6658e07783c807ee7ac29b9e1244fa21.

Prefer **small pull requests**. These are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise split it.

**Test plan (required)**

add what i have above for testing.

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

Make sure you test on both platforms if your change affects both platforms.

The code must pass tests and shouldn't add more Flow errors.

**Code formatting**

Look around. Match the style of the rest of the codebase.

