### PR TITLE
Enable configuration of gesture direction

### DIFF
--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -158,6 +158,10 @@ Object to override the distance of touch start from the edge of the screen to re
 - `horizontal` - *number* - Distance for horizontal direction. Defaults to 25.
 - `vertical` - *number* - Distance for vertical direction. Defaults to 135.
 
+#### `gestureDirection`
+
+Object to override the direction for dismiss gestures. `default` for normal behaviour depending on `I18nManager.isRTL` value. `inverted` for inverted direction.
+
 ### Navigator Props
 
 The navigator component created by `StackNavigator(...)` takes the following props:

--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -160,7 +160,7 @@ Object to override the distance of touch start from the edge of the screen to re
 
 #### `gestureDirection`
 
-Object to override the direction for dismiss gestures. `default` for normal behaviour depending on `I18nManager.isRTL` value. `inverted` for inverted direction.
+String to override the direction for dismiss gesture. `default` for normal behaviour or `inverted` for right-to-left swipes.
 
 ### Navigator Props
 

--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -324,6 +324,7 @@ export type NavigationStackScreenOptions = NavigationScreenOptions & {
   headerStyle?: ViewStyleProp,
   gesturesEnabled?: boolean,
   gestureResponseDistance?: { vertical?: number, horizontal?: number },
+  gestureDirection?: 'default' | 'inverted',
 };
 
 export type NavigationStackRouterConfig = {

--- a/src/views/CardStack/CardStack.js
+++ b/src/views/CardStack/CardStack.js
@@ -306,7 +306,7 @@ class CardStack extends React.Component<Props> {
           ? layout.height.__getValue()
           : layout.width.__getValue();
         const currentValue =
-          (I18nManager.isRTL && axis === 'dx') || gestureDirectionInverted
+          (I18nManager.isRTL && axis === 'dx') !== gestureDirectionInverted
             ? startValue + gesture[axis] / axisDistance
             : startValue - gesture[axis] / axisDistance;
         const value = clamp(index - 1, currentValue, index);

--- a/src/views/CardStack/CardStack.js
+++ b/src/views/CardStack/CardStack.js
@@ -240,6 +240,8 @@ class CardStack extends React.Component<Props> {
     const { navigation, position, layout, scene, scenes, mode } = this.props;
     const { index } = navigation.state;
     const isVertical = mode === 'modal';
+    const { options } = this._getScreenDetails(scene);
+    const gestureDirectionInverted = options.gestureDirection === 'inverted';
 
     const responder = PanResponder.create({
       onPanResponderTerminate: () => {
@@ -270,7 +272,9 @@ class CardStack extends React.Component<Props> {
         const axisHasBeenMeasured = !!axisLength;
 
         // Measure the distance from the touch to the edge of the screen
-        const screenEdgeDistance = currentDragPosition - currentDragDistance;
+        const screenEdgeDistance = gestureDirectionInverted
+          ? axisLength - (currentDragPosition - currentDragDistance)
+          : currentDragPosition - currentDragDistance;
         // Compare to the gesture distance relavant to card or modal
         const {
           gestureResponseDistance: userGestureResponseDistance = {},
@@ -302,7 +306,7 @@ class CardStack extends React.Component<Props> {
           ? layout.height.__getValue()
           : layout.width.__getValue();
         const currentValue =
-          I18nManager.isRTL && axis === 'dx'
+          (I18nManager.isRTL && axis === 'dx') || gestureDirectionInverted
             ? startValue + gesture[axis] / axisDistance
             : startValue - gesture[axis] / axisDistance;
         const value = clamp(index - 1, currentValue, index);
@@ -325,12 +329,20 @@ class CardStack extends React.Component<Props> {
         const axisDistance = isVertical
           ? layout.height.__getValue()
           : layout.width.__getValue();
-        const movedDistance = gesture[isVertical ? 'dy' : 'dx'];
-        const gestureVelocity = gesture[isVertical ? 'vy' : 'vx'];
+        const movedDistance = gestureDirectionInverted
+          ? -gesture[isVertical ? 'dy' : 'dx']
+          : gesture[isVertical ? 'dy' : 'dx'];
+        const gestureVelocity = gestureDirectionInverted
+          ? -gesture[isVertical ? 'vy' : 'vx']
+          : gesture[isVertical ? 'vy' : 'vx'];
         const defaultVelocity = axisDistance / ANIMATION_DURATION;
         const velocity = Math.max(Math.abs(gestureVelocity), defaultVelocity);
-        const resetDuration = movedDistance / velocity;
-        const goBackDuration = (axisDistance - movedDistance) / velocity;
+        const resetDuration = gestureDirectionInverted
+          ? (axisDistance - movedDistance) / velocity
+          : movedDistance / velocity;
+        const goBackDuration = gestureDirectionInverted
+          ? movedDistance / velocity
+          : (axisDistance - movedDistance) / velocity;
 
         // To asyncronously get the current animated value, we need to run stopAnimation:
         position.stopAnimation((value: number) => {
@@ -356,7 +368,6 @@ class CardStack extends React.Component<Props> {
       },
     });
 
-    const { options } = this._getScreenDetails(scene);
     const gesturesEnabled =
       typeof options.gesturesEnabled === 'boolean'
         ? options.gesturesEnabled

--- a/src/views/CardStack/CardStack.js
+++ b/src/views/CardStack/CardStack.js
@@ -329,12 +329,11 @@ class CardStack extends React.Component<Props> {
         const axisDistance = isVertical
           ? layout.height.__getValue()
           : layout.width.__getValue();
-        const movedDistance = gestureDirectionInverted
-          ? -gesture[isVertical ? 'dy' : 'dx']
-          : gesture[isVertical ? 'dy' : 'dx'];
-        const gestureVelocity = gestureDirectionInverted
-          ? -gesture[isVertical ? 'vy' : 'vx']
-          : gesture[isVertical ? 'vy' : 'vx'];
+        const movementDirection = gestureDirectionInverted ? -1 : 1;
+        const movedDistance =
+          movementDirection * gesture[isVertical ? 'dy' : 'dx'];
+        const gestureVelocity =
+          movementDirection * gesture[isVertical ? 'vy' : 'vx'];
         const defaultVelocity = axisDistance / ANIMATION_DURATION;
         const velocity = Math.max(Math.abs(gestureVelocity), defaultVelocity);
         const resetDuration = gestureDirectionInverted


### PR DESCRIPTION
Enables configuration of the back gesture direction. This is useful if the app uses custom right-to-left navigation transitions with the `transitionConfig.sreenInterpolator` configuration parameter. Discussion around this topic can be found in issue #2393.

**Test plan**

Configuring the repository `ReduxExample` app with the following right-to-left transition configuration

```javascript
export const AppNavigator = StackNavigator({
  Login: { screen: LoginScreen },
  Main: { screen: MainScreen },
  Profile: { screen: ProfileScreen },
}, {
  navigationOptions: () => ({
    gestureDirection: 'inverted',
  }),
  transitionConfig: () => ({
    screenInterpolator: sceneProps => {
      const { layout, position, scene } = sceneProps;
      const { index } = scene;
      const width = layout.initWidth;

      return {
        transform: [{
          translateX: position.interpolate({
            inputRange: [index - 1, index, index + 1],
            outputRange: [-width, 0, width],
          }),
        }]
      };
    },
  })
});
```

yields the following results

![react-navigation-gesture-direction](https://user-images.githubusercontent.com/1143250/33553847-1c45c9aa-d903-11e7-8eb2-d7f121e619fb.gif)
