### PR TITLE
Set sdkVersion to 23.0.0

### DIFF
--- a/examples/ReduxExample/app.json
+++ b/examples/ReduxExample/app.json
@@ -12,7 +12,7 @@
       "icon": "./assets/icons/react-navigation.png",
       "hideExponentText": false
     },
-    "sdkVersion": "22.0.0",
+    "sdkVersion": "23.0.0",
     "entryPoint": "./node_modules/react-native-scripts/build/bin/crna-entry.js",
     "packagerOpts": {
       "assetExts": [


### PR DESCRIPTION
This small PR fixes "React Native version mismatch" error in ReduxExample.

![rn-redux-example-error](https://user-images.githubusercontent.com/67445/33177026-c7bb96ca-d093-11e7-83ce-1abcda85ac0c.png)