### PR TITLE
fix 2953 (Deep Linking - related)

### DIFF
--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -30,6 +30,14 @@ function _getUuid() {
   return `${uniqueBaseId}-${uuidCount++}`;
 }
 
+function isEmpty(obj: ?Object): boolean {
+  if (!obj) return true;
+  for (let key in obj) {
+    return false;
+  }
+  return true;
+}
+
 export default (
   routeConfigs: NavigationRouteConfigMap,
   stackConfig: NavigationStackRouterConfig = {}
@@ -375,17 +383,17 @@ export default (
 
       // reduce the items of the query string. any query params may
       // be overridden by path params
-      const queryParams =
-        inputParams ||
-        (queryString || '').split('&').reduce((result: *, item: string) => {
-          if (item !== '') {
-            const nextResult = result || {};
-            const [key, value] = item.split('=');
-            nextResult[key] = value;
-            return nextResult;
-          }
-          return result;
-        }, null);
+      const queryParams = !isEmpty(inputParams)
+        ? inputParams
+        : (queryString || '').split('&').reduce((result: *, item: string) => {
+            if (item !== '') {
+              const nextResult = result || {};
+              const [key, value] = item.split('=');
+              nextResult[key] = value;
+              return nextResult;
+            }
+            return result;
+          }, null);
 
       // reduce the matched pieces of the path into the params
       // of the route. `params` is null if there are no params.


### PR DESCRIPTION
As reported in #2953, deep linking with uri that contains query params does not work anymore on master. query params are not passed down the state params.
inputParams is by default equal to {} [as can be seen here](https://github.com/react-community/react-navigation/blob/d1c434b54c73b6ed17b1642acd6646fbca92c92e/src/createNavigationContainer.js#L87), therefore, queryParams returns always {} even if queryString is not empty.

Test plan:
tested by the author of #2953 as seen [here](https://github.com/react-community/react-navigation/issues/2953#issuecomment-344181884)