### PR TITLE
Add NavigationContainer and NavigationContainerProps types

### DIFF
--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -228,9 +228,9 @@ export type NavigationScreenDetails<T> = {
   navigation: NavigationScreenProp<NavigationRoute>,
 };
 
-export type NavigationScreenOptions = {|
+export type NavigationScreenOptions = {
   title?: string,
-|};
+};
 
 export type NavigationScreenConfigProps = {
   navigation: NavigationScreenProp<NavigationRoute>,
@@ -418,6 +418,31 @@ export type NavigationScreenProp<+S> = {
 export type NavigationNavigatorProps<O: {}, S: {}> = {
   navigation: NavigationScreenProp<S>,
   screenProps?: {},
+  navigationOptions?: O,
+};
+
+/**
+ * Navigation container
+ */
+
+export type NavigationContainer<
+  State: NavigationState,
+  Options: {},
+  Props: {}
+> = React.ComponentType<NavigationContainerProps<State, Options> & Props> & {
+  router: NavigationRouter<State, Options>,
+  navigationOptions?: ?NavigationScreenConfig<Options>,
+};
+
+export type NavigationContainerProps<S: {}, O: {}> = {
+  uriPrefix?: string | RegExp,
+  onNavigationStateChange?: (
+    NavigationState,
+    NavigationState,
+    NavigationAction
+  ) => void,
+  navigation?: NavigationScreenProp<S>,
+  screenProps?: *,
   navigationOptions?: O,
 };
 

--- a/src/createNavigationContainer.js
+++ b/src/createNavigationContainer.js
@@ -13,19 +13,9 @@ import type {
   NavigationNavigator,
   PossiblyDeprecatedNavigationAction,
   NavigationInitAction,
+  NavigationContainerProps,
+  NavigationContainer,
 } from './TypeDefinition';
-
-type Props<S, O> = {
-  uriPrefix?: string | RegExp,
-  onNavigationStateChange?: (
-    NavigationState,
-    NavigationState,
-    NavigationAction
-  ) => void,
-  navigation?: NavigationScreenProp<S>,
-  screenProps?: *,
-  navigationOptions?: O,
-};
 
 type State<NavState> = {
   nav: ?NavState,
@@ -40,15 +30,19 @@ type State<NavState> = {
 export default function createNavigationContainer<S: NavigationState, O: {}>(
   // Let the NavigationNavigator props flowwwww
   Component: NavigationNavigator<S, O, *>
-) {
-  class NavigationContainer extends React.Component<Props<S, O>, State<S>> {
+): NavigationContainer<S, O, *> {
+  class NavigationContainer extends React.Component<
+    NavigationContainerProps<S, O>,
+    State<S>
+  > {
     subs: ?{
       remove: () => void,
     } = null;
 
     static router = Component.router;
+    static navigationOptions = null;
 
-    constructor(props: Props<S, O>) {
+    constructor(props: NavigationContainerProps<S, O>) {
       super(props);
 
       this._validateProps(props);
@@ -64,7 +58,7 @@ export default function createNavigationContainer<S: NavigationState, O: {}>(
       return !this.props.navigation;
     }
 
-    _validateProps(props: Props<S, O>) {
+    _validateProps(props: NavigationContainerProps<S, O>) {
       if (this._isStateful()) {
         return;
       }
@@ -142,7 +136,7 @@ export default function createNavigationContainer<S: NavigationState, O: {}>(
       }
     }
 
-    componentWillReceiveProps(nextProps: Props<S, O>) {
+    componentWillReceiveProps(nextProps: NavigationContainerProps<S, O>) {
       this._validateProps(nextProps);
     }
 


### PR DESCRIPTION
Adding types for these fixes the errors we're seeing when using `TabNavigator` and `StackNavigator`. We should finally be able to close #2933 now.