### PR TITLE
feat: accept name argument for useRoute

### DIFF
--- a/packages/core/src/__tests__/useRoute.test.tsx
+++ b/packages/core/src/__tests__/useRoute.test.tsx
@@ -3,7 +3,6 @@ import { render } from '@testing-library/react-native';
 
 import { BaseNavigationContainer } from '../BaseNavigationContainer';
 import { Screen } from '../Screen';
-import type { RouteProp } from '../types';
 import { useNavigationBuilder } from '../useNavigationBuilder';
 import { useRoute } from '../useRoute';
 import { MockRouter, MockRouterKey } from './__fixtures__/MockRouter';
@@ -13,6 +12,47 @@ beforeEach(() => {
 });
 
 test('gets route prop from context', () => {
+  expect.assertions(2);
+
+  const TestNavigator = (props: any): any => {
+    const { state, descriptors } = useNavigationBuilder(MockRouter, props);
+
+    return state.routes.map((route) => descriptors[route.key].render());
+  };
+
+  const Test = () => {
+    expect(useRoute().params).toEqual({ x: 1 });
+
+    expect(useRoute<{ foo: { x: number } }, 'foo'>('foo').params?.x).toBe(1);
+
+    return null;
+  };
+
+  render(
+    <BaseNavigationContainer>
+      <TestNavigator>
+        <Screen name="foo" component={Test} initialParams={{ x: 1 }} />
+      </TestNavigator>
+    </BaseNavigationContainer>
+  );
+});
+
+test('throws if not used in a screen', () => {
+  expect.assertions(1);
+
+  const Test = () => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    expect(() => useRoute<{ test: { x: number } }, 'test'>('test')).toThrow(
+      "Couldn't find a route object. Is your component inside a screen in a navigator?"
+    );
+
+    return null;
+  };
+
+  render(<Test />);
+});
+
+test("throws if provided route name doesn't match current route name", () => {
   expect.assertions(1);
 
   const TestNavigator = (props: any): any => {
@@ -22,9 +62,10 @@ test('gets route prop from context', () => {
   };
 
   const Test = () => {
-    const route = useRoute<RouteProp<{ sample: { x: string } }, 'sample'>>();
-
-    expect(route?.params?.x).toBe(1);
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    expect(() => useRoute<{ test: { x: number } }, 'test'>('test')).toThrow(
+      "The provided route name ('test') doesn't match the current route's name ('foo'). It must be used in the 'test' screen."
+    );
 
     return null;
   };

--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -1063,12 +1063,22 @@ export type PathConfigMap<ParamList extends {}> = {
 };
 
 export type ParamsForRoute<
-  ParamList extends ParamListBase,
+  ParamList extends {},
   Key extends string,
-> = {
-  [K in keyof ParamList]: K extends Key
-    ? ParamList[K]
-    : ParamList[K] extends NavigatorScreenParams<infer T>
-      ? ParamsForRoute<T, Key>
-      : never;
-}[keyof ParamList];
+> = FlattenIfLeafRoute<
+  {
+    [K in keyof ParamList]: K extends Key
+      ? ParamList[K]
+      : NotUndefined<ParamList[K]> extends NavigatorScreenParams<infer T>
+        ? ParamsForRoute<T, Key>
+        : never;
+  }[keyof ParamList]
+>;
+
+/**
+ * If the params type is a leaf route (i.e. not a navigator),
+ * flatten it to remove all type alias names, unions etc.
+ * This will show a plain object when hovering over the type.
+ */
+type FlattenIfLeafRoute<T> =
+  T extends NavigatorScreenParams<{}> ? T : { [K in keyof T]: T[K] } & {};

--- a/packages/core/src/useRoute.tsx
+++ b/packages/core/src/useRoute.tsx
@@ -1,15 +1,31 @@
-import type { ParamListBase } from '@react-navigation/routers';
+import type { ParamListBase, Route } from '@react-navigation/routers';
 import * as React from 'react';
 
 import { NavigationRouteContext } from './NavigationRouteContext';
-import type { RouteProp } from './types';
+import type { ParamListRoute, ParamsForRoute, RouteProp } from './types';
 
 /**
  * Hook to access the route prop of the parent screen anywhere.
  *
  * @returns Route prop of the parent screen.
  */
-export function useRoute<T extends RouteProp<ParamListBase>>(): T {
+export function useRoute<
+  RootParamList extends {} = ReactNavigation.RootParamList,
+  RouteName extends AllRouteNames<RootParamList> = AllRouteNames<RootParamList>,
+>(
+  name: RouteName
+): Route<
+  RouteName,
+  RootParamList extends ParamListBase
+    ? ParamsForRoute<RootParamList, RouteName>
+    : undefined
+>;
+export function useRoute<
+  RootParamList extends {} = ReactNavigation.RootParamList,
+>(): RootParamList extends ParamListBase
+  ? ParamListRoute<RootParamList>
+  : RouteProp<ParamListBase>;
+export function useRoute(name?: string) {
   const route = React.useContext(NavigationRouteContext);
 
   if (route === undefined) {
@@ -18,5 +34,19 @@ export function useRoute<T extends RouteProp<ParamListBase>>(): T {
     );
   }
 
-  return route as T;
+  if (name !== undefined && route.name !== name) {
+    throw new Error(
+      `The provided route name ('${name}') doesn't match the current route's name ('${route.name}'). It must be used in the '${name}' screen.`
+    );
+  }
+
+  return route;
 }
+
+/**
+ * Get all possible route names from a param list and its nested navigators.
+ */
+type AllRouteNames<RootParamList extends {}> =
+  RootParamList extends ParamListBase
+    ? ParamListRoute<RootParamList>['name']
+    : string;

--- a/packages/routers/src/types.tsx
+++ b/packages/routers/src/types.tsx
@@ -65,38 +65,39 @@ export type PartialState<State extends NavigationState> = Partial<
 export type Route<
   RouteName extends string,
   Params extends object | undefined = object | undefined,
-> = Readonly<{
-  /**
-   * Unique key for the route.
-   */
-  key: string;
-  /**
-   * User-provided name for the route.
-   */
-  name: RouteName;
-  /**
-   * Path associated with the route.
-   * Usually present when the screen was opened from a deep link.
-   */
-  path?: string;
-  /**
-   * History of param changes for this route.
-   */
-  history?: { type: 'params'; params: object }[];
-}> &
-  (undefined extends Params
-    ? Readonly<{
+> = Readonly<
+  {
+    /**
+     * Unique key for the route.
+     */
+    key: string;
+    /**
+     * User-provided name for the route.
+     */
+    name: RouteName;
+    /**
+     * Path associated with the route.
+     * Usually present when the screen was opened from a deep link.
+     */
+    path?: string;
+    /**
+     * History of param changes for this route.
+     */
+    history?: { type: 'params'; params: object }[];
+  } & (undefined extends Params
+    ? {
         /**
          * Params for this route
          */
         params?: Readonly<Params>;
-      }>
-    : Readonly<{
+      }
+    : {
         /**
          * Params for this route
          */
         params: Readonly<Params>;
-      }>);
+      })
+>;
 
 export type ParamListBase = Record<string, object | undefined>;
 


### PR DESCRIPTION
**Motivation**

This updates `useRoute` to use a type-safe API.

- The `useRoute` hook now accepts an argument - the name of the route
- The argument to `useRoute` provides auto-completion based on all routes in the project (using `ReactNavigation.RootParamList`)
- The returned type of `useRoute` is based on the route name argument
- When no argument is passed, `useRoute` returns a union of all routes in the project

BREAKING CHANGE: `useRoute` no longer accepts a generic to override the returned type since it's not type-safe. User can do `const route = useRoute() as SomeType` to make it explicit.

https://github.com/user-attachments/assets/512ab42e-af24-452e-8ef1-99276a3ba17c

NOTE: This doesn't check parent routes. It's being worked on in https://github.com/react-navigation/react-navigation/pull/12790

**Test plan**

- Added unit tests and type tests
