### PR TITLE
refactor:  rename headerLargeTitle to headerLargeTitleEnabled

### DIFF
--- a/example/src/Screens/NativeStack.tsx
+++ b/example/src/Screens/NativeStack.tsx
@@ -316,7 +316,7 @@ export function NativeStack(
 
           return {
             title: `Article by ${route.params?.author ?? 'Unknown'}`,
-            headerLargeTitle: true,
+            headerLargeTitleEnabled: true,
             headerLargeTitleShadowVisible: false,
             headerRight: ({ tintColor }) => (
               <HeaderButton

--- a/packages/bottom-tabs/src/unstable/NativeScreen/types.ts
+++ b/packages/bottom-tabs/src/unstable/NativeScreen/types.ts
@@ -20,7 +20,7 @@ export type NativeHeaderOptions = {
   title?: string;
   /**
    * Style of the header when a large title is shown
-   * The large title is shown if `headerLargeTitle` is `true` and
+   * The large title is shown if `headerLargeTitleEnabled` is `true` and
    * the edge of any scrollable content reaches the matching edge of the header.
    *
    * Supported properties:

--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -196,7 +196,7 @@ export type NativeStackNavigationOptions = {
   headerBackImageSource?: ImageSourcePropType;
   /**
    * Style of the header when a large title is shown.
-   * The large title is shown if `headerLargeTitle` is `true` and
+   * The large title is shown if `headerLargeTitleEnabled` is `true` and
    * the edge of any scrollable content reaches the matching edge of the header.
    *
    * Supported properties:
@@ -220,7 +220,7 @@ export type NativeStackNavigationOptions = {
    *
    * @platform ios
    */
-  headerLargeTitle?: boolean;
+  headerLargeTitleEnabled?: boolean;
   /**
    * Whether drop shadow of header is visible when a large title is shown.
    *

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -342,7 +342,8 @@ const SceneView = ({
                 // As it's the only case where the header height can change frequently
                 const doesHeaderAnimate =
                   Platform.OS === 'ios' &&
-                  (options.headerLargeTitle || options.headerSearchBarOptions);
+                  (options.headerLargeTitleEnabled ||
+                    options.headerSearchBarOptions);
 
                 if (doesHeaderAnimate) {
                   setHeaderHeightDebounced(headerHeight);

--- a/packages/native-stack/src/views/useHeaderConfigProps.tsx
+++ b/packages/native-stack/src/views/useHeaderConfigProps.tsx
@@ -161,7 +161,7 @@ export function useHeaderConfigProps({
   headerBackVisible,
   headerShadowVisible,
   headerLargeStyle,
-  headerLargeTitle,
+  headerLargeTitleEnabled,
   headerLargeTitleShadowVisible,
   headerLargeTitleStyle,
   headerBackground,
@@ -294,7 +294,7 @@ export function useHeaderConfigProps({
     headerBackground != null ||
     headerTransparent ||
     // When using a SearchBar or large title, the header needs to be translucent for it to work on iOS
-    ((hasHeaderSearchBar || headerLargeTitle) &&
+    ((hasHeaderSearchBar || headerLargeTitleEnabled) &&
       Platform.OS === 'ios' &&
       headerTransparent !== false);
 
@@ -453,7 +453,7 @@ export function useHeaderConfigProps({
       headerShadowVisible === false ||
       headerBackground != null ||
       (headerTransparent && headerShadowVisible !== true),
-    largeTitle: headerLargeTitle,
+    largeTitle: headerLargeTitleEnabled,
     largeTitleBackgroundColor,
     largeTitleColor,
     largeTitleFontFamily,


### PR DESCRIPTION
BREAKING CHANGE: Users would need to change usage of `headerLargeTitle: true` to `headerLargeTitleEnabled: true`

Rename headerLargeTitle to headerLargeTitleEnabled to allow title string in future

Resolves https://github.com/orgs/react-navigation/projects/1/views/1?filterQuery=+assignee%3Aosdnk&pane=issue&itemId=136549479