### PR TITLE
fix: use Navigation generic type for layout prop

### DIFF
--- a/example/__typechecks__/static.check.tsx
+++ b/example/__typechecks__/static.check.tsx
@@ -28,6 +28,12 @@ import {
 import { expectTypeOf } from 'expect-type';
 
 const NativeStack = createNativeStackNavigator({
+  layout: ({ navigation, children }) => {
+    expectTypeOf(navigation.getState().type).toEqualTypeOf<'stack'>();
+    expectTypeOf(navigation.push).toExtend<() => void>();
+
+    return <>{children}</>;
+  },
   groups: {
     GroupA: {
       screenLayout: ({ navigation, children }) => {

--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -84,7 +84,7 @@ export type DefaultNavigatorOptions<
    */
   layout?: (props: {
     state: State;
-    navigation: NavigationHelpers<ParamList>;
+    navigation: Navigation;
     descriptors: Record<
       string,
       Descriptor<


### PR DESCRIPTION
**Motivation**

 When using the `layout` callback on the drawer navigator, I noticed that the `navigation` object being passed to the function was typed using `NavigationHelpers` rather than the `Navigation` generic which is used in other callbacks like `screenLayout`.

This PR updates the type for the navigation object so that it is properly typed.

**Test plan**
Just a type change. I've added a small test to ensure that the layout callback is now using the `Navigation` generic.
