### PR TITLE
fix: prevent header from disappearing after modal navigation

### DIFF
--- a/packages/stack/src/views/Stack/CardStack.tsx
+++ b/packages/stack/src/views/Stack/CardStack.tsx
@@ -653,7 +653,9 @@ export class CardStack extends React.Component<Props, State> {
     }
 
     const floatingHeader = (
-      <React.Fragment key="header">
+      <React.Fragment
+        key={isFloatHeaderAbsolute ? 'header-absolute' : 'header-float'}
+      >
         {renderHeader({
           mode: 'float',
           scenes,


### PR DESCRIPTION
## Problem

Floating headers become invisible after navigating back from a modal screen that uses `ModalPresentationIOS` transition.


### Reproduction Steps

1. Navigate to Screen A (header visible ✓)
2. Navigate to Screen B (header visible ✓)
3. Navigate to Modal Screen C with `presentation: 'modal'`, `headerShown: false`, and `ModalPresentationIOS` transition preset
  (this is how we discovered the issue).
4. Navigate back to Screen B (header visible ✓)
5. Navigate back to Screen A (header **invisible** ✗)

### Root Cause

The `floatingHeader` element in `CardStack.tsx` is conditionally rendered in two different positions in the React tree based on the `isFloatHeaderAbsolute` flag:

```tsx
return (
  <View style={styles.container}>
    {isFloatHeaderAbsolute ? null : floatingHeader}  // Position A
    <MaybeScreenContainer>...</MaybeScreenContainer>
    {isFloatHeaderAbsolute ? floatingHeader : null}  // Position B
  </View>
);
```

Both positions use the same React key (`key="header"`). When `isFloatHeaderAbsolute` changes from `true` to `false` (or vice versa) during navigation, React attempts to reuse the component by moving it between positions in the tree. However, this causes the component to fail to properly commit to the native view hierarchy, resulting in invisible header elements.

## Solution

Use different React keys for different render positions to force React to properly unmount/remount the header when it moves between positions:

```tsx
const floatingHeader = (
  <React.Fragment key={isFloatHeaderAbsolute ? 'header-absolute' : 'header-float'}>
    {floatingHeaderContent}
  </React.Fragment>
);
```

## Testing

> Note: We are running v6.x in our project and that's were we found the bug and developed the fix.

Tested with the reproduction steps above - headers now remain visible throughout the navigation flow.

## Related Issues

Fixes #12456
