### PR TITLE
chore(native-stack): update docs for `scrollEdgeEffects`, `headerBlurEffect`

### DIFF
--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -746,7 +746,7 @@ export type NativeStackNavigationOptions = {
    * Depending on values set, it will blur the scrolling content below certain UI elements (header items, search bar)
    * for the specified edge of the ScrollView.
    *
-   * When set in nested containers, i.e. ScreenStack inside BottomTabs, or the other way around,
+   * When set in nested containers, i.e. Native Stack inside Native Bottom Tabs, or the other way around,
    * the ScrollView will use only the innermost one's config.
    *
    * **Note:** Using both `headerBlurEffect` and `scrollEdgeEffects` (>= iOS 26) simultaneously may cause overlapping effects.


### PR DESCRIPTION
**Motivation**

Aligns in-code docs with recent changes in [`react-native-screens`](https://github.com/software-mansion/react-native-screens/pull/3407)' docs:

- add possible values for `scrollEdgeEffects`,
- add information about `headerBlurEffect` and `scrollEdgeEffects` interaction.
