### PR TITLE
Fix #3019

### DIFF
--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -142,7 +142,10 @@ class Header extends React.PureComponent<Props, State> {
   _renderLeftComponent = (props: SceneProps): ?React.Node => {
     // $FlowFixMe
     const { options } = this.props.getScreenDetails(props.scene);
-    if (React.isValidElement(options.headerLeft)) {
+    if (
+      React.isValidElement(options.headerLeft) ||
+      options.headerLeft === null
+    ) {
       return options.headerLeft;
     }
     if (props.scene.index === 0) {


### PR DESCRIPTION
I introduced a bug in PR https://github.com/react-community/react-navigation/pull/2712 which causes the default `headerLeft` (the back button) to show up if user passes `headerLeft: null` in the navigation options instead of not rendering anything: https://github.com/react-community/react-navigation/issues/3019. This is a fix for the bug.