### PR TITLE
Allow strings Component types through as screens

### DIFF
--- a/src/routers/validateRouteConfigMap.js
+++ b/src/routers/validateRouteConfigMap.js
@@ -35,7 +35,11 @@ function validateRouteConfigMap(routeConfigs: NavigationRouteConfigMap) {
       );
     }
 
-    if (routeConfig.screen && typeof routeConfig.screen !== 'function') {
+    if (
+      routeConfig.screen &&
+      typeof routeConfig.screen !== 'function' &&
+      typeof routeConfig.screen !== 'string'
+    ) {
       throw new Error(
         `The component for route '${routeName}' must be a ` +
           'React component. For example:\n\n' +


### PR DESCRIPTION
In React Fiber (React 16), strings are used for intrinsics like 'div' and 'View'. As a result, if you use a View as a screen in an academic experience, you get a red error screen. This PR prevents that from happening.