### PR TITLE
Export flow types

### DIFF
--- a/src/react-navigation.js
+++ b/src/react-navigation.js
@@ -4,6 +4,8 @@
 
 /* eslint global-require: 0 */
 
+/*:: export type * from './TypeDefinition'; */
+
 module.exports = {
   // Core
   get createNavigationContainer() {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request: -->

> Explain the **motivation** for making this change. What existing problem does the pull request solve?

Closes https://github.com/react-community/react-navigation/issues/912.

I exported all of the Flow definitions from src/TypeDefinitions.js, so that you can import the types without having to reach into the internals of the library.

**Before:**
```js
import {type NavigationState} from 'react-navigation/src/TypeDefinition';
```

**After:**
```js
import {type NavigationState} from 'react-navigation';
```

> Prefer **small pull requests**. These are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise split it.

Well, it's one line, so… I don't think I can make it much smaller 😉

## Test plan (required)

> Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

```
$ flow
No errors!

$ cat > sample.js <<EOF
// @flow
 
import {type NavigationState} from './src/react-navigation';
 
let foo: NavigationState = {};
EOF

$ flow
Error: sample.js:5
  5: let foo: NavigationState = {};
              ^^^^^^^^^^^^^^^ property `index`. Property not found in
  5: let foo: NavigationState = {};
                                ^^ object literal

Error: sample.js:5
  5: let foo: NavigationState = {};
              ^^^^^^^^^^^^^^^ property `routes`. Property not found in
  5: let foo: NavigationState = {};
                                ^^ object literal

Found 2 errors
```

> Make sure you test on both platforms if your change affects both platforms.
This only affects flow types, so neither platform is directly affected.

> The code must pass tests and shouldn't add more Flow errors.
```
$ flow
No errors!
```

## Code formatting

> Look around. Match the style of the rest of the codebase.
Er, as much as I could. I made sure to include the semicolon.

---

I had to use the Flow comment syntax for this, as Babel currently chokes on "export type * from". I'm going to file a bug there next.

I don't know what the generated `lib/` and `lib-rn/` folders are for, so I wasn't sure how to test them.