### PR TITLE
Don't use params from unrelated action when initializing nav state

### DIFF
--- a/src/routers/TabRouter.js
+++ b/src/routers/TabRouter.js
@@ -61,9 +61,7 @@ export default (
         const routes = order.map((routeName: string) => {
           const tabRouter = tabRouters[routeName];
           if (tabRouter) {
-            const childAction = NavigationActions.init({
-              ...(action.params ? { params: action.params } : {}),
-            });
+            const childAction = NavigationActions.init();
             return {
               ...tabRouter.getStateForAction(childAction),
               key: routeName,

--- a/src/routers/__tests__/TabRouter-test.js
+++ b/src/routers/__tests__/TabRouter-test.js
@@ -215,7 +215,6 @@ describe('TabRouter', () => {
     const navAction = {
       type: NavigationActions.NAVIGATE,
       routeName: 'Baz',
-      params: { foo: '42', bar: '43' },
     };
     let state = router.getStateForAction(navAction);
     expect(state).toEqual({
@@ -227,8 +226,8 @@ describe('TabRouter', () => {
           key: 'Baz',
           routeName: 'Baz',
           routes: [
-            { key: 'Boo', routeName: 'Boo', params: { foo: '42', bar: '43' } },
-            { key: 'Bar', routeName: 'Bar', params: { foo: '42', bar: '43' } },
+            { key: 'Boo', routeName: 'Boo' },
+            { key: 'Bar', routeName: 'Bar' },
           ],
         },
       ],
@@ -248,8 +247,8 @@ describe('TabRouter', () => {
       key: 'Baz',
       routeName: 'Baz',
       routes: [
-        { key: 'Boo', routeName: 'Boo', params: { foo: '42', bar: '43' } },
-        { key: 'Bar', routeName: 'Bar', params: { foo: '42', bar: '43' } },
+        { key: 'Boo', routeName: 'Boo' },
+        { key: 'Bar', routeName: 'Bar' },
       ],
     });
   });


### PR DESCRIPTION
`TabRouter.getStateForAction` has some code at the start to initialize an empty nav state before handling any action. This initialization is achieved by passing `INIT` actions to all child routes. However, the code strangely also passes these child routes the params that were given to the action. The initialization should be separate from the processing of the action.