### PR TITLE
fix: fix type errors in generated declaration file of bottom-tabs (#10032)

### DIFF
--- a/packages/bottom-tabs/src/navigators/createBottomTabNavigator.tsx
+++ b/packages/bottom-tabs/src/navigators/createBottomTabNavigator.tsx
@@ -34,12 +34,15 @@ function BottomTabNavigator({
   screenListeners,
   screenOptions,
   sceneContainerStyle,
-  // @ts-expect-error: lazy is deprecated
-  lazy,
-  // @ts-expect-error: tabBarOptions is deprecated
-  tabBarOptions,
-  ...rest
+  ...restWithDeprecated
 }: Props) {
+  let {
+    // @ts-expect-error: lazy is deprecated
+    lazy,
+    // @ts-expect-error: tabBarOptions is deprecated
+    tabBarOptions,
+    ...rest
+  } = restWithDeprecated;
   let defaultScreenOptions: BottomTabNavigationOptions = {};
 
   if (tabBarOptions) {


### PR DESCRIPTION
Details can be found in the issue #10032 
Try to fix the type errors by moving `@ts-expect-error` comments into function body, so it won't affect generated declaration file.