### PR TITLE
fix: export useRoutePath to match docs - fixes #12776

### DIFF
--- a/packages/native/src/index.tsx
+++ b/packages/native/src/index.tsx
@@ -11,5 +11,6 @@ export { useLinkBuilder } from './useLinkBuilder';
 export { type LinkProps, useLinkProps } from './useLinkProps';
 export { useLinkTo } from './useLinkTo';
 export { useLocale } from './useLocale';
+export { useRoutePath } from './useRoutePath';
 export { useScrollToTop } from './useScrollToTop';
 export * from '@react-navigation/core';


### PR DESCRIPTION
**Motivation**

The documentation suggests that `useRoutePath` is a hook I can use, but it is not exported by `@react-navigation/native`.

https://reactnavigation.org/docs/use-route-path

**Test plan**

N/A - just exporting something to match what the docs say.