### PR TITLE
SafeAreaView - Fix for Web usage

### DIFF
--- a/src/views/SafeAreaView.js
+++ b/src/views/SafeAreaView.js
@@ -11,7 +11,6 @@ import {
 } from 'react-native';
 import withOrientation from './withOrientation';
 
-const { isIPhoneX_deprecated } = DeviceInfo;
 // See https://mydevice.io/devices/ for device dimensions
 const X_WIDTH = 375;
 const X_HEIGHT = 812;
@@ -24,8 +23,10 @@ const { PlatformConstants = {} } = NativeModules;
 const { minor = 0 } = PlatformConstants.reactNativeVersion || {};
 
 const isIPhoneX = (() => {
+  if (Platform.OS === 'web') return false;
+
   if (minor >= 50) {
-    return isIPhoneX_deprecated;
+    return DeviceInfo.isIPhoneX_deprecated;
   }
 
   return (


### PR DESCRIPTION
With the recent change to add SafeAreaView there was a change that broke projects using `react-navigation` inside `react-native-web`. The use of `DeviceInfo` and more specifically the property `isIPhoneX_deprecated` caused exceptions anytime `SafeAreaView` is used with `react-native-web`. This meant that `Header` couldn't be used without `SafeAreaView` being fixed.

**Test plan (required)**
Test that the functionality still works correctly in native by opening a `StackNavigator` with a header on both native (iOS or Android) and Web (via `react-native-web`)
