### PR TITLE
feat: move Badge to elements and expose it in public API

### DIFF
--- a/packages/bottom-tabs/src/views/TabBarIcon.tsx
+++ b/packages/bottom-tabs/src/views/TabBarIcon.tsx
@@ -1,4 +1,4 @@
-import { TabBarIconBadge } from '@react-navigation/elements';
+import { Badge } from '@react-navigation/elements';
 import type { Route } from '@react-navigation/native';
 import React from 'react';
 import {
@@ -98,14 +98,14 @@ export function TabBarIcon({
           color: inactiveTintColor,
         })}
       </View>
-      <TabBarIconBadge
+      <Badge
         visible={badge != null}
         size={iconSize * 0.75}
         allowFontScaling={allowFontScaling}
         style={[styles.badge, badgeStyle]}
       >
         {badge}
-      </TabBarIconBadge>
+      </Badge>
     </View>
   );
 }

--- a/packages/elements/src/Badge.tsx
+++ b/packages/elements/src/Badge.tsx
@@ -31,7 +31,7 @@ type Props = TextProps & {
 
 const useNativeDriver = Platform.OS !== 'web';
 
-export function TabBarIconBadge({
+export function Badge({
   children,
   style,
   visible = true,

--- a/packages/elements/src/index.tsx
+++ b/packages/elements/src/index.tsx
@@ -4,6 +4,7 @@ import clearIcon from './assets/clear-icon.png';
 import closeIcon from './assets/close-icon.png';
 import searchIcon from './assets/search-icon.png';
 
+export { Badge } from './Badge';
 export { Button } from './Button';
 export { Color } from './Color';
 export { Container, type Props as ContainerProps } from './Container';
@@ -25,7 +26,6 @@ export { MissingIcon } from './MissingIcon';
 export { PlatformPressable } from './PlatformPressable';
 export { SafeAreaProviderCompat } from './SafeAreaProviderCompat';
 export { Screen } from './Screen';
-export { TabBarIconBadge } from './TabBarIconBadge';
 export { Text } from './Text';
 export { useFrameSize } from './useFrameSize';
 


### PR DESCRIPTION
**Motivation**

Badge is currently not exposed via public API of the lib which makes it impossible to use it when building custom tab.

**Test plan**

Run example app and check that nothing is broken. This PR only moves the file and exposes component in elements package public API.

I renamed component from Badge to TabBarIconBadge so it's clear what it is for, but if it's not desired, let me know and I will fix it.