### PR TITLE
feat: align header item types with react-native-screens

### DIFF
--- a/example/src/Screens/NativeStack.tsx
+++ b/example/src/Screens/NativeStack.tsx
@@ -298,7 +298,7 @@ export function NativeStack(
                   },
                   {
                     label: 'Inline submenu',
-                    displayInline: true,
+                    inline: true,
                     destructive: true,
                     icon: { type: 'sfSymbol', name: 'star' },
                     type: 'submenu',
@@ -307,7 +307,7 @@ export function NativeStack(
                         label: 'Sub Action 1',
                         state: 'mixed',
                         type: 'action',
-                        subtitle: 'With subtitle',
+                        description: 'With description',
                         onPress: () => Alert.alert('Sub Action 1 pressed'),
                         destructive: true,
                         keepsMenuPresented: true,
@@ -322,8 +322,8 @@ export function NativeStack(
                   },
                   {
                     label: 'Palette',
-                    displayInline: true,
-                    displayAsPalette: true,
+                    inline: true,
+                    layout: 'palette',
                     destructive: true,
                     type: 'submenu',
                     items: [

--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -880,11 +880,9 @@ export type NativeStackHeaderItemMenuAction = {
    */
   label: string;
   /**
-   * The subtitle displayed alongside the menu element’s label.
-   *
-   * Read more: https://developer.apple.com/documentation/uikit/uimenuelement/subtitle
+   * The secondary text displayed alongside the label of the menu item.
    */
-  subtitle?: string;
+  description?: string;
   /**
    * Icon for the menu item.
    */
@@ -948,17 +946,25 @@ export type NativeStackHeaderItemMenuSubmenu = {
    */
   icon?: PlatformIconIOSSfSymbol;
   /**
-   * Whether the menu is displayed inline.
+   * Whether the menu is displayed inline with the parent menu.
+   * By default, submenus are displayed after expanding the parent menu item.
+   * Inline menus are displayed as part of the parent menu as a section.
+   *
+   * Defaults to `false`.
    *
    * Read more: https://developer.apple.com/documentation/uikit/uimenu/options-swift.struct/displayinline
    */
-  displayInline?: boolean;
+  inline?: boolean;
   /**
-   * Whether the menu is displayed as a palette.
+   * How the submenu items are displayed.
+   * - `default`: menu items are displayed normally.
+   * - `palette`: menu items are displayed in a horizontal row.
+   *
+   * Defaults to `default`.
    *
    * Read more: https://developer.apple.com/documentation/uikit/uimenu/options-swift.struct/displayaspalette
    */
-  displayAsPalette?: boolean;
+  layout?: 'default' | 'palette';
   /**
    * Whether to apply destructive style to the menu item.
    *
@@ -966,11 +972,13 @@ export type NativeStackHeaderItemMenuSubmenu = {
    */
   destructive?: boolean;
   /**
-   * Whether the menu and its submenus allow a single menu item to be in the “on” state.
+   * Whether multiple items in the submenu can be selected, i.e. in "on" state.
+   *
+   * Defaults to `false`.
    *
    * Read more: https://developer.apple.com/documentation/uikit/uimenu/options-swift.struct/singleselection
    */
-  singleSelection?: boolean;
+  multiselectable?: boolean;
   /**
    * Array of menu items (actions or submenus).
    */
@@ -998,17 +1006,23 @@ export type NativeStackHeaderItemMenu = SharedHeaderItem & {
      */
     title?: string;
     /**
-     * Whether the menu and its submenus allow a single menu item to be in the “on” state.
+     * Whether multiple items in the submenu can be selected, i.e. in "on" state.
+     *
+     * Defaults to `false`.
      *
      * Read more: https://developer.apple.com/documentation/uikit/uimenu/options-swift.struct/singleselection
      */
-    singleSelection?: boolean;
+    multiselectable?: boolean;
     /**
-     * Whether the menu is displayed as a palette.
+     * How the submenu items are displayed.
+     * - `default`: menu items are displayed normally.
+     * - `palette`: menu items are displayed in a horizontal row.
+     *
+     * Defaults to `default`.
      *
      * Read more: https://developer.apple.com/documentation/uikit/uimenu/options-swift.struct/displayaspalette
      */
-    displayAsPalette?: boolean;
+    layout?: 'default' | 'palette';
     /**
      * Array of menu items (actions or submenus).
      */

--- a/packages/native-stack/src/views/useHeaderConfigProps.tsx
+++ b/packages/native-stack/src/views/useHeaderConfigProps.tsx
@@ -93,10 +93,14 @@ const processBarButtonItems = (
         };
 
         if (processedItem.type === 'menu' && item.type === 'menu') {
+          const { multiselectable, layout } = item.menu;
+
           processedItem = {
             ...processedItem,
             menu: {
               ...processedItem.menu,
+              singleSelection: !multiselectable,
+              displayAsPalette: layout === 'palette',
               items: item.menu.items.map(getMenuItem),
             },
           };
@@ -137,19 +141,25 @@ const processBarButtonItems = (
 const getMenuItem = (
   item: NativeStackHeaderItemMenuAction | NativeStackHeaderItemMenuSubmenu
 ): HeaderBarButtonItemMenuAction | HeaderBarButtonItemSubmenu => {
-  const { label, ...rest } = item;
+  if (item.type === 'submenu') {
+    const { label, inline, layout, items, multiselectable, ...rest } = item;
 
-  if (rest.type === 'submenu') {
     return {
       ...rest,
       title: label,
-      items: rest.items.map(getMenuItem),
+      displayAsPalette: layout === 'palette',
+      displayInline: inline,
+      singleSelection: !multiselectable,
+      items: items.map(getMenuItem),
     };
   }
+
+  const { label, description, ...rest } = item;
 
   return {
     ...rest,
     title: label,
+    subtitle: description,
   };
 };
 


### PR DESCRIPTION
**Motivation**

**Waiting for 4.19 release of react-native-screens**

New properties were added to header items in https://github.com/software-mansion/react-native-screens/pull/3396

This PR adds them in react-navigation

**Test plan**

1. Typecheck
2. Manual testing of NativeStack example

<img height="500" alt="Simulator Screenshot - iPhone 17 Pro - 2025-12-15 at 12 50 18" src="https://github.com/user-attachments/assets/0992dacd-5356-44d9-bbb2-eb24e72d4eef" />
