### PR TITLE
feat: expose icon type for bottom tabs

### DIFF
--- a/packages/bottom-tabs/src/index.tsx
+++ b/packages/bottom-tabs/src/index.tsx
@@ -35,11 +35,11 @@ export type {
   BottomTabBarButtonProps,
   BottomTabBarProps,
   BottomTabHeaderProps,
+  BottomTabIcon,
   BottomTabNavigationEventMap,
   BottomTabNavigationOptions,
   BottomTabNavigationProp,
   BottomTabNavigatorProps,
   BottomTabOptionsArgs,
   BottomTabScreenProps,
-  Icon,
 } from './types';


### PR DESCRIPTION
**Motivation**

This PR:
* Exposes the `Icon` type in the bottom tabs index export. This ensures consumers don't have to use an import path such as: `node_modules/@react-navigation/bottom-tabs/lib/typescript/src/unstable/types`. Please let me know if perhaps the name of the type should be changed to `UnstableIcon` to match the nature of the API 👍 


**Test plan**

* Ensure type is exposed properly by verifying you can import from the root of the package: `@react-navigation/bottom-tabs`

