### PR TITLE
feat: export scrollEdgeEffects prop from react-native-screens

### DIFF
--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -21,6 +21,7 @@ import type {
 import type {
   ScreenProps,
   ScreenStackHeaderConfigProps,
+  ScrollEdgeEffect,
   SearchBarProps,
 } from 'react-native-screens';
 
@@ -629,6 +630,24 @@ export type NativeStackNavigationOptions = {
    * Only supported on iOS and Android.
    */
   freezeOnBlur?: boolean;
+  /**
+   * Configures the scroll edge effect for the _content ScrollView_ (the ScrollView that is present in first descendants chain of the Screen).
+   * Depending on values set, it will blur the scrolling content below certain UI elements (Header Items, SearchBar)
+   * for the specifed edge of the ScrollView.
+   *
+   * When set in nested containers, i.e. ScreenStack inside BottomTabs, or the other way around,
+   * the ScrollView will use only the innermost one's config.
+   *
+   * @platform ios
+   *
+   * @supported iOS 26 or higher
+   */
+  scrollEdgeEffects?: {
+    bottom?: ScrollEdgeEffect;
+    left?: ScrollEdgeEffect;
+    right?: ScrollEdgeEffect;
+    top?: ScrollEdgeEffect;
+  };
   /**
    * Footer component that can be used alongside formSheet stack presentation style.
    *

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -128,6 +128,7 @@ const SceneView = ({
     statusBarHidden,
     statusBarStyle,
     unstable_sheetFooter,
+    scrollEdgeEffects,
     freezeOnBlur,
     contentStyle,
   } = options;
@@ -321,6 +322,12 @@ const SceneView = ({
           nativeBackButtonDismissalEnabled={false} // on Android
           onHeaderBackButtonClicked={onHeaderBackButtonClicked}
           preventNativeDismiss={isRemovePrevented} // on iOS
+          scrollEdgeEffects={{
+            bottom: scrollEdgeEffects?.bottom ?? 'automatic',
+            top: scrollEdgeEffects?.top ?? 'automatic',
+            left: scrollEdgeEffects?.left ?? 'automatic',
+            right: scrollEdgeEffects?.right ?? 'automatic',
+          }}
           onNativeDismissCancelled={onNativeDismissCancelled}
           // Unfortunately, because of the bug that exists on Fabric, where native event drivers
           // for Animated objects are being created after the first notifications about the header height


### PR DESCRIPTION
This PR adds support for `scrollEdgeEffects` that were recently added to `react-native-screen`, and adds support for [UIScrollEdgeEffect](https://developer.apple.com/documentation/uikit/uiscrolledgeeffect) on content ScrollView, starting from iOS 26. The API present in screens merges the two that are exposed in UIKit (`style` enum and `hidden` bool) into one (simply making `hidden` one of style options).

Currently, only `top` and `bottom` options are testable, while `left` and `right` might appear in some special cases when configured natively (i.e. using [this](https://developer.apple.com/documentation/uikit/uiscrolledgeelementcontainerinteraction)).

**Motivation**

Feature parity with react-native-screens

**Test plan**

Used example app / NativeStack / NewsFeed. Appended the following options:
```ts
          headerTransparent: true,
          scrollEdgeEffects: { top: 'hard', bottom: 'hard' },
          headerSearchBarOptions: {}
```
where `hard` option behaves like frosted glass, `soft` and `automatic` blurs the content slightly, `hidden` renders the content without any effect.
<img width="398" height="181" alt="image" src="https://github.com/user-attachments/assets/75436d05-846f-4b0d-adb7-5356ffb41396" />

<img width="401" height="192" alt="image" src="https://github.com/user-attachments/assets/21d7ec0c-8749-44d3-871d-1ac65097aa96" />

<img width="402" height="192" alt="image" src="https://github.com/user-attachments/assets/dad385b2-c427-4331-aac1-23b48ea59f63" />

Related PR in react-native-screens: https://github.com/software-mansion/react-native-screens/pull/3212

The change must pass lint, typescript and tests.
