### PR TITLE
Pass props down into SafeAreaView's nested View

### DIFF
--- a/src/views/SafeAreaView.js
+++ b/src/views/SafeAreaView.js
@@ -111,6 +111,7 @@ class SafeView extends Component {
         ref={c => (this.view = c)}
         onLayout={this._onLayout}
         style={safeAreaStyle}
+        {...this.props}
       >
         {this.props.children}
       </View>


### PR DESCRIPTION
- this was causing a problem where we were setting `pointerEvents` on a `SafeAreaView` and it wasn't being respected