### PR TITLE
feat: accept name argument for useNavigation

### DIFF
--- a/example/__typechecks__/common.check.tsx
+++ b/example/__typechecks__/common.check.tsx
@@ -7,31 +7,40 @@ import type {
 } from '@react-navigation/bottom-tabs';
 import type {
   DrawerNavigationOptions,
+  DrawerNavigationProp,
   DrawerScreenProps,
 } from '@react-navigation/drawer';
 import { Button } from '@react-navigation/elements';
 import {
+  type CompositeNavigationProp,
   type CompositeScreenProps,
+  type GenericNavigation,
   Link,
   type NavigationAction,
   type NavigationContainerRef,
   type NavigationHelpers,
+  type NavigationProp,
   type NavigatorScreenParams,
+  type ParamListBase,
   type RootParamList,
   type Route,
   type RouteForName,
   type RouteProp,
   type Theme,
   useLinkProps,
+  useNavigation,
   useRoute,
 } from '@react-navigation/native';
 import {
   createStackNavigator,
   type StackNavigationOptions,
+  type StackNavigationProp,
   type StackOptionsArgs,
   type StackScreenProps,
 } from '@react-navigation/stack';
 import { expectTypeOf } from 'expect-type';
+
+import type { StaticScreenParams } from '../src/Screens/Static';
 
 /**
  * Check for the type of the `navigation` and `route` objects with regular usage
@@ -820,3 +829,118 @@ useRoute<RootStackParamList, 'Invalid'>('Invalid');
 
 // @ts-expect-error
 useRoute('Invalid');
+
+/**
+ * Check for useNavigation return type based on the arguments
+ */
+{
+  const navigation = useNavigation();
+
+  expectTypeOf(navigation).toEqualTypeOf<GenericNavigation<RootParamList>>();
+
+  expectTypeOf(navigation.getParent()).toEqualTypeOf<
+    NavigationProp<ParamListBase> | undefined
+  >();
+}
+
+{
+  const navigation = useNavigation<typeof Stack>();
+
+  expectTypeOf(navigation).toEqualTypeOf<
+    {
+      [K in keyof RootStackParamList]: StackNavigationProp<
+        RootStackParamList,
+        K
+      >;
+    }[keyof RootStackParamList]
+  >();
+
+  expectTypeOf(navigation.getParent()).toEqualTypeOf<
+    NavigationProp<ParamListBase> | undefined
+  >();
+
+  expectTypeOf(navigation.getState().type).toEqualTypeOf<'stack'>();
+
+  expectTypeOf(navigation.getState().routeNames).toEqualTypeOf<
+    (keyof RootStackParamList)[]
+  >();
+
+  expectTypeOf(navigation.setOptions)
+    .parameter(0)
+    .toEqualTypeOf<Partial<StackNavigationOptions>>();
+}
+
+{
+  const navigation = useNavigation('NotFound');
+
+  expectTypeOf(navigation).toEqualTypeOf<
+    StackNavigationProp<RootParamList, 'NotFound'>
+  >();
+
+  expectTypeOf(navigation.getParent)
+    .parameter(0)
+    .toEqualTypeOf<'NotFound' | undefined>();
+
+  expectTypeOf(navigation.getState().type).toEqualTypeOf<'stack'>();
+
+  expectTypeOf(navigation.getState().routeNames).toEqualTypeOf<
+    (keyof RootParamList)[]
+  >();
+
+  expectTypeOf(navigation.setOptions)
+    .parameter(0)
+    .toEqualTypeOf<Partial<StackNavigationOptions>>();
+}
+
+{
+  const navigation = useNavigation('Examples');
+
+  expectTypeOf(navigation).toEqualTypeOf<
+    CompositeNavigationProp<
+      DrawerNavigationProp<{ Examples: undefined }, 'Examples'>,
+      StackNavigationProp<RootParamList, 'Home'>
+    >
+  >();
+
+  expectTypeOf(navigation.getParent)
+    .parameter(0)
+    .toEqualTypeOf<'Examples' | 'Home' | undefined>();
+
+  expectTypeOf(navigation.getParent('Home')).toEqualTypeOf<
+    StackNavigationProp<RootParamList, 'Home'>
+  >();
+
+  expectTypeOf(navigation.getState().type).toEqualTypeOf<'drawer'>();
+
+  expectTypeOf(navigation.getState().routeNames).toEqualTypeOf<'Examples'[]>();
+
+  expectTypeOf(navigation.setOptions)
+    .parameter(0)
+    .toEqualTypeOf<Partial<DrawerNavigationOptions>>();
+}
+
+{
+  const navigation = useNavigation('Home');
+
+  expectTypeOf(navigation).toEqualTypeOf<
+    StackNavigationProp<RootParamList, 'Home'> &
+      CompositeNavigationProp<
+        StackNavigationProp<StaticScreenParams, 'Home'>,
+        StackNavigationProp<RootParamList, 'StaticScreen'>
+      >
+  >();
+
+  expectTypeOf(navigation.getParent)
+    .parameter(0)
+    .toEqualTypeOf<'Home' | 'StaticScreen' | undefined>();
+
+  expectTypeOf(navigation.getState().type).toEqualTypeOf<'stack'>();
+
+  expectTypeOf(navigation.getState().routeNames).toEqualTypeOf<
+    (keyof RootParamList)[]
+  >();
+
+  expectTypeOf(navigation.setOptions)
+    .parameter(0)
+    .toEqualTypeOf<Partial<StackNavigationOptions>>();
+}

--- a/example/__typechecks__/static.check.tsx
+++ b/example/__typechecks__/static.check.tsx
@@ -8,8 +8,7 @@ import {
   type CompositeNavigationProp,
   createStaticNavigation,
   type NavigationContainerRef,
-  type NavigationForName,
-  type NavigationListForNavigator,
+  type NavigationListForNested,
   type NavigationProp,
   type NavigatorScreenParams,
   type StaticParamList,
@@ -220,19 +219,19 @@ expectTypeOf<RootParamList>().toEqualTypeOf<{
 /**
  * Infer navigation props from navigator
  */
-expectTypeOf<NavigationForName<typeof RootStack, 'Home'>>().toEqualTypeOf<
+expectTypeOf<NavigationListForNested<typeof RootStack>['Home']>().toEqualTypeOf<
   StackNavigationProp<RootParamList, 'Home'>
 >();
 
-expectTypeOf<NavigationForName<typeof RootStack, 'Feed'>>().toEqualTypeOf<
+expectTypeOf<NavigationListForNested<typeof RootStack>['Feed']>().toEqualTypeOf<
   StackNavigationProp<RootParamList, 'Feed'>
 >();
 
-expectTypeOf<NavigationForName<typeof RootStack, 'Settings'>>().toEqualTypeOf<
-  StackNavigationProp<RootParamList, 'Settings'>
->();
+expectTypeOf<
+  NavigationListForNested<typeof RootStack>['Settings']
+>().toEqualTypeOf<StackNavigationProp<RootParamList, 'Settings'>>();
 
-expectTypeOf<NavigationForName<typeof RootStack, 'Chat'>>().toEqualTypeOf<
+expectTypeOf<NavigationListForNested<typeof RootStack>['Chat']>().toEqualTypeOf<
   CompositeNavigationProp<
     BottomTabNavigationProp<StaticParamList<typeof HomeTabs>, 'Chat'>,
     StackNavigationProp<RootParamList, 'Home'>
@@ -241,12 +240,12 @@ expectTypeOf<NavigationForName<typeof RootStack, 'Chat'>>().toEqualTypeOf<
 
 expectTypeOf<
   // @ts-expect-error
-  NavigationForName<typeof RootStack, 'Invalid'>
+  NavigationListForNested<typeof RootStack>['Invalid']
 >().toEqualTypeOf<unknown>();
 
-expectTypeOf<
-  keyof NavigationListForNavigator<typeof RootStack>
->().toEqualTypeOf<RooStackRouteName | 'Groups' | 'Chat'>();
+expectTypeOf<keyof NavigationListForNested<typeof RootStack>>().toEqualTypeOf<
+  RooStackRouteName | 'Groups' | 'Chat'
+>();
 
 /**
  * Infer screen names from config

--- a/example/src/Screens/BottomTabs.tsx
+++ b/example/src/Screens/BottomTabs.tsx
@@ -62,8 +62,7 @@ const linking: PathConfigMap<BottomTabParams> = {
 };
 
 const AlbumsScreen = () => {
-  const navigation =
-    useNavigation<BottomTabScreenProps<BottomTabParams>['navigation']>();
+  const navigation = useNavigation<typeof Tab>();
   const headerHeight = useHeaderHeight();
   const tabBarHeight = useBottomTabBarHeight();
   const isFocused = useIsFocused();

--- a/example/src/Screens/FullHistoryTabs.tsx
+++ b/example/src/Screens/FullHistoryTabs.tsx
@@ -1,10 +1,6 @@
-import {
-  type BottomTabNavigationProp,
-  createBottomTabNavigator,
-} from '@react-navigation/bottom-tabs';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { Button, Text } from '@react-navigation/elements';
 import {
-  type StaticParamList,
   type StaticScreenProps,
   useNavigation,
   useRoute,
@@ -18,7 +14,7 @@ function TestScreen({
   route: { params },
 }: StaticScreenProps<{ count: number } | undefined>) {
   const route = useRoute();
-  const navigation = useNavigation<BottomTabNavigationProp<TabsParamList>>();
+  const navigation = useNavigation<typeof Tabs>();
 
   return (
     <View style={styles.container}>
@@ -56,8 +52,6 @@ function CounterLayout({ children }: { children: React.ReactNode }) {
 
   return <>{children}</>;
 }
-
-type TabsParamList = StaticParamList<typeof Tabs>;
 
 const Tabs = createBottomTabNavigator({
   backBehavior: 'fullHistory',

--- a/example/src/Screens/NativeBottomTabs.native.tsx
+++ b/example/src/Screens/NativeBottomTabs.native.tsx
@@ -1,8 +1,5 @@
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
-import {
-  createNativeBottomTabNavigator,
-  type NativeBottomTabScreenProps,
-} from '@react-navigation/bottom-tabs/unstable';
+import { createNativeBottomTabNavigator } from '@react-navigation/bottom-tabs/unstable';
 import {
   Button,
   getHeaderTitle,
@@ -49,10 +46,7 @@ const linking: PathConfigMap<NativeBottomTabParams> = {
 };
 
 const AlbumsScreen = () => {
-  const navigation =
-    useNavigation<
-      NativeBottomTabScreenProps<NativeBottomTabParams>['navigation']
-    >();
+  const navigation = useNavigation<typeof Tab>();
   const headerHeight = useHeaderHeight();
   const insets = useSafeAreaInsets();
   const isFocused = useIsFocused();

--- a/example/src/Screens/Static.tsx
+++ b/example/src/Screens/Static.tsx
@@ -1,6 +1,7 @@
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { Button, HeaderBackButton } from '@react-navigation/elements';
+import type { StaticParamList } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 import * as React from 'react';
 import {
@@ -14,6 +15,8 @@ import {
 import { Albums } from '../Shared/Albums';
 import { Chat } from '../Shared/Chat';
 import { Contacts } from '../Shared/Contacts';
+
+export type StaticScreenParams = StaticParamList<typeof StaticStack>;
 
 const getTabBarIcon =
   (name: React.ComponentProps<typeof MaterialCommunityIcons>['name']) =>

--- a/packages/core/src/NavigationProvider.tsx
+++ b/packages/core/src/NavigationProvider.tsx
@@ -17,6 +17,10 @@ export const NavigationContext = React.createContext<
   NavigationProp<ParamListBase> | undefined
 >(undefined);
 
+export const NavigationRouteNameContext = React.createContext<
+  string | undefined
+>(undefined);
+
 type Props = {
   route: Route<string>;
   navigation: NavigationProp<ParamListBase>;
@@ -28,10 +32,12 @@ type Props = {
  */
 export const NavigationProvider = ({ route, navigation, children }: Props) => {
   return (
-    <NavigationRouteContext.Provider value={route}>
-      <NavigationContext.Provider value={navigation}>
-        {children}
-      </NavigationContext.Provider>
-    </NavigationRouteContext.Provider>
+    <NavigationContext.Provider value={navigation}>
+      <NavigationRouteContext.Provider value={route}>
+        <NavigationRouteNameContext.Provider value={route.name}>
+          {children}
+        </NavigationRouteNameContext.Provider>
+      </NavigationRouteContext.Provider>
+    </NavigationContext.Provider>
   );
 };

--- a/packages/core/src/__tests__/useNavigation.test.tsx
+++ b/packages/core/src/__tests__/useNavigation.test.tsx
@@ -1,7 +1,10 @@
 import { beforeEach, expect, test } from '@jest/globals';
+import { StackRouter } from '@react-navigation/routers';
 import { render } from '@testing-library/react-native';
+import { act, useEffect } from 'react';
 
 import { BaseNavigationContainer } from '../BaseNavigationContainer';
+import { createNavigationContainerRef } from '../createNavigationContainerRef';
 import { Screen } from '../Screen';
 import { useNavigation } from '../useNavigation';
 import { useNavigationBuilder } from '../useNavigationBuilder';
@@ -12,7 +15,7 @@ beforeEach(() => {
 });
 
 test('gets navigation prop from context', () => {
-  expect.assertions(1);
+  expect.assertions(2);
 
   const TestNavigator = (props: any): any => {
     const { state, descriptors } = useNavigationBuilder(MockRouter, props);
@@ -23,7 +26,11 @@ test('gets navigation prop from context', () => {
   const Test = () => {
     const navigation = useNavigation();
 
-    expect(navigation.navigate).toBeDefined();
+    expect(navigation.getState()?.routeNames).toEqual(['foo']);
+
+    useEffect(() => {
+      expect(() => navigation.setOptions({})).not.toThrow();
+    }, [navigation]);
 
     return null;
   };
@@ -38,7 +45,7 @@ test('gets navigation prop from context', () => {
 });
 
 test("gets navigation's parent from context", () => {
-  expect.assertions(1);
+  expect.assertions(6);
 
   const TestNavigator = (props: any): any => {
     const { state, descriptors } = useNavigationBuilder(MockRouter, props);
@@ -49,41 +56,23 @@ test("gets navigation's parent from context", () => {
   const Test = () => {
     const navigation = useNavigation();
 
-    expect(navigation.getParent()).toBeDefined();
+    expect(navigation.getState()?.routeNames).toEqual(['quo']);
 
-    return null;
-  };
+    expect(navigation.getParent()?.getState()?.routeNames).toEqual(['bar']);
 
-  render(
-    <BaseNavigationContainer>
-      <TestNavigator>
-        <Screen name="foo">
-          {() => (
-            <TestNavigator>
-              <Screen name="bar" component={Test} />
-            </TestNavigator>
-          )}
-        </Screen>
-      </TestNavigator>
-    </BaseNavigationContainer>
-  );
-});
+    expect(navigation.getParent()?.getParent()?.getState()?.routeNames).toEqual(
+      ['foo']
+    );
 
-test("gets navigation's parent's parent from context", () => {
-  expect.assertions(2);
+    useEffect(() => {
+      expect(() => navigation.setOptions({})).not.toThrow();
 
-  const TestNavigator = (props: any): any => {
-    const { state, descriptors } = useNavigationBuilder(MockRouter, props);
+      expect(() => navigation.getParent()?.setOptions({})).not.toThrow();
 
-    return state.routes.map((route) => descriptors[route.key].render());
-  };
-
-  const Test = () => {
-    const navigation = useNavigation();
-    const parent = navigation.getParent();
-
-    expect(parent).toBeDefined();
-    expect(parent?.navigate).toBeDefined();
+      expect(() =>
+        navigation.getParent()?.getParent()?.setOptions({})
+      ).not.toThrow();
+    }, [navigation]);
 
     return null;
   };
@@ -110,7 +99,7 @@ test("gets navigation's parent's parent from context", () => {
 });
 
 test('gets navigation from container from context', () => {
-  expect.assertions(1);
+  expect.assertions(3);
 
   const TestNavigator = (props: any): any => {
     const { state, descriptors } = useNavigationBuilder(MockRouter, props);
@@ -122,6 +111,13 @@ test('gets navigation from container from context', () => {
     const navigation = useNavigation();
 
     expect(navigation.navigate).toBeDefined();
+    expect(navigation.getState()).toBeUndefined();
+
+    useEffect(() => {
+      expect(() => navigation.setOptions({})).toThrow(
+        'Cannot call setOptions outside a screen'
+      );
+    }, [navigation]);
 
     return null;
   };
@@ -134,6 +130,144 @@ test('gets navigation from container from context', () => {
       </TestNavigator>
     </BaseNavigationContainer>
   );
+});
+
+test('gets navigation by route name', () => {
+  expect.assertions(8);
+
+  const TestNavigator = (props: any): any => {
+    const { state, descriptors } = useNavigationBuilder(MockRouter, props);
+
+    return state.routes.map((route) => descriptors[route.key].render());
+  };
+
+  const Test = () => {
+    // @ts-expect-error - types not configured for test
+    const navigationA: any = useNavigation('baz');
+
+    expect(navigationA.getState()?.routeNames).toEqual(['baz', 'qux']);
+
+    // @ts-expect-error - types not configured for test
+    const navigationB: any = useNavigation('bar');
+
+    expect(navigationB.getState()?.routeNames).toEqual(['bar']);
+
+    // @ts-expect-error - types not configured for test
+    const navigationC: any = useNavigation('foo');
+
+    expect(navigationC.getState()?.routeNames).toEqual(['foo']);
+
+    expect(() =>
+      // @ts-expect-error - types not configured for test
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      useNavigation('qux')
+    ).toThrow(
+      "Couldn't find a navigation object for 'qux' in current or any parent screens. Is your component inside the correct screen?"
+    );
+
+    expect(() =>
+      // @ts-expect-error - types not configured for test
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      useNavigation('non-existent')
+    ).toThrow(
+      "Couldn't find a navigation object for 'non-existent' in current or any parent screens. Is your component inside the correct screen?"
+    );
+
+    useEffect(() => {
+      expect(() => navigationA.setOptions({})).not.toThrow();
+      expect(() => navigationB.setOptions({})).not.toThrow();
+      expect(() => navigationC.setOptions({})).not.toThrow();
+    }, [navigationA, navigationB, navigationC]);
+
+    return null;
+  };
+
+  render(
+    <BaseNavigationContainer>
+      <TestNavigator>
+        <Screen name="foo">
+          {() => (
+            <TestNavigator>
+              <Screen name="bar">
+                {() => (
+                  <TestNavigator>
+                    <Screen name="baz" component={Test} />
+                    <Screen name="qux">{() => null}</Screen>
+                  </TestNavigator>
+                )}
+              </Screen>
+            </TestNavigator>
+          )}
+        </Screen>
+      </TestNavigator>
+    </BaseNavigationContainer>
+  );
+});
+
+test('gets navigation in preloaded screen', () => {
+  expect.assertions(4);
+
+  const TestNavigator = (props: any): any => {
+    const { state, descriptors, describe } = useNavigationBuilder(
+      StackRouter,
+      props
+    );
+
+    return (
+      <>
+        {state.routes.map((route) => descriptors[route.key].render())}
+        {state.preloadedRoutes?.map((route) => describe(route, true).render())}
+      </>
+    );
+  };
+
+  const Test = () => {
+    const navigationA: any = useNavigation();
+
+    expect(navigationA.getState()?.routeNames).toEqual(['bar', 'baz']);
+
+    // @ts-expect-error - types not configured for test
+    const navigationB: any = useNavigation('baz');
+
+    expect(navigationB.getState()?.routeNames).toEqual(['bar', 'baz']);
+
+    // @ts-expect-error - types not configured for test
+    const navigationC: any = useNavigation('foo');
+
+    expect(navigationC.getState()?.routeNames).toEqual(['foo']);
+
+    expect(() =>
+      // @ts-expect-error - types not configured for test
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      useNavigation('qux')
+    ).toThrow(
+      "Couldn't find a navigation object for 'qux' in current or any parent screens. Is your component inside the correct screen?"
+    );
+
+    return null;
+  };
+
+  const ref = createNavigationContainerRef();
+
+  render(
+    <BaseNavigationContainer ref={ref}>
+      <TestNavigator>
+        <Screen name="foo">
+          {() => (
+            <TestNavigator>
+              <Screen name="bar">{() => null}</Screen>
+              <Screen name="baz" component={Test} />
+            </TestNavigator>
+          )}
+        </Screen>
+      </TestNavigator>
+    </BaseNavigationContainer>
+  );
+
+  act(() => {
+    // @ts-expect-error - types not configured for test
+    ref.preload('baz');
+  });
 });
 
 test('throws if called outside a navigation context', () => {

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -33,7 +33,7 @@ export { useTheme } from './theming/useTheme';
 export * from './types';
 export { useFocusEffect } from './useFocusEffect';
 export { useIsFocused } from './useIsFocused';
-export { useNavigation } from './useNavigation';
+export { type GenericNavigation, useNavigation } from './useNavigation';
 export { useNavigationBuilder } from './useNavigationBuilder';
 export { useNavigationContainerRef } from './useNavigationContainerRef';
 export { useNavigationIndependentTree } from './useNavigationIndependentTree';

--- a/packages/core/src/useNavigation.tsx
+++ b/packages/core/src/useNavigation.tsx
@@ -1,29 +1,136 @@
-import { type NavigationState } from '@react-navigation/routers';
+import type { NavigationState } from '@react-navigation/routers';
 import * as React from 'react';
 
 import { NavigationContainerRefContext } from './NavigationContainerRefContext';
-import { NavigationContext } from './NavigationProvider';
-import type { NavigationProp, RootParamList } from './types';
+import {
+  NavigationContext,
+  NavigationRouteNameContext,
+} from './NavigationProvider';
+import type {
+  NavigationListForNavigator,
+  NavigationListForNested,
+  NavigationProp,
+  RootNavigator,
+  RootParamList,
+} from './types';
+
+/**
+ * Use a stripped down NavigationProp if no screen is specified.
+ *
+ * The hook can be used in `NavigationContainer` directly, not inside of a navigator.
+ * So navigator specific methods won't be available.
+ */
+export type GenericNavigation<ParamList extends {}> = Omit<
+  NavigationProp<ParamList>,
+  'getState' | 'setParams' | 'replaceParams' | 'pushParams' | 'setOptions'
+> & {
+  /**
+   * Returns the navigator's state.
+   *
+   * This may return `undefined` if used outside of a navigator,
+   * as the navigator may not have rendered yet
+   */
+  getState(): NavigationState | undefined;
+
+  /**
+   * Update the param object for the route.
+   * The new params will be shallow merged with the old one.
+   *
+   * @param params Partial params object for the current route.
+   */
+  setParams(
+    // We don't know which route to set params for
+    params: unknown
+  ): void;
+
+  /**
+   * Replace the param object for the route
+   *
+   * @param params Params object for the current route.
+   */
+  replaceParams(
+    // We don't know which route to replace params for
+    params: unknown
+  ): void;
+
+  /**
+   * Push new params for the route.
+   * The params are not merged with previous params.
+   * This adds an entry to navigation history.
+   *
+   * @param params Params object for the current route.
+   */
+  pushParams(
+    // We don't know which route to push params for
+    params: unknown
+  ): void;
+
+  /**
+   * Update the options for the route.
+   * The options object will be shallow merged with default options object.
+   *
+   * @param options Partial options object for the current screen.
+   */
+  setOptions(
+    // We don't know which navigator to set options for
+    options: unknown
+  ): void;
+};
 
 /**
  * Hook to access the navigation prop of the parent screen anywhere.
  *
+ * If the route name of the current or one of the parents is specified,
+ * the navigation prop for that route is returned.
+ *
  * @returns Navigation prop of the parent screen.
  */
+export function useNavigation(): GenericNavigation<RootParamList>;
 export function useNavigation<
-  T = Omit<NavigationProp<RootParamList>, 'getState'> & {
-    getState(): NavigationState | undefined;
-  },
->(): T {
-  const root = React.useContext(NavigationContainerRefContext);
-  const navigation = React.useContext(NavigationContext);
+  const Navigator = RootNavigator,
+>(): NavigationListForNavigator<Navigator>[keyof NavigationListForNavigator<Navigator>];
+export function useNavigation<
+  const Navigator = RootNavigator,
+  const RouteName extends
+    keyof NavigationListForNested<Navigator> = keyof NavigationListForNested<Navigator>,
+>(name: RouteName): NavigationListForNested<Navigator>[RouteName];
+export function useNavigation(name?: string): unknown {
+  const root = React.use(NavigationContainerRefContext);
+  const navigation = React.use(NavigationContext);
 
-  if (navigation === undefined && root === undefined) {
+  if (name === undefined) {
+    if (navigation === undefined && root === undefined) {
+      throw new Error(
+        "Couldn't find a navigation object. Is your component inside NavigationContainer?"
+      );
+    }
+
+    return navigation ?? root;
+  }
+
+  const routeName = React.use(NavigationRouteNameContext);
+
+  // Generally, this condition isn't needed as `getParent(name)` works for current screen
+  // However, it'll throw if the hook is used in a preloaded screen
+  if (routeName === name) {
+    if (navigation === undefined) {
+      throw new Error(
+        `Couldn't find a navigation object for '${name}'. This is not expected.`
+      );
+    }
+
+    return navigation;
+  }
+
+  // We get parent first so that `getParent(name)` is not called in preloaded screens
+  // It's ok since `getParent` also works for current screen, so parent is not skipped
+  const parent = navigation?.getParent()?.getParent(name);
+
+  if (parent === undefined) {
     throw new Error(
-      "Couldn't find a navigation object. Is your component inside NavigationContainer?"
+      `Couldn't find a navigation object for '${name}' in current or any parent screens. Is your component inside the correct screen?`
     );
   }
 
-  // FIXME: Figure out a better way to do this
-  return (navigation ?? root) as unknown as T;
+  return parent;
 }


### PR DESCRIPTION
**Motivation**

This updates `useNavigation` to return more useful types.

- The `useNavigation` hook now accepts an argument - the name of the route
- The argument to `useNavigation` provides auto-completion based on all routes in the project (using `RootParamList`)
- The returned type of `useNavigation` is the navigation object for the provided route
- When no argument is passed, `useNavigation` returns the navigation object for screens in the root navigator

BREAKING CHANGE: `useNavigation` no longer accepts a generic to override the returned type since it's not type-safe. User can do `const navigation = useNavigation() as SomeType` to make it explicit.

https://github.com/user-attachments/assets/bc3397bd-67b3-4341-b514-58fdaf33772a



**Test plan**

- [x] Add unit tests
- [x] Add type tests