### PR TITLE
docs: update link to GitHub contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,7 +114,7 @@ The `package.json` file contains various scripts for common tasks:
 
 ### Sending a pull request
 
-> **Working on your first pull request?** You can learn how from this _free_ series: [How to Contribute to an Open Source Project on GitHub](https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github).
+> **Working on your first pull request?** You can learn how from this _free_ series: [How to Contribute to an Open Source Project on GitHub](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github).
 
 When you're sending a pull request:
 


### PR DESCRIPTION
## Motivation

This pull request fixes an incorrect URL in the documentation.

The existing link pointed to a non-working / outdated page, which could confuse users when following the documentation.  
This change updates the URL to the correct destination.

## Test plan

1. Open the updated documentation file.
2. Click the corrected URL.
3. Confirm that the link navigates to the intended page successfully.

This change only affects documentation and does not impact runtime behavior.
