### PR TITLE
Inward StackRouter Navigation Param Propagation

### DIFF
--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -77,10 +77,14 @@ export default (routeConfigs, stackConfig = {}) => {
     }
 
     if (initialChildRouter) {
+      const params = (action.params || initialRouteParams) && {
+        ...(action.params || {}),
+        ...(initialRouteParams || {}),
+      };
       route = initialChildRouter.getStateForAction(
         NavigationActions.navigate({
           routeName: initialRouteName,
-          params: initialRouteParams,
+          ...(params ? { params } : {})
         })
       );
     }


### PR DESCRIPTION
Hopefully this fixes #3255 -- the stack layering below is currently not passing params properly.

```
+ StackRouter(AppMain)
--+ View(AppView)
--+ StackRouter(ModalMain)
----+ View(ModalView)
```

When `AppMain` tries to navigate to `ModalMain` with params, those params are not passed to `ModalView`. This change should include those params merged over-top of the StackRouter default parameters.

### Tasks Remaining

- [ ] Add an entry under the "Unreleased" heading in [CHANGELOG.md](https://github.com/react-navigation/react-navigation/blob/master/CHANGELOG.md#unreleased) which explains your change.
