### PR TITLE
feat: add staticXScreen type to improve defining screens

### DIFF
--- a/example/__typechecks__/static.check.tsx
+++ b/example/__typechecks__/static.check.tsx
@@ -18,6 +18,7 @@ import {
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import {
   createStackNavigator,
+  createStackScreen,
   type StackNavigationProp,
 } from '@react-navigation/stack';
 import { expectTypeOf } from 'expect-type';
@@ -580,3 +581,164 @@ switch (route.name) {
     >();
     break;
 }
+
+/**
+ * Infer types from typed screen component
+ */
+createStackNavigator({
+  screens: {
+    Profile: createStackScreen({
+      screen: (
+        _: StaticScreenProps<{ userId: string; filter?: 'recent' | 'popular' }>
+      ) => null,
+      options: ({ route, navigation }) => {
+        expectTypeOf(route.name).toEqualTypeOf<string>();
+        expectTypeOf(route.params).toEqualTypeOf<{
+          userId: string;
+          filter?: 'recent' | 'popular';
+        }>();
+
+        expectTypeOf(navigation.getState().type).toEqualTypeOf<'stack'>();
+
+        return {
+          headerTitle: route.params.userId,
+        };
+      },
+      listeners: ({ route, navigation }) => {
+        expectTypeOf(route.params).toEqualTypeOf<{
+          userId: string;
+          filter?: 'recent' | 'popular';
+        }>();
+
+        expectTypeOf(navigation.getState().type).toEqualTypeOf<'stack'>();
+
+        return {};
+      },
+      layout: ({ route, navigation, children }) => {
+        expectTypeOf(route.params).toEqualTypeOf<{
+          userId: string;
+          filter?: 'recent' | 'popular';
+        }>();
+
+        expectTypeOf(navigation.getState().type).toEqualTypeOf<'stack'>();
+
+        return <>{children}</>;
+      },
+      getId: ({ params }) => {
+        expectTypeOf(params).toEqualTypeOf<{
+          userId: string;
+          filter?: 'recent' | 'popular';
+        }>();
+
+        return params.userId;
+      },
+      initialParams: {
+        filter: 'recent',
+        // @ts-expect-error
+        userId: 3,
+      },
+    }),
+  },
+});
+
+/**
+ * Handle screen component without optional params
+ */
+createStackNavigator({
+  screens: {
+    Details: createStackScreen({
+      screen: (
+        _: StaticScreenProps<{ itemId: number; info: string } | undefined>
+      ) => null,
+      options: ({ route, navigation }) => {
+        expectTypeOf(route.name).toEqualTypeOf<string>();
+        expectTypeOf(route.params).toEqualTypeOf<
+          | {
+              itemId: number;
+              info: string;
+            }
+          | undefined
+        >();
+        expectTypeOf(navigation.getState().type).toEqualTypeOf<'stack'>();
+
+        return {};
+      },
+      listeners: ({ route, navigation }) => {
+        expectTypeOf(route.params).toEqualTypeOf<
+          | {
+              itemId: number;
+              info: string;
+            }
+          | undefined
+        >();
+        expectTypeOf(navigation.getState().type).toEqualTypeOf<'stack'>();
+
+        return {};
+      },
+      layout: ({ route, navigation, children }) => {
+        expectTypeOf(route.params).toEqualTypeOf<
+          | {
+              itemId: number;
+              info: string;
+            }
+          | undefined
+        >();
+        expectTypeOf(navigation.getState().type).toEqualTypeOf<'stack'>();
+
+        return <>{children}</>;
+      },
+      getId: ({ params }) => {
+        expectTypeOf(params).toEqualTypeOf<
+          | {
+              itemId: number;
+              info: string;
+            }
+          | undefined
+        >();
+
+        return params?.itemId.toString();
+      },
+      initialParams: {
+        itemId: 1,
+        info: 'Item 1',
+      },
+    }),
+  },
+});
+
+/**
+ * Handle screen component without typed route prop
+ */
+createStackNavigator({
+  screens: {
+    Settings: createStackScreen({
+      screen: () => null,
+      options: ({ route, navigation }) => {
+        expectTypeOf(route.name).toEqualTypeOf<string>();
+        expectTypeOf(route.params).toEqualTypeOf<undefined>();
+        expectTypeOf(navigation.getState().type).toEqualTypeOf<'stack'>();
+
+        return {};
+      },
+      listeners: ({ route, navigation }) => {
+        expectTypeOf(route.params).toEqualTypeOf<undefined>();
+        expectTypeOf(navigation.getState().type).toEqualTypeOf<'stack'>();
+
+        return {};
+      },
+      layout: ({ route, navigation, children }) => {
+        expectTypeOf(route.params).toEqualTypeOf<undefined>();
+        expectTypeOf(navigation.getState().type).toEqualTypeOf<'stack'>();
+
+        return <>{children}</>;
+      },
+      getId: ({ params }) => {
+        expectTypeOf(params).toEqualTypeOf<undefined>();
+
+        return 'static-id';
+      },
+      // @ts-expect-error
+      initialParams: {},
+    }),
+  },
+});

--- a/packages/bottom-tabs/src/index.tsx
+++ b/packages/bottom-tabs/src/index.tsx
@@ -10,7 +10,10 @@ export { SceneStyleInterpolators, TransitionPresets, TransitionSpecs };
 /**
  * Navigators
  */
-export { createBottomTabNavigator } from './navigators/createBottomTabNavigator';
+export {
+  createBottomTabNavigator,
+  createBottomTabScreen,
+} from './navigators/createBottomTabNavigator';
 
 /**
  * Views

--- a/packages/bottom-tabs/src/navigators/createBottomTabNavigator.tsx
+++ b/packages/bottom-tabs/src/navigators/createBottomTabNavigator.tsx
@@ -4,6 +4,7 @@ import {
   StackActions,
   type StaticConfig,
   type StaticParamList,
+  type StaticScreenConfig,
   type TabActionHelpers,
   type TabNavigationState,
   TabRouter,
@@ -117,4 +118,18 @@ export function createBottomTabNavigator<
 >;
 export function createBottomTabNavigator(config?: unknown) {
   return createNavigatorFactory(BottomTabNavigator)(config);
+}
+
+export function createBottomTabScreen<
+  const Screen extends React.ComponentType<any>,
+>(
+  config: StaticScreenConfig<
+    Screen,
+    TabNavigationState<ParamListBase>,
+    BottomTabNavigationOptions,
+    BottomTabNavigationEventMap,
+    BottomTabNavigationProp<ParamListBase>
+  >
+) {
+  return config;
 }

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -21,10 +21,9 @@ export {
   createComponentForStaticNavigation,
   createPathConfigForStaticNavigation,
   type StaticConfig,
-  type StaticConfigGroup,
-  type StaticConfigScreens,
   type StaticNavigation,
   type StaticParamList,
+  type StaticScreenConfig,
   type StaticScreenProps,
 } from './StaticNavigation';
 export { ThemeContext } from './theming/ThemeContext';

--- a/packages/drawer/src/index.tsx
+++ b/packages/drawer/src/index.tsx
@@ -1,7 +1,10 @@
 /**
  * Navigators
  */
-export { createDrawerNavigator } from './navigators/createDrawerNavigator';
+export {
+  createDrawerNavigator,
+  createDrawerScreen,
+} from './navigators/createDrawerNavigator';
 
 /**
  * Views

--- a/packages/drawer/src/navigators/createDrawerNavigator.tsx
+++ b/packages/drawer/src/navigators/createDrawerNavigator.tsx
@@ -7,6 +7,7 @@ import {
   type ParamListBase,
   type StaticConfig,
   type StaticParamList,
+  type StaticScreenConfig,
   type TypedNavigator,
   useNavigationBuilder,
 } from '@react-navigation/native';
@@ -86,4 +87,18 @@ export function createDrawerNavigator<
 ): TypedNavigator<DrawerTypeBag<StaticParamList<{ config: Config }>>, Config>;
 export function createDrawerNavigator(config?: unknown) {
   return createNavigatorFactory(DrawerNavigator)(config);
+}
+
+export function createDrawerScreen<
+  const Screen extends React.ComponentType<any>,
+>(
+  config: StaticScreenConfig<
+    Screen,
+    DrawerNavigationState<ParamListBase>,
+    DrawerNavigationOptions,
+    DrawerNavigationEventMap,
+    DrawerNavigationProp<ParamListBase>
+  >
+) {
+  return config;
 }

--- a/packages/material-top-tabs/src/index.tsx
+++ b/packages/material-top-tabs/src/index.tsx
@@ -1,7 +1,10 @@
 /**
  * Navigators
  */
-export { createMaterialTopTabNavigator } from './navigators/createMaterialTopTabNavigator';
+export {
+  createMaterialTopTabNavigator,
+  createMaterialTopTabScreen,
+} from './navigators/createMaterialTopTabNavigator';
 
 /**
  * Views

--- a/packages/material-top-tabs/src/navigators/createMaterialTopTabNavigator.tsx
+++ b/packages/material-top-tabs/src/navigators/createMaterialTopTabNavigator.tsx
@@ -3,6 +3,7 @@ import {
   type ParamListBase,
   type StaticConfig,
   type StaticParamList,
+  type StaticScreenConfig,
   type TabActionHelpers,
   type TabNavigationState,
   TabRouter,
@@ -89,4 +90,18 @@ export function createMaterialTopTabNavigator<
 >;
 export function createMaterialTopTabNavigator(config?: unknown) {
   return createNavigatorFactory(MaterialTopTabNavigator)(config);
+}
+
+export function createMaterialTopTabScreen<
+  const Screen extends React.ComponentType<any>,
+>(
+  config: StaticScreenConfig<
+    Screen,
+    TabNavigationState<ParamListBase>,
+    MaterialTopTabNavigationOptions,
+    MaterialTopTabNavigationEventMap,
+    MaterialTopTabNavigationProp<ParamListBase>
+  >
+) {
+  return config;
 }

--- a/packages/native-stack/src/index.tsx
+++ b/packages/native-stack/src/index.tsx
@@ -1,7 +1,10 @@
 /**
  * Navigators
  */
-export { createNativeStackNavigator } from './navigators/createNativeStackNavigator';
+export {
+  createNativeStackNavigator,
+  createNativeStackScreen,
+} from './navigators/createNativeStackNavigator';
 
 /**
  * Views

--- a/packages/native-stack/src/navigators/createNativeStackNavigator.tsx
+++ b/packages/native-stack/src/navigators/createNativeStackNavigator.tsx
@@ -9,6 +9,7 @@ import {
   type StackRouterOptions,
   type StaticConfig,
   type StaticParamList,
+  type StaticScreenConfig,
   type TypedNavigator,
   useNavigationBuilder,
 } from '@react-navigation/native';
@@ -117,4 +118,18 @@ export function createNativeStackNavigator<
 >;
 export function createNativeStackNavigator(config?: unknown) {
   return createNavigatorFactory(NativeStackNavigator)(config);
+}
+
+export function createNativeStackScreen<
+  const Screen extends React.ComponentType<any>,
+>(
+  config: StaticScreenConfig<
+    Screen,
+    StackNavigationState<ParamListBase>,
+    NativeStackNavigationOptions,
+    NativeStackNavigationEventMap,
+    NativeStackNavigationProp<ParamListBase>
+  >
+) {
+  return config;
 }

--- a/packages/stack/src/index.tsx
+++ b/packages/stack/src/index.tsx
@@ -6,7 +6,10 @@ import * as TransitionSpecs from './TransitionConfigs/TransitionSpecs';
 /**
  * Navigators
  */
-export { createStackNavigator } from './navigators/createStackNavigator';
+export {
+  createStackNavigator,
+  createStackScreen,
+} from './navigators/createStackNavigator';
 
 /**
  * Views

--- a/packages/stack/src/navigators/createStackNavigator.tsx
+++ b/packages/stack/src/navigators/createStackNavigator.tsx
@@ -9,6 +9,7 @@ import {
   type StackRouterOptions,
   type StaticConfig,
   type StaticParamList,
+  type StaticScreenConfig,
   type TypedNavigator,
   useLocale,
   useNavigationBuilder,
@@ -115,4 +116,18 @@ export function createStackNavigator<
 ): TypedNavigator<StackTypeBag<StaticParamList<{ config: Config }>>, Config>;
 export function createStackNavigator(config?: unknown) {
   return createNavigatorFactory(StackNavigator)(config);
+}
+
+export function createStackScreen<
+  const Screen extends React.ComponentType<any>,
+>(
+  config: StaticScreenConfig<
+    Screen,
+    StackNavigationState<ParamListBase>,
+    StackNavigationOptions,
+    StackNavigationEventMap,
+    StackNavigationProp<ParamListBase>
+  >
+) {
+  return config;
 }


### PR DESCRIPTION
In the static config, we can't infer the type of `route` object in callbacks such as `options`, `listeners` etc. The `createXScreen` helpers attempt to solve this issue.