### PR TITLE
fix(native-stack): incorrect text truncation in header title

### DIFF
--- a/packages/native-stack/src/views/HeaderConfig.tsx
+++ b/packages/native-stack/src/views/HeaderConfig.tsx
@@ -254,6 +254,9 @@ export function HeaderConfig({
       ) : (
         <>
           {headerLeftElement != null || typeof headerTitle === 'function' ? (
+            // The style passed to header left, together with title element being wrapped
+            // in flex view is reqruied for proper header layout, in particular,
+            // for the text truncation to work.
             <ScreenStackHeaderLeftView
               style={!isCenterViewRenderedAndroid ? { flex: 1 } : null}
             >


### PR DESCRIPTION
**Motivation**

Together with corresponding PR in `react-native-screens`:

* https://github.com/software-mansion/react-native-screens/pull/2325

this PR fixes https://github.com/software-mansion/react-native-screens/issues/1946 

tldr: text truncation in header title should work properly from now on. 

This PR changes the layout model of the native-header. Previously Yoga has been informed that the children are positioned absolutely and its only responsibility was to determine the view sizes. Right now, on Yoga layer (but not in native layer) the header is laid out with flexbox model.

**Test plan**

I've conducted the tests manually on `TestHeaderTitle` test screen in `FabricExample` application in `react-native-screens` repository.

Below is the spreadsheet from these tests.


![image](https://github.com/user-attachments/assets/4ca595b9-4e17-4126-91e8-39007a3fa20a)


Corresponding v6 PR:

* https://github.com/react-navigation/react-navigation/pull/12135

