### PR TITLE
feat(bottom-tabs): use component instead of function

### DIFF
--- a/packages/bottom-tabs/src/views/BottomTabView.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabView.tsx
@@ -68,13 +68,11 @@ const hasAnimation = (options: BottomTabNavigationOptions) => {
   return Boolean(transitionSpec);
 };
 
-const renderTabBarDefault = (props: BottomTabBarProps) => (
-  <BottomTabBar {...props} />
-);
+const TabBarDefault = (props: BottomTabBarProps) => <BottomTabBar {...props} />;
 
 export function BottomTabView(props: Props) {
   const {
-    tabBar = renderTabBarDefault,
+    tabBar: TabBar = TabBarDefault,
     state,
     navigation,
     descriptors,
@@ -204,19 +202,19 @@ export function BottomTabView(props: Props) {
   const renderTabBar = () => {
     return (
       <SafeAreaInsetsContext.Consumer>
-        {(insets) =>
-          tabBar({
-            state: state,
-            descriptors: descriptors,
-            navigation: navigation,
-            insets: {
+        {(insets) => (
+          <TabBar
+            state={state}
+            descriptors={descriptors}
+            navigation={navigation}
+            insets={{
               top: safeAreaInsets?.top ?? insets?.top ?? 0,
               right: safeAreaInsets?.right ?? insets?.right ?? 0,
               bottom: safeAreaInsets?.bottom ?? insets?.bottom ?? 0,
               left: safeAreaInsets?.left ?? insets?.left ?? 0,
-            },
-          })
-        }
+            }}
+          ></TabBar>
+        )}
       </SafeAreaInsetsContext.Consumer>
     );
   };


### PR DESCRIPTION
**Motivation**

This solves a potential issue when using the `tabbar` prop on the [bottom tabs navigator dynamically](https://reactnavigation.org/docs/bottom-tab-navigator/?config=dynamic#tabbar), while also using the [React Compiler](https://react.dev/learn/react-compiler).

When creating an inline component directly on the prop, the code works, but it breaks the [react/no-unstable-nested-components](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-unstable-nested-components.md) rule. When moving the component outside, the rule passes, but the code breaks.

This PR should solve this issue; we've patched the package internally and are running it in production.

**Test plan**

First, [install the Babel plugin](https://react.dev/learn/react-compiler/installation#babel).

With the current implementation, this code will break with the compiler on:

```tsx
function CustomTabBar(props) {
  return <MyTabBar {...props} />
}

function MyTabs() {
  return (
    <Tab.Navigator
      tabBar={CustomTabBar}
    >
      {/* ... */}
    </Tab.Navigator>
  );
}
```

[Here's a reproduction repo](https://github.com/tcK1/navigation-compiler-repro).
