### PR TITLE
fix: fixing set params and set options methods on BaseNavigationContainer

### DIFF
--- a/packages/core/src/BaseNavigationContainer.tsx
+++ b/packages/core/src/BaseNavigationContainer.tsx
@@ -209,12 +209,6 @@ export const BaseNavigationContainer = React.forwardRef(
         getCurrentRoute,
         getCurrentOptions,
         isReady,
-        setParams: () => {
-          throw new Error('Cannot call setParams outside a screen');
-        },
-        setOptions: () => {
-          throw new Error('Cannot call setOptions outside a screen');
-        },
       }),
       [
         canGoBack,


### PR DESCRIPTION
**Motivation**
The latest update [@react-navigation/core@6.4.11](https://github.com/react-navigation/react-navigation/releases/tag/%40react-navigation%2Fcore%406.4.11) broke react navigation and subsequently expo router

**Test plan**

- Create an app
- Create the router
- Try to setParams on a screen
- Try to setOptions on a screen

The change must pass lint, typescript and tests.
