### PR TITLE
Fix proptypes deprecation issues

### DIFF
--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import * as React from 'react';
+import React from 'react';
 
 import type { TabScene } from './views/TabView/TabView';
 

--- a/src/navigators/DrawerNavigator.js
+++ b/src/navigators/DrawerNavigator.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import * as React from 'react';
+import React from 'react';
 import { Dimensions, Platform, ScrollView } from 'react-native';
 
 import createNavigator from './createNavigator';

--- a/src/navigators/StackNavigator.js
+++ b/src/navigators/StackNavigator.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import * as React from 'react';
+import React from 'react';
 import createNavigationContainer from '../createNavigationContainer';
 import createNavigator from './createNavigator';
 import CardStackTransitioner from '../views/CardStack/CardStackTransitioner';

--- a/src/navigators/TabNavigator.js
+++ b/src/navigators/TabNavigator.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import * as React from 'react';
+import React from 'react';
 import { Platform } from 'react-native';
 
 import createNavigator from './createNavigator';

--- a/src/navigators/createNavigator.js
+++ b/src/navigators/createNavigator.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import * as React from 'react';
+import React from 'react';
 
 import type {
   NavigationRouter,

--- a/src/routers/__tests__/Routers-test.js
+++ b/src/routers/__tests__/Routers-test.js
@@ -1,7 +1,7 @@
 /* @flow */
 /* eslint react/no-multi-comp:0 */
 
-import * as React from 'react';
+import React from 'react';
 
 import StackRouter from '../StackRouter';
 import TabRouter from '../TabRouter';

--- a/src/routers/__tests__/StackRouter-test.js
+++ b/src/routers/__tests__/StackRouter-test.js
@@ -1,7 +1,7 @@
 /* @flow */
 /* eslint no-shadow:0, react/no-multi-comp:0, react/display-name:0 */
 
-import * as React from 'react';
+import React from 'react';
 
 import StackRouter from '../StackRouter';
 import TabRouter from '../TabRouter';

--- a/src/views/CardStack/Card.js
+++ b/src/views/CardStack/Card.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import * as React from 'react';
+import React from 'react';
 
 import { Animated, StyleSheet } from 'react-native';
 

--- a/src/views/CardStack/CardStack.js
+++ b/src/views/CardStack/CardStack.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import * as React from 'react';
+import React from 'react';
 
 import clamp from 'clamp';
 import {

--- a/src/views/CardStack/CardStackTransitioner.js
+++ b/src/views/CardStack/CardStackTransitioner.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import * as React from 'react';
+import React from 'react';
 import { NativeModules } from 'react-native';
 
 import CardStack from './CardStack';

--- a/src/views/CardStack/PointerEventsContainer.js
+++ b/src/views/CardStack/PointerEventsContainer.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import * as React from 'react';
+import React from 'react';
 
 import invariant from '../../utils/invariant';
 

--- a/src/views/Drawer/DrawerNavigatorItems.js
+++ b/src/views/Drawer/DrawerNavigatorItems.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import * as React from 'react';
+import React from 'react';
 import { View, Text, Platform, StyleSheet } from 'react-native';
 
 import SafeAreaView from '../SafeAreaView';

--- a/src/views/Drawer/DrawerScreen.js
+++ b/src/views/Drawer/DrawerScreen.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import * as React from 'react';
+import React from 'react';
 
 import SceneView from '../SceneView';
 import withCachedChildNavigation from '../../withCachedChildNavigation';

--- a/src/views/Drawer/DrawerSidebar.js
+++ b/src/views/Drawer/DrawerSidebar.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import * as React from 'react';
+import React from 'react';
 import { StyleSheet, View } from 'react-native';
 
 import withCachedChildNavigation from '../../withCachedChildNavigation';

--- a/src/views/Drawer/DrawerView.js
+++ b/src/views/Drawer/DrawerView.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import * as React from 'react';
+import React from 'react';
 import { Dimensions } from 'react-native';
 import DrawerLayout from 'react-native-drawer-layout-polyfill';
 

--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -2,7 +2,7 @@
 
 'no babel-plugin-flow-react-proptypes';
 
-import * as React from 'react';
+import React from 'react';
 
 import {
   Animated,

--- a/src/views/Header/HeaderBackButton.js
+++ b/src/views/Header/HeaderBackButton.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import * as React from 'react';
+import React from 'react';
 import {
   I18nManager,
   Image,

--- a/src/views/Header/HeaderTitle.js
+++ b/src/views/Header/HeaderTitle.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import * as React from 'react';
+import React from 'react';
 
 import { Text, View, Platform, StyleSheet, Animated } from 'react-native';
 

--- a/src/views/SceneView.js
+++ b/src/views/SceneView.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import * as React from 'react';
+import React from 'react';
 import propTypes from 'prop-types';
 
 import type {

--- a/src/views/TabView/TabBarBottom.js
+++ b/src/views/TabView/TabBarBottom.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import * as React from 'react';
+import React from 'react';
 import {
   Animated,
   TouchableWithoutFeedback,

--- a/src/views/TabView/TabBarIcon.js
+++ b/src/views/TabView/TabBarIcon.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import * as React from 'react';
+import React from 'react';
 import { Animated, View, StyleSheet } from 'react-native';
 
 import type {

--- a/src/views/TabView/TabBarTop.js
+++ b/src/views/TabView/TabBarTop.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import * as React from 'react';
+import React from 'react';
 import { Animated, StyleSheet } from 'react-native';
 import { TabBar } from 'react-native-tab-view';
 import TabBarIcon from './TabBarIcon';

--- a/src/views/TabView/TabView.js
+++ b/src/views/TabView/TabView.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import * as React from 'react';
+import React from 'react';
 import { View, StyleSheet, Platform } from 'react-native';
 import { TabViewAnimated, TabViewPagerPan } from 'react-native-tab-view';
 import type { Layout } from 'react-native-tab-view/src/TabViewTypeDefinitions';

--- a/src/views/TouchableItem.js
+++ b/src/views/TouchableItem.js
@@ -9,7 +9,7 @@
  * On iOS you can pass the props of TouchableOpacity, on Android pass the props
  * of TouchableNativeFeedback.
  */
-import * as React from 'react';
+import React from 'react';
 import {
   Platform,
   TouchableNativeFeedback,

--- a/src/views/Transitioner.js
+++ b/src/views/Transitioner.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import * as React from 'react';
+import React from 'react';
 
 import { Animated, Easing, StyleSheet, View } from 'react-native';
 

--- a/src/views/withNavigation.js
+++ b/src/views/withNavigation.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import * as React from 'react';
+import React from 'react';
 import propTypes from 'prop-types';
 import hoistStatics from 'hoist-non-react-statics';
 

--- a/src/views/withOrientation.js
+++ b/src/views/withOrientation.js
@@ -1,6 +1,6 @@
 // @flow
 
-import * as React from 'react';
+import React from 'react';
 import { Dimensions } from 'react-native';
 import hoistNonReactStatic from 'hoist-non-react-statics';
 

--- a/src/withCachedChildNavigation.js
+++ b/src/withCachedChildNavigation.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import * as React from 'react';
+import React from 'react';
 
 import addNavigationHelpers from './addNavigationHelpers';
 

--- a/website/src/PhoneGraphic.js
+++ b/website/src/PhoneGraphic.js
@@ -2,7 +2,7 @@
  * @flow
  */
 
-import * as React from 'react';
+import React from 'react';
 
 type Props = { sources: { android: string, iphone: string } };
 type State = { activeExample: string };


### PR DESCRIPTION
Avoid importing PropTypes, checkPropTypes and createClass that are deprecated.

@kelset 

**Test plan (required)**

<img width="533" alt="screen shot 2017-11-27 at 7 15 14 pm" src="https://user-images.githubusercontent.com/2577356/33292324-9e2c945a-d3a7-11e7-83b8-44440dc8b457.png">


Related issues

https://github.com/react-community/react-navigation/issues/2019
https://github.com/react-community/react-navigation/issues/2984
https://github.com/react-community/react-navigation/issues/2979
https://github.com/react-community/react-navigation/issues/3005

