### PR TITLE
feat: accept route name in useNavigationState

### DIFF
--- a/example/__typechecks__/common.check.tsx
+++ b/example/__typechecks__/common.check.tsx
@@ -14,21 +14,25 @@ import { Button } from '@react-navigation/elements';
 import {
   type CompositeNavigationProp,
   type CompositeScreenProps,
+  type DrawerNavigationState,
   type GenericNavigation,
   Link,
   type NavigationAction,
   type NavigationContainerRef,
   type NavigationHelpers,
   type NavigationProp,
+  type NavigationRoute,
   type NavigatorScreenParams,
   type ParamListBase,
   type RootParamList,
   type Route,
   type RouteForName,
   type RouteProp,
+  type StackNavigationState,
   type Theme,
   useLinkProps,
   useNavigation,
+  useNavigationState,
   useRoute,
 } from '@react-navigation/native';
 import {
@@ -943,4 +947,70 @@ useRoute('Invalid');
   expectTypeOf(navigation.setOptions)
     .parameter(0)
     .toEqualTypeOf<Partial<StackNavigationOptions>>();
+}
+
+/**
+ * Check for useNavigationState return type based on the arguments
+ */
+{
+  const state = useNavigationState((state) => state);
+
+  expectTypeOf(state.routeNames).toEqualTypeOf<string[]>();
+
+  /* Selecting specific properties */
+  const index = useNavigationState((state) => state.index);
+
+  expectTypeOf(index).toEqualTypeOf<number>();
+
+  const routes = useNavigationState((state) => state.routes);
+
+  expectTypeOf(routes).toEqualTypeOf<NavigationRoute<ParamListBase, string>[]>(
+    routes
+  );
+}
+
+{
+  const state = useNavigationState<
+    StackNavigationState<RootStackParamList>,
+    typeof Stack,
+    'PostDetails'
+  >('PostDetails', (state) => state);
+
+  expectTypeOf(state.type).toEqualTypeOf<'stack'>();
+
+  expectTypeOf(state.routeNames).toEqualTypeOf<(keyof RootStackParamList)[]>();
+
+  /* Invalid drawer state specified for stack */
+  useNavigationState<
+    DrawerNavigationState<RootStackParamList>,
+    typeof Stack,
+    'PostDetails'
+    // @ts-expect-error
+  >('PostDetails', (state) => state);
+}
+
+{
+  const type = useNavigationState('Examples', (state) => state.type);
+
+  expectTypeOf(type).toEqualTypeOf<'drawer'>();
+
+  const routeNames = useNavigationState(
+    'Examples',
+    (state) => state.routeNames
+  );
+
+  expectTypeOf(routeNames).toEqualTypeOf<'Examples'[]>();
+}
+
+{
+  const index = useNavigationState('NotFound', (state) => state.index);
+
+  expectTypeOf(index).toEqualTypeOf<number>();
+
+  const routeNames = useNavigationState(
+    'NotFound',
+    (state) => state.routeNames
+  );
+
+  expectTypeOf(routeNames).toEqualTypeOf<(keyof RootParamList)[]>();
 }

--- a/packages/core/src/__tests__/useNavigationState.test.tsx
+++ b/packages/core/src/__tests__/useNavigationState.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, expect, jest, test } from '@jest/globals';
+import { beforeEach, expect, test } from '@jest/globals';
 import type { NavigationState } from '@react-navigation/routers';
 import { act, render } from '@testing-library/react-native';
 import * as React from 'react';
@@ -27,19 +27,23 @@ test('gets the current navigation state', () => {
     );
   };
 
-  const callback = jest.fn<(state: NavigationState) => void>();
-
   const Test = () => {
-    const state = useNavigationState((state) => state);
+    const index = useNavigationState((state) => state.index);
+    const params = useNavigationState(
+      (state) => state.routes[state.index].params
+    );
 
-    callback(state);
-
-    return null;
+    return (
+      <>
+        {index}
+        {JSON.stringify(params)}
+      </>
+    );
   };
 
   const navigation = React.createRef<any>();
 
-  const element = (
+  const element = render(
     <BaseNavigationContainer ref={navigation}>
       <TestNavigator>
         <Screen name="first" component={Test} />
@@ -49,26 +53,24 @@ test('gets the current navigation state', () => {
     </BaseNavigationContainer>
   );
 
-  render(element);
-
-  expect(callback).toHaveBeenCalledTimes(1);
-  expect(callback.mock.calls[0][0].index).toBe(0);
+  expect(element).toMatchInlineSnapshot(`"0"`);
 
   act(() => navigation.current.navigate('second'));
 
-  expect(callback).toHaveBeenCalledTimes(2);
-  expect(callback.mock.calls[1][0].index).toBe(1);
+  expect(element).toMatchInlineSnapshot(`"1"`);
 
   act(() => navigation.current.navigate('third'));
 
-  expect(callback).toHaveBeenCalledTimes(3);
-  expect(callback.mock.calls[2][0].index).toBe(2);
+  expect(element).toMatchInlineSnapshot(`"2"`);
 
   act(() => navigation.current.navigate('second', { answer: 42 }));
 
-  expect(callback).toHaveBeenCalledTimes(4);
-  expect(callback.mock.calls[3][0].index).toBe(1);
-  expect(callback.mock.calls[3][0].routes[1].params).toEqual({ answer: 42 });
+  expect(element).toMatchInlineSnapshot(`
+[
+  "1",
+  "{"answer":42}",
+]
+`);
 });
 
 test('gets the current navigation state with selector', () => {
@@ -85,19 +87,15 @@ test('gets the current navigation state with selector', () => {
     );
   };
 
-  const callback = jest.fn();
-
   const Test = () => {
     const index = useNavigationState((state) => state.index);
 
-    callback(index);
-
-    return null;
+    return <>{index}</>;
   };
 
   const navigation = React.createRef<any>();
 
-  const element = (
+  const root = render(
     <BaseNavigationContainer ref={navigation}>
       <TestNavigator>
         <Screen name="first" component={Test} />
@@ -107,25 +105,19 @@ test('gets the current navigation state with selector', () => {
     </BaseNavigationContainer>
   );
 
-  render(element);
-
-  expect(callback).toHaveBeenCalledTimes(1);
-  expect(callback.mock.calls[0][0]).toBe(0);
+  expect(root).toMatchInlineSnapshot(`"0"`);
 
   act(() => navigation.current.navigate('second'));
 
-  expect(callback).toHaveBeenCalledTimes(2);
-  expect(callback.mock.calls[1][0]).toBe(1);
+  expect(root).toMatchInlineSnapshot(`"1"`);
 
   act(() => navigation.current.navigate('third'));
 
-  expect(callback).toHaveBeenCalledTimes(3);
-  expect(callback.mock.calls[1][0]).toBe(1);
+  expect(root).toMatchInlineSnapshot(`"2"`);
 
   act(() => navigation.current.navigate('second'));
 
-  expect(callback).toHaveBeenCalledTimes(4);
-  expect(callback.mock.calls[3][0]).toBe(1);
+  expect(root).toMatchInlineSnapshot(`"1"`);
 });
 
 test('gets the correct value if selector changes', () => {
@@ -142,25 +134,19 @@ test('gets the correct value if selector changes', () => {
     );
   };
 
-  const callback = jest.fn();
-
   const SelectorContext = React.createContext<any>(null);
 
   const Test = () => {
     const selector = React.useContext(SelectorContext);
     const result = useNavigationState(selector);
 
-    callback(result);
-
-    return null;
+    return <>{result}</>;
   };
-
-  const navigation = React.createRef<any>();
 
   const App = ({ selector }: { selector: (state: NavigationState) => any }) => {
     return (
       <SelectorContext.Provider value={selector}>
-        <BaseNavigationContainer ref={navigation}>
+        <BaseNavigationContainer>
           <TestNavigator>
             <Screen name="first" component={Test} />
             <Screen name="second">{() => null}</Screen>
@@ -173,13 +159,11 @@ test('gets the correct value if selector changes', () => {
 
   const root = render(<App selector={(state) => state.index} />);
 
-  expect(callback).toHaveBeenCalledTimes(1);
-  expect(callback.mock.calls[0][0]).toBe(0);
+  expect(root).toMatchInlineSnapshot(`"0"`);
 
   root.update(<App selector={(state) => state.routes[state.index].name} />);
 
-  expect(callback).toHaveBeenCalledTimes(2);
-  expect(callback.mock.calls[1][0]).toBe('first');
+  expect(root).toMatchInlineSnapshot(`"first"`);
 });
 
 test('gets the current navigation state at navigator level', () => {
@@ -299,5 +283,261 @@ test('gets the current navigation state at navigator level', () => {
     }
   ]
 }"
+`);
+});
+
+test('gets navigation state for current route name', () => {
+  const TestNavigator = (props: any): any => {
+    const { state, descriptors, NavigationContent } = useNavigationBuilder(
+      MockRouter,
+      props
+    );
+
+    return (
+      <NavigationContent>
+        {state.routes.map((route) => descriptors[route.key].render())}
+      </NavigationContent>
+    );
+  };
+
+  const Test = () => {
+    // @ts-expect-error for test purposes
+    const index = useNavigationState('child', (state) => state.index);
+    const routeName = useNavigationState(
+      // @ts-expect-error for test purposes
+      'child',
+      (state: any) => state.routes[state.index].name
+    );
+    const params = useNavigationState(
+      // @ts-expect-error for test purposes
+      'child',
+      (state: any) => state.routes[state.index].params
+    );
+
+    return (
+      <>
+        {index}
+        {routeName}
+        {JSON.stringify(params)}
+      </>
+    );
+  };
+
+  const navigation = React.createRef<any>();
+
+  const root = render(
+    <BaseNavigationContainer ref={navigation}>
+      <TestNavigator>
+        <Screen name="parent">
+          {() => (
+            <TestNavigator>
+              <Screen name="child" component={Test} />
+              <Screen name="second">{() => null}</Screen>
+              <Screen name="third">{() => null}</Screen>
+            </TestNavigator>
+          )}
+        </Screen>
+      </TestNavigator>
+    </BaseNavigationContainer>
+  );
+
+  expect(root).toMatchInlineSnapshot(`
+[
+  "0",
+  "child",
+]
+`);
+
+  act(() => navigation.current.navigate('child', { answer: 42 }));
+
+  expect(root).toMatchInlineSnapshot(`
+[
+  "0",
+  "child",
+  "{"answer":42}",
+]
+`);
+
+  act(() => navigation.current.navigate('second'));
+
+  expect(root).toMatchInlineSnapshot(`
+[
+  "1",
+  "second",
+]
+`);
+});
+
+test('gets navigation state for parent route name', () => {
+  const TestNavigator = (props: any): any => {
+    const { state, descriptors, NavigationContent } = useNavigationBuilder(
+      MockRouter,
+      props
+    );
+
+    return (
+      <NavigationContent>
+        {state.routes.map((route) => descriptors[route.key].render())}
+      </NavigationContent>
+    );
+  };
+
+  const Test = () => {
+    // @ts-expect-error for test purposes
+    const index = useNavigationState('parent', (state) => state.index);
+    const routeName = useNavigationState(
+      // @ts-expect-error for test purposes
+      'parent',
+      (state: any) => state.routes[state.index].name
+    );
+    const params = useNavigationState(
+      // @ts-expect-error for test purposes
+      'child',
+      (state: any) => state.routes[state.index].params
+    );
+
+    return (
+      <>
+        {index}
+        {routeName}
+        {JSON.stringify(params)}
+      </>
+    );
+  };
+
+  const navigation = React.createRef<any>();
+
+  const root = render(
+    <BaseNavigationContainer ref={navigation}>
+      <TestNavigator>
+        <Screen name="parent">
+          {() => (
+            <TestNavigator>
+              <Screen name="child" component={Test} />
+              <Screen name="second">{() => null}</Screen>
+              <Screen name="third">{() => null}</Screen>
+            </TestNavigator>
+          )}
+        </Screen>
+        <Screen name="other">{() => null}</Screen>
+      </TestNavigator>
+    </BaseNavigationContainer>
+  );
+
+  expect(root).toMatchInlineSnapshot(`
+[
+  "0",
+  "parent",
+]
+`);
+
+  act(() => navigation.current.navigate('parent', { answer: 42 }));
+
+  expect(root).toMatchInlineSnapshot(`
+[
+  "0",
+  "parent",
+]
+`);
+
+  act(() => navigation.current.navigate('other'));
+
+  expect(root).toMatchInlineSnapshot(`
+[
+  "1",
+  "other",
+]
+`);
+});
+
+test('gets navigation state for grandparent route name', () => {
+  const TestNavigator = (props: any): any => {
+    const { state, descriptors, NavigationContent } = useNavigationBuilder(
+      MockRouter,
+      props
+    );
+
+    return (
+      <NavigationContent>
+        {state.routes.map((route) => descriptors[route.key].render())}
+      </NavigationContent>
+    );
+  };
+
+  const Test = () => {
+    const index = useNavigationState(
+      // @ts-expect-error for test purposes
+      'grandparent',
+      (state: any) => state.index
+    );
+    const routeName = useNavigationState(
+      // @ts-expect-error for test purposes
+      'grandparent',
+      (state: any) => state.routes[state.index].name
+    );
+    const params = useNavigationState(
+      // @ts-expect-error for test purposes
+      'grandparent',
+      (state: any) => state.routes[state.index].params
+    );
+
+    return (
+      <>
+        {index}
+        {routeName}
+        {JSON.stringify(params)}
+      </>
+    );
+  };
+
+  const navigation = React.createRef<any>();
+
+  const root = render(
+    <BaseNavigationContainer ref={navigation}>
+      <TestNavigator>
+        <Screen name="grandparent">
+          {() => (
+            <TestNavigator>
+              <Screen name="parent">
+                {() => (
+                  <TestNavigator>
+                    <Screen name="child" component={Test} />
+                    <Screen name="second">{() => null}</Screen>
+                  </TestNavigator>
+                )}
+              </Screen>
+              <Screen name="third">{() => null}</Screen>
+            </TestNavigator>
+          )}
+        </Screen>
+        <Screen name="fourth">{() => null}</Screen>
+      </TestNavigator>
+    </BaseNavigationContainer>
+  );
+
+  expect(root).toMatchInlineSnapshot(`
+[
+  "0",
+  "grandparent",
+]
+`);
+
+  act(() => navigation.current.navigate('grandparent', { answer: 42 }));
+
+  expect(root).toMatchInlineSnapshot(`
+[
+  "0",
+  "grandparent",
+  "{"answer":42}",
+]
+`);
+
+  act(() => navigation.current.navigate('fourth'));
+
+  expect(root).toMatchInlineSnapshot(`
+[
+  "1",
+  "fourth",
+]
 `);
 });

--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -10,7 +10,7 @@ import type {
 } from '@react-navigation/routers';
 import type * as React from 'react';
 
-import type { FlatType, UnionToIntersection } from './utilities';
+import type { UnionToIntersection } from './utilities';
 
 /**
  * Root navigator used in the app.
@@ -844,13 +844,12 @@ type MaybeParamListRoute<ParamList extends {}> = ParamList extends ParamListBase
   ? ParamListRoute<ParamList>
   : Route<string>;
 
-export type NavigationListForNavigator<Navigator> = FlatType<
+export type NavigationListForNavigator<Navigator> =
   Navigator extends TypedNavigator<infer Bag, any>
     ? Bag['NavigationList']
     : Navigator extends PrivateValueStore<[any, infer NavigationList, any]>
       ? NavigationList
-      : {}
->;
+      : {};
 
 export type NavigationListForNested<Navigator> =
   NavigationListForNavigator<Navigator> &

--- a/packages/core/src/useNavigationState.tsx
+++ b/packages/core/src/useNavigationState.tsx
@@ -3,31 +3,106 @@ import * as React from 'react';
 import useLatestCallback from 'use-latest-callback';
 import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/with-selector';
 
-type Selector<ParamList extends ParamListBase, T> = (
-  state: NavigationState<ParamList>
-) => T;
+import type {
+  NavigationListForNested,
+  NavigationProp,
+  RootNavigator,
+} from './types';
+import { useNavigation } from './useNavigation';
+
+type NavigationStateListener = {
+  getState: () => NavigationState<ParamListBase>;
+  subscribe: (callback: () => void) => () => void;
+};
+
+type NavigationStateForNested<
+  Navigator,
+  RouteName extends keyof NavigationListForNested<Navigator>,
+> = NavigationListForNested<Navigator>[RouteName] extends {
+  getState: () => infer State;
+}
+  ? State
+  : never;
 
 /**
  * Hook to get a value from the current navigation state using a selector.
  *
- * @param selector Selector function to get a value from the state.
+ * If the route name of the current or one of the parents is specified,
+ * the navigation state of the navigator for that route is used.
+ *
+ * A selector function must be provided to select the desired value from the navigation state.
  */
-export function useNavigationState<ParamList extends ParamListBase, T>(
-  selector: Selector<ParamList, T>
-): T {
-  const stateListener = React.useContext(NavigationStateListenerContext);
+export function useNavigationState<
+  const T,
+  const Navigator = RootNavigator,
+  const RouteName extends
+    keyof NavigationListForNested<Navigator> = keyof NavigationListForNested<Navigator>,
+>(
+  routeName: RouteName,
+  selector: (state: NavigationStateForNested<Navigator, RouteName>) => T
+): T;
+export function useNavigationState<T>(
+  selector: (state: NavigationState<ParamListBase>) => T
+): T;
+export function useNavigationState(...args: unknown[]): unknown {
+  let navigation: NavigationProp<ParamListBase> | undefined,
+    stateListener: NavigationStateListener | undefined,
+    selector;
 
-  if (stateListener == null) {
+  if (typeof args[0] === 'string') {
+    // `useNavigation` uses `use` internally, so it's fine to call it conditionally
+    // @ts-expect-error we can't specify the type here
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    navigation = useNavigation(args[0]);
+    selector = args[1];
+  } else {
+    selector = args[0];
+  }
+
+  if (navigation == null) {
+    stateListener = React.use(NavigationStateListenerContext);
+
+    if (stateListener == null) {
+      throw new Error(
+        "Couldn't get the navigation state. Is your component inside a navigator?"
+      );
+    }
+  }
+
+  const subscribe = React.useCallback(
+    (callback: () => void) => {
+      if (navigation) {
+        return navigation.addListener('state', callback);
+      } else if (stateListener) {
+        return stateListener.subscribe(callback);
+      } else {
+        throw new Error(
+          "Couldn't subscribe to navigation state changes. This is not expected."
+        );
+      }
+    },
+    [navigation, stateListener]
+  );
+
+  const getSnapshot = navigation
+    ? navigation.getState
+    : stateListener?.getState;
+
+  if (getSnapshot == null) {
+    throw new Error("Couldn't get the navigation state. This is not expected.");
+  }
+
+  if (typeof selector !== 'function') {
     throw new Error(
-      "Couldn't get the navigation state. Is your component inside a navigator?"
+      `A selector function must be provided (got ${typeof selector}).`
     );
   }
 
   const value = useSyncExternalStoreWithSelector(
-    stateListener.subscribe,
-    // @ts-expect-error: this is unsafe, but needed to make the generic work
-    stateListener.getState,
-    stateListener.getState,
+    subscribe,
+    getSnapshot,
+    getSnapshot,
+    // @ts-expect-error we can't infer the type here
     selector
   );
 
@@ -73,9 +148,5 @@ export function NavigationStateListenerProvider({
 }
 
 const NavigationStateListenerContext = React.createContext<
-  | {
-      getState: () => NavigationState<ParamListBase>;
-      subscribe: (callback: () => void) => () => void;
-    }
-  | undefined
+  NavigationStateListener | undefined
 >(undefined);


### PR DESCRIPTION
**Motivation**

This updates `useNavigationState` to accept route name, similar to `useNavigation` and `useRoute`.

This makes sure that the returned state has the proper type for the navigator where the route is. 

```js
const focusedRoute = useNavigationState('SomeParentRoute', (state) => state.routes[state.index])
```


https://github.com/user-attachments/assets/75961073-2323-42d9-bd41-3c1f9aa10b9b



**Test plan**

Added unit tests and type tests.
