### PR TITLE
fix(drawer): detach drawer open/close state from animation

### DIFF
--- a/packages/drawer/src/views/modern/Drawer.tsx
+++ b/packages/drawer/src/views/modern/Drawer.tsx
@@ -155,25 +155,21 @@ export default function Drawer({
 
       touchStartX.value = 0;
       touchX.value = 0;
-      translationX.value = withSpring(
-        translateX,
-        {
-          velocity,
-          stiffness: 1000,
-          damping: 500,
-          mass: 3,
-          overshootClamping: true,
-          restDisplacementThreshold: 0.01,
-          restSpeedThreshold: 0.01,
-        },
-        () => {
-          if (translationX.value === getDrawerTranslationX(true)) {
-            runOnJS(onOpen)();
-          } else if (translationX.value === getDrawerTranslationX(false)) {
-            runOnJS(onClose)();
-          }
-        }
-      );
+      translationX.value = withSpring(translateX, {
+        velocity,
+        stiffness: 1000,
+        damping: 500,
+        mass: 3,
+        overshootClamping: true,
+        restDisplacementThreshold: 0.01,
+        restSpeedThreshold: 0.01,
+      });
+
+      if (open) {
+        runOnJS(onOpen)();
+      } else {
+        runOnJS(onClose)();
+      }
     },
     [getDrawerTranslationX, onClose, onOpen, touchStartX, touchX, translationX]
   );


### PR DESCRIPTION
## Motivation

Attaching the state of the drawer to the spring animation caused a bug where the drawer was irresponsive for a few hundred milliseconds after it was open with a gesture. 

Matching the position of the drawer in the `withSpring` callback was faulty because the spring animation needs some time before it finally settles thus updating the `drawer status` with delay.

This PR decouples the value of spring animation in the drawer from the open/closed state of the drawer.

Tested both on Android and iOS.

Fixes #10504
Fixes #10410

## Before

https://user-images.githubusercontent.com/39658211/175023993-1ec8cc1b-d43b-4ab1-a725-1ec355a34e28.mov

## After

https://user-images.githubusercontent.com/39658211/175024019-d6b282e0-cecc-4916-9583-aa037e64e40d.mov

## Example code snippet to test this change:

<details>
<summary>Code</summary>

```jsx
import { createDrawerNavigator } from '@react-navigation/drawer';
import { NavigationContainer } from '@react-navigation/native';
import * as React from 'react';
import { Text, View } from 'react-native';

function Feed() {
  return (
    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
      <Text>
        Open drawer with gesture and swiftly click on one of the buttons
      </Text>
    </View>
  );
}

function Notifications() {
  return (
    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
      <Text>Other Screen</Text>
    </View>
  );
}

const Drawer = createDrawerNavigator();

function MyDrawer() {
  return (
    <Drawer.Navigator>
      <Drawer.Screen name="Feed" component={Feed} />
      <Drawer.Screen name="Notifications" component={Notifications} />
    </Drawer.Navigator>
  );
}

export default function App() {
  return (
    <NavigationContainer>
      <MyDrawer />
    </NavigationContainer>
  );
}
```
</details>
