### PR TITLE
feat: add a `navigationKey` prop to Screen and Group

### DIFF
--- a/packages/core/src/isArrayEqual.tsx
+++ b/packages/core/src/isArrayEqual.tsx
@@ -3,5 +3,13 @@
  * We need to make sure that both values and order match.
  */
 export default function isArrayEqual(a: any[], b: any[]) {
-  return a.length === b.length && a.every((it, index) => it === b[index]);
+  if (a === b) {
+    return true;
+  }
+
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  return a.every((it, index) => it === b[index]);
 }

--- a/packages/core/src/isRecordEqual.tsx
+++ b/packages/core/src/isRecordEqual.tsx
@@ -1,0 +1,20 @@
+/**
+ * Compare two records with primitive values as the content.
+ */
+export default function isRecordEqual(
+  a: Record<string, any>,
+  b: Record<string, any>
+) {
+  if (a === b) {
+    return true;
+  }
+
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+
+  if (aKeys.length !== bKeys.length) {
+    return false;
+  }
+
+  return aKeys.every((key) => a[key] === b[key]);
+}

--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -440,6 +440,13 @@ export type RouteConfig<
   EventMap extends EventMapBase
 > = {
   /**
+   * Optional key for this screen. This doesn't need to be unique.
+   * If the key changes, existing screens with this name will be removed or reset.
+   * Useful when we have some common screens and have conditional rendering.
+   */
+  navigationKey?: string;
+
+  /**
    * Route name of this screen.
    */
   name: RouteName;
@@ -482,6 +489,12 @@ export type RouteGroupConfig<
   ParamList extends ParamListBase,
   ScreenOptions extends {}
 > = {
+  /**
+   * Optional key for the screens in this group.
+   * If the key changes, all existing screens in this group will be removed or reset.
+   */
+  navigationKey?: string;
+
   /**
    * Navigator options for this screen.
    */

--- a/packages/core/src/useDescriptors.tsx
+++ b/packages/core/src/useDescriptors.tsx
@@ -29,10 +29,11 @@ export type ScreenConfigWithParent<
   State extends NavigationState,
   ScreenOptions extends {},
   EventMap extends EventMapBase
-> = [
-  (ScreenOptionsOrCallback<ScreenOptions> | undefined)[] | undefined,
-  RouteConfig<ParamListBase, string, State, ScreenOptions, EventMap>
-];
+> = {
+  keys: (string | undefined)[];
+  options: (ScreenOptionsOrCallback<ScreenOptions> | undefined)[] | undefined;
+  props: RouteConfig<ParamListBase, string, State, ScreenOptions, EventMap>;
+};
 
 type ScreenOptionsOrCallback<ScreenOptions extends {}> =
   | ScreenOptions
@@ -149,15 +150,15 @@ export default function useDescriptors<
     >
   >((acc, route, i) => {
     const config = screens[route.name];
-    const screen = config[1];
+    const screen = config.props;
     const navigation = navigations[route.key];
 
     const optionsList = [
       // The default `screenOptions` passed to the navigator
       screenOptions,
       // The `screenOptions` props passed to `Group` elements
-      ...((config[0]
-        ? config[0].filter(Boolean)
+      ...((config.options
+        ? config.options.filter(Boolean)
         : []) as ScreenOptionsOrCallback<ScreenOptions>[]),
       // The `options` prop passed to `Screen` elements,
       screen.options,

--- a/packages/core/src/useNavigationBuilder.tsx
+++ b/packages/core/src/useNavigationBuilder.tsx
@@ -15,6 +15,7 @@ import { isValidElementType } from 'react-is';
 
 import Group from './Group';
 import isArrayEqual from './isArrayEqual';
+import isRecordEqual from './isRecordEqual';
 import NavigationHelpersContext from './NavigationHelpersContext';
 import NavigationRouteContext from './NavigationRouteContext';
 import NavigationStateContext from './NavigationStateContext';
@@ -51,6 +52,9 @@ type NavigatorRoute<State extends NavigationState> = {
   params?: NavigatorScreenParams<ParamListBase, State>;
 };
 
+const isValidKey = (key: unknown) =>
+  key === undefined || (typeof key === 'string' && key !== '');
+
 /**
  * Extract route config object from React children elements.
  *
@@ -62,7 +66,12 @@ const getRouteConfigsFromChildren = <
   EventMap extends EventMapBase
 >(
   children: React.ReactNode,
-  options?: ScreenConfigWithParent<State, ScreenOptions, EventMap>[0]
+  groupKey?: string,
+  groupOptions?: ScreenConfigWithParent<
+    State,
+    ScreenOptions,
+    EventMap
+  >['options']
 ) => {
   const configs = React.Children.toArray(children).reduce<
     ScreenConfigWithParent<State, ScreenOptions, EventMap>[]
@@ -71,29 +80,50 @@ const getRouteConfigsFromChildren = <
       if (child.type === Screen) {
         // We can only extract the config from `Screen` elements
         // If something else was rendered, it's probably a bug
-        acc.push([
-          options,
-          child.props as RouteConfig<
+
+        if (!isValidKey(child.props.navigationKey)) {
+          throw new Error(
+            `Got an invalid 'navigationKey' prop (${JSON.stringify(
+              child.props.navigationKey
+            )}) for the screen '${
+              child.props.name
+            }'. It must be a non-empty string or 'undefined'.`
+          );
+        }
+
+        acc.push({
+          keys: [groupKey, child.props.navigationKey],
+          options: groupOptions,
+          props: child.props as RouteConfig<
             ParamListBase,
             string,
             State,
             ScreenOptions,
             EventMap
           >,
-        ]);
+        });
         return acc;
       }
 
       if (child.type === React.Fragment || child.type === Group) {
+        if (!isValidKey(child.props.navigationKey)) {
+          throw new Error(
+            `Got an invalid 'navigationKey' prop (${JSON.stringify(
+              child.props.navigationKey
+            )}) for the group. It must be a non-empty string or 'undefined'.`
+          );
+        }
+
         // When we encounter a fragment or group, we need to dive into its children to extract the configs
         // This is handy to conditionally define a group of screens
         acc.push(
           ...getRouteConfigsFromChildren<State, ScreenOptions, EventMap>(
             child.props.children,
+            child.props.navigationKey,
             child.type !== Group
-              ? options
-              : options != null
-              ? [...options, child.props.screenOptions]
+              ? groupOptions
+              : groupOptions != null
+              ? [...groupOptions, child.props.screenOptions]
               : [child.props.screenOptions]
           )
         );
@@ -118,7 +148,7 @@ const getRouteConfigsFromChildren = <
 
   if (process.env.NODE_ENV !== 'production') {
     configs.forEach((config) => {
-      const { name, children, component, getComponent } = config[1];
+      const { name, children, component, getComponent } = config.props;
 
       if (typeof name !== 'string' || !name) {
         throw new Error(
@@ -236,20 +266,27 @@ export default function useNavigationBuilder<
   const screens = routeConfigs.reduce<
     Record<string, ScreenConfigWithParent<State, ScreenOptions, EventMap>>
   >((acc, config) => {
-    if (config[1].name in acc) {
+    if (config.props.name in acc) {
       throw new Error(
-        `A navigator cannot contain multiple 'Screen' components with the same name (found duplicate screen named '${config[1].name}')`
+        `A navigator cannot contain multiple 'Screen' components with the same name (found duplicate screen named '${config.props.name}')`
       );
     }
 
-    acc[config[1].name] = config;
+    acc[config.props.name] = config;
     return acc;
   }, {});
 
-  const routeNames = routeConfigs.map((config) => config[1].name);
+  const routeNames = routeConfigs.map((config) => config.props.name);
+  const routeKeyList = routeNames.reduce<Record<string, React.Key | undefined>>(
+    (acc, curr) => {
+      acc[curr] = screens[curr].keys.map((key) => key ?? '').join(':');
+      return acc;
+    },
+    {}
+  );
   const routeParamList = routeNames.reduce<Record<string, object | undefined>>(
     (acc, curr) => {
-      const { initialParams } = screens[curr][1];
+      const { initialParams } = screens[curr].props;
       acc[curr] = initialParams;
       return acc;
     },
@@ -260,7 +297,7 @@ export default function useNavigationBuilder<
   >(
     (acc, curr) =>
       Object.assign(acc, {
-        [curr]: screens[curr][1].getId,
+        [curr]: screens[curr].props.getId,
       }),
     {}
   );
@@ -315,7 +352,7 @@ export default function useNavigationBuilder<
     const initialRouteParamList = routeNames.reduce<
       Record<string, object | undefined>
     >((acc, curr) => {
-      const { initialParams } = screens[curr][1];
+      const { initialParams } = screens[curr].props;
       const initialParamsFromParams =
         route?.params?.state == null &&
         route?.params?.initial !== false &&
@@ -371,6 +408,14 @@ export default function useNavigationBuilder<
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentState, router, isStateValid]);
 
+  const previousRouteKeyListRef = React.useRef(routeKeyList);
+
+  React.useEffect(() => {
+    previousRouteKeyListRef.current = routeKeyList;
+  });
+
+  const previousRouteKeyList = previousRouteKeyListRef.current;
+
   let state =
     // If the state isn't initialized, or stale, use the state we initialized instead
     // The state won't update until there's a change needed in the state we have initalized locally
@@ -381,12 +426,20 @@ export default function useNavigationBuilder<
 
   let nextState: State = state;
 
-  if (!isArrayEqual(state.routeNames, routeNames)) {
+  if (
+    !isArrayEqual(state.routeNames, routeNames) ||
+    !isRecordEqual(routeKeyList, previousRouteKeyList)
+  ) {
     // When the list of route names change, the router should handle it to remove invalid routes
     nextState = router.getStateForRouteNamesChange(state, {
       routeNames,
       routeParamList,
       routeGetIdList,
+      routeKeyChanges: Object.keys(routeKeyList).filter(
+        (name) =>
+          previousRouteKeyList.hasOwnProperty(name) &&
+          routeKeyList[name] !== previousRouteKeyList[name]
+      ),
     });
   }
 
@@ -522,7 +575,7 @@ export default function useNavigationBuilder<
         ...[
           screenListeners,
           ...routeNames.map((name) => {
-            const { listeners } = screens[name][1];
+            const { listeners } = screens[name].props;
             return listeners;
           }),
         ].map((listeners) => {

--- a/packages/routers/src/StackRouter.tsx
+++ b/packages/routers/src/StackRouter.tsx
@@ -175,9 +175,14 @@ export default function StackRouter(options: StackRouterOptions) {
       };
     },
 
-    getStateForRouteNamesChange(state, { routeNames, routeParamList }) {
-      const routes = state.routes.filter((route) =>
-        routeNames.includes(route.name)
+    getStateForRouteNamesChange(
+      state,
+      { routeNames, routeParamList, routeKeyChanges }
+    ) {
+      const routes = state.routes.filter(
+        (route) =>
+          routeNames.includes(route.name) &&
+          !routeKeyChanges.includes(route.name)
       );
 
       if (routes.length === 0) {

--- a/packages/routers/src/TabRouter.tsx
+++ b/packages/routers/src/TabRouter.tsx
@@ -237,10 +237,15 @@ export default function TabRouter({
       );
     },
 
-    getStateForRouteNamesChange(state, { routeNames, routeParamList }) {
+    getStateForRouteNamesChange(
+      state,
+      { routeNames, routeParamList, routeKeyChanges }
+    ) {
       const routes = routeNames.map(
         (name) =>
-          state.routes.find((r) => r.name === name) || {
+          state.routes.find(
+            (r) => r.name === name && !routeKeyChanges.includes(r.name)
+          ) || {
             name,
             key: `${name}-${nanoid()}`,
             params: routeParamList[name],

--- a/packages/routers/src/__tests__/StackRouter.test.tsx
+++ b/packages/routers/src/__tests__/StackRouter.test.tsx
@@ -173,6 +173,7 @@ it('gets state on route names change', () => {
           fiz: { fruit: 'apple' },
         },
         routeGetIdList: {},
+        routeKeyChanges: [],
       }
     )
   ).toEqual({
@@ -206,6 +207,7 @@ it('gets state on route names change', () => {
           baz: { name: 'John' },
         },
         routeGetIdList: {},
+        routeKeyChanges: [],
       }
     )
   ).toEqual({
@@ -240,6 +242,7 @@ it('gets state on route names change with initialRouteName', () => {
           baz: { name: 'John' },
         },
         routeGetIdList: {},
+        routeKeyChanges: [],
       }
     )
   ).toEqual({

--- a/packages/routers/src/__tests__/TabRouter.test.tsx
+++ b/packages/routers/src/__tests__/TabRouter.test.tsx
@@ -490,6 +490,7 @@ it('gets state on route names change', () => {
           fiz: { fruit: 'apple' },
         },
         routeGetIdList: {},
+        routeKeyChanges: [],
       }
     )
   ).toEqual({
@@ -525,6 +526,7 @@ it('gets state on route names change', () => {
         routeNames: ['foo', 'fiz'],
         routeParamList: {},
         routeGetIdList: {},
+        routeKeyChanges: [],
       }
     )
   ).toEqual({
@@ -566,6 +568,7 @@ it('preserves focused route on route names change', () => {
           fiz: { fruit: 'apple' },
         },
         routeGetIdList: {},
+        routeKeyChanges: [],
       }
     )
   ).toEqual({
@@ -609,6 +612,7 @@ it('falls back to first route if route is removed on route names change', () => 
           fiz: { fruit: 'apple' },
         },
         routeGetIdList: {},
+        routeKeyChanges: [],
       }
     )
   ).toEqual({

--- a/packages/routers/src/types.tsx
+++ b/packages/routers/src/types.tsx
@@ -182,7 +182,13 @@ export type Router<
    */
   getStateForRouteNamesChange(
     state: State,
-    options: RouterConfigOptions
+    options: RouterConfigOptions & {
+      /**
+       * List of routes whose key has changed even if they still have the same name.
+       * This allows to remove screens declaratively.
+       */
+      routeKeyChanges: string[];
+    }
   ): State;
 
   /**


### PR DESCRIPTION
Currently we recommend conditional rendering when implementing auth flow. However there are scenarios when this approach doesn't work and users need to manually reset their navigation state.

For example, consider the following:

```js
<Stack.Navigator>
  {isSignedIn ? (
    <Stack.Screen name="Home" component={Home} />
  ) : (
    <Stack.Screen name="SignIn" component={SignIn} />
  )}
  <Stack.Screen name="Chat" component={Chat} />
</Stack.Navigator>
```

Here, we're conditionally rendering a `SignIn` and `Home` screens. From both screens, user can navigate to the `Chat` screen. While the user is in `Chat` screen, it's possible that user may get logged out. In this case, we'd like the user to go back to the `SignIn` screen.



https://user-images.githubusercontent.com/1174278/136726236-ee2270cb-61e5-4715-8ca4-b7005ded437b.mp4


However, there's currently no way to do this other than manually calling `navigation.reset`. It adds extra imperative code and using `reset` requires more advanced knowledge of navigation state. And if we need to `reset` anyway, the conditional rendering provides no value and only complicates things.

This adds a way to declaratively control this behavior instead of an imperative method. If the user specifies a `navigationKey` prop on the screen that also changes, then we'd treat it as the old screen being gone. For example:

```js
<Stack.Navigator>
  {isSignedIn ? (
    <Stack.Screen name="Home" component={Home} />
  ) : (
    <Stack.Screen name="SignIn" component={SignIn} />
  )}
  <Stack.Screen navigationKey={String(isSignedIn)} name="Chat" component={Chat} />
</Stack.Navigator>
```

Here, when the `navigationKey` changes, the `Chat` screen will be removed. We can easily control the behavior by adding a single prop - no need to call `reset` manually.


https://user-images.githubusercontent.com/1174278/136725484-f3b61374-bc75-431e-aadc-762b95a2adc0.mp4

The `navigationKey` can be any `string`. It can also be used on `Group` if we need this behavior for several screens:

```js
<Stack.Group navigationKey={String(isSignedIn)}}>
  <Stack.Screen name="Chat" component={Chat} />
  <Stack.Screen name="Support" component={Support} />
</Stack.Group>
```

When `navigationKey` prop is used for a screen in a tab or drawer navigator, then the screen will remount if the navigationKey changes.

I also considered using the `key` prop instead of adding a new one, but `key` gets special treatment in React, so we can't read the original key. Using `key` might also break existing apps which use `key` incorrectly for screens (e.g. using `index`).
    
I chose the name `navigationKey` because I couldn't find an alternative. We already use `getId` for another purpose, so `id` cannot be used. Suggestions welcome for the prop name.