### PR TITLE
refactor: rework how screens are preloaded

### DIFF
--- a/example/e2e/maestro/native-stack-preload-flow.yml
+++ b/example/e2e/maestro/native-stack-preload-flow.yml
@@ -1,0 +1,28 @@
+appId: ${APP_ID}
+name: Native Stack Preload Flow
+---
+- runFlow:
+    file: ../launch.yml
+    env:
+      LINK: native-stack-preload-flow
+      TEXT: 'Home'
+- assertVisible:
+    text: 'Details is not preloaded yet.'
+- tapOn:
+    text: 'Preload Details'
+- extendedWaitUntil:
+    timeout: 3000
+    visible: 'Details is preloaded!'
+- tapOn:
+    text: 'Navigate to Details'
+- assertVisible:
+    text: 'Loaded!'
+- tapOn:
+    text: 'Back to home'
+- tapOn:
+    text: 'Navigate to Details'
+- assertVisible:
+    text: 'Loading...'
+- extendedWaitUntil:
+    timeout: 3000
+    visible: 'Loaded!'

--- a/example/src/Screens/StackPreloadFlow.tsx
+++ b/example/src/Screens/StackPreloadFlow.tsx
@@ -66,7 +66,7 @@ const HomeScreen = ({
   const timerRef = useRef<NodeJS.Timeout | undefined>(undefined);
 
   useEffect(() => {
-    navigation.addListener('blur', () => {
+    return navigation.addListener('blur', () => {
       clearTimeout(timerRef.current);
       setIsReady(false);
     });

--- a/packages/core/src/__tests__/useNavigation.test.tsx
+++ b/packages/core/src/__tests__/useNavigation.test.tsx
@@ -208,15 +208,12 @@ test('gets navigation in preloaded screen', () => {
   expect.assertions(4);
 
   const TestNavigator = (props: any): any => {
-    const { state, descriptors, describe } = useNavigationBuilder(
-      StackRouter,
-      props
-    );
+    const { state, descriptors } = useNavigationBuilder(StackRouter, props);
 
     return (
       <>
         {state.routes.map((route) => descriptors[route.key].render())}
-        {state.preloadedRoutes?.map((route) => describe(route, true).render())}
+        {state.preloadedRoutes?.map((route) => descriptors[route.key].render())}
       </>
     );
   };

--- a/packages/core/src/__tests__/useNavigationCache.test.tsx
+++ b/packages/core/src/__tests__/useNavigationCache.test.tsx
@@ -37,8 +37,8 @@ test('preserves reference for navigation objects', () => {
     const previous = React.useRef<any>(undefined);
 
     const emitter = useEventEmitter();
-    const { navigations } = useNavigationCache({
-      state,
+    const navigations = useNavigationCache({
+      routes: state.routes,
       getState,
       navigation,
       setOptions,

--- a/packages/core/src/__tests__/useOnAction.test.tsx
+++ b/packages/core/src/__tests__/useOnAction.test.tsx
@@ -1281,16 +1281,19 @@ test("prevents removing a child screen with 'beforeRemove' event with 'resetRoot
     type: 'stack',
   });
 
-  act(() =>
-    ref.current?.resetRoot({
+  act(() => {
+    const state = {
       index: 0,
       key: 'stack-2',
       routeNames: ['foo', 'bar', 'baz'],
       routes: [{ key: 'foo-3', name: 'foo' }],
+      preloadedRoutes: [],
       stale: false,
       type: 'stack',
-    })
-  );
+    };
+
+    ref.current?.resetRoot(state);
+  });
 
   expect(onStateChange).toHaveBeenCalledTimes(1);
   expect(onBeforeRemove).toHaveBeenCalledTimes(1);
@@ -1322,16 +1325,19 @@ test("prevents removing a child screen with 'beforeRemove' event with 'resetRoot
 
   shouldPrevent = false;
 
-  act(() =>
-    ref.current?.resetRoot({
+  act(() => {
+    const state = {
       index: 0,
       key: 'stack-2',
       routeNames: ['foo', 'bar', 'baz'],
       routes: [{ key: 'foo-3', name: 'foo' }],
+      preloadedRoutes: [],
       stale: false,
       type: 'stack',
-    })
-  );
+    };
+
+    ref.current?.resetRoot(state);
+  });
 
   expect(onStateChange).toHaveBeenCalledTimes(2);
   expect(onStateChange).toHaveBeenCalledWith({
@@ -1339,6 +1345,7 @@ test("prevents removing a child screen with 'beforeRemove' event with 'resetRoot
     key: 'stack-2',
     routeNames: ['foo', 'bar', 'baz'],
     routes: [{ key: 'foo-3', name: 'foo' }],
+    preloadedRoutes: [],
     stale: false,
     type: 'stack',
   });

--- a/packages/core/src/__tests__/usePreventRemove.test.tsx
+++ b/packages/core/src/__tests__/usePreventRemove.test.tsx
@@ -947,16 +947,19 @@ test("prevents removing a child screen with 'usePreventRemove' hook with 'resetR
     type: 'stack',
   });
 
-  act(() =>
-    ref.current?.resetRoot({
+  act(() => {
+    const state = {
       index: 0,
       key: 'stack-2',
       routeNames: ['foo', 'bar', 'baz'],
       routes: [{ key: 'foo-3', name: 'foo' }],
+      preloadedRoutes: [],
       stale: false,
       type: 'stack',
-    })
-  );
+    };
+
+    ref.current?.resetRoot(state);
+  });
 
   expect(onStateChange).toHaveBeenCalledTimes(1);
 

--- a/packages/core/src/useNavigationBuilder.tsx
+++ b/packages/core/src/useNavigationBuilder.tsx
@@ -887,13 +887,15 @@ export function useNavigationBuilder<
     getStateListeners: keyedListeners.getState,
   });
 
-  const { describe, descriptors } = useDescriptors<
+  const descriptors = useDescriptors<
     State,
     ActionHelpers,
     ScreenOptions,
     EventMap
   >({
-    state,
+    routes: router.getRoutesFromState
+      ? router.getRoutesFromState(state)
+      : state.routes,
     screens,
     navigation,
     screenOptions,
@@ -940,7 +942,6 @@ export function useNavigationBuilder<
   return {
     state,
     navigation,
-    describe,
     descriptors,
     NavigationContent,
   };

--- a/packages/native-stack/src/navigators/createNativeStackNavigator.tsx
+++ b/packages/native-stack/src/navigators/createNativeStackNavigator.tsx
@@ -37,7 +37,7 @@ function NativeStackNavigator({
   router,
   ...rest
 }: NativeStackNavigatorProps) {
-  const { state, describe, descriptors, navigation, NavigationContent } =
+  const { state, descriptors, navigation, NavigationContent } =
     useNavigationBuilder<
       StackNavigationState<ParamListBase>,
       StackRouterOptions,
@@ -94,7 +94,6 @@ function NativeStackNavigator({
         state={state}
         navigation={navigation}
         descriptors={descriptors}
-        describe={describe}
       />
     </NavigationContent>
   );

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -10,7 +10,6 @@ import { SafeAreaProviderCompat } from '@react-navigation/elements/internal';
 import {
   NavigationProvider,
   type ParamListBase,
-  type RouteProp,
   StackActions,
   type StackNavigationState,
   usePreventRemoveContext,
@@ -415,36 +414,20 @@ type Props = {
   state: StackNavigationState<ParamListBase>;
   navigation: NativeStackNavigationHelpers;
   descriptors: NativeStackDescriptorMap;
-  describe: (
-    route: RouteProp<ParamListBase>,
-    placeholder: boolean
-  ) => NativeStackDescriptor;
 };
 
-export function NativeStackView({
-  state,
-  navigation,
-  descriptors,
-  describe,
-}: Props) {
+export function NativeStackView({ state, navigation, descriptors }: Props) {
   const { setNextDismissedKey } = useDismissedRouteError(state);
 
   useInvalidPreventRemoveError(descriptors);
 
   const modalRouteKeys = getModalRouteKeys(state.routes, descriptors);
 
-  const preloadedDescriptors =
-    state.preloadedRoutes.reduce<NativeStackDescriptorMap>((acc, route) => {
-      acc[route.key] = acc[route.key] || describe(route, true);
-      return acc;
-    }, {});
-
   return (
     <SafeAreaProviderCompat>
       <ScreenStack style={styles.container}>
         {state.routes.concat(state.preloadedRoutes).map((route, index) => {
-          const descriptor =
-            descriptors[route.key] ?? preloadedDescriptors[route.key];
+          const descriptor = descriptors[route.key];
           const isFocused = state.index === index;
           const isBelowFocused = state.index - 1 === index;
           const previousKey = state.routes[index - 1]?.key;
@@ -457,9 +440,9 @@ export function NativeStackView({
           const isModal = modalRouteKeys.includes(route.key);
           const isModalOnIos = isModal && Platform.OS === 'ios';
 
-          const isPreloaded =
-            preloadedDescriptors[route.key] !== undefined &&
-            descriptors[route.key] === undefined;
+          const isPreloaded = state.preloadedRoutes.some(
+            (r) => r.key === route.key
+          );
 
           // On Fabric, when screen is frozen, animated and reanimated values are not updated
           // due to component being unmounted. To avoid this, we don't freeze the previous screen there

--- a/packages/native-stack/src/views/NativeStackView.tsx
+++ b/packages/native-stack/src/views/NativeStackView.tsx
@@ -11,7 +11,6 @@ import {
 } from '@react-navigation/elements/internal';
 import {
   type ParamListBase,
-  type RouteProp,
   type StackNavigationState,
   useLinkBuilder,
 } from '@react-navigation/native';
@@ -19,7 +18,6 @@ import * as React from 'react';
 import { Animated, Image, StyleSheet, View } from 'react-native';
 
 import type {
-  NativeStackDescriptor,
   NativeStackDescriptorMap,
   NativeStackNavigationHelpers,
 } from '../types';
@@ -27,13 +25,8 @@ import { AnimatedHeaderHeightContext } from '../utils/useAnimatedHeaderHeight';
 
 type Props = {
   state: StackNavigationState<ParamListBase>;
-  // This is used for the native implementation of the stack.
   navigation: NativeStackNavigationHelpers;
   descriptors: NativeStackDescriptorMap;
-  describe: (
-    route: RouteProp<ParamListBase>,
-    placeholder: boolean
-  ) => NativeStackDescriptor;
 };
 
 const TRANSPARENT_PRESENTATIONS = [
@@ -41,15 +34,9 @@ const TRANSPARENT_PRESENTATIONS = [
   'containedTransparentModal',
 ];
 
-export function NativeStackView({ state, descriptors, describe }: Props) {
+export function NativeStackView({ state, descriptors }: Props) {
   const parentHeaderBack = React.useContext(HeaderBackContext);
   const { buildHref } = useLinkBuilder();
-
-  const preloadedDescriptors =
-    state.preloadedRoutes.reduce<NativeStackDescriptorMap>((acc, route) => {
-      acc[route.key] = acc[route.key] || describe(route, true);
-      return acc;
-    }, {});
 
   return (
     <SafeAreaProviderCompat>
@@ -61,8 +48,7 @@ export function NativeStackView({ state, descriptors, describe }: Props) {
           ? descriptors[previousKey]
           : undefined;
         const nextDescriptor = nextKey ? descriptors[nextKey] : undefined;
-        const { options, navigation, render } =
-          descriptors[route.key] ?? preloadedDescriptors[route.key];
+        const { options, navigation, render } = descriptors[route.key];
 
         const headerBack = previousDescriptor
           ? {
@@ -93,9 +79,9 @@ export function NativeStackView({ state, descriptors, describe }: Props) {
 
         const nextPresentation = nextDescriptor?.options.presentation;
 
-        const isPreloaded =
-          preloadedDescriptors[route.key] !== undefined &&
-          descriptors[route.key] === undefined;
+        const isPreloaded = state.preloadedRoutes.some(
+          (r) => r.key === route.key
+        );
 
         return (
           <Screen

--- a/packages/routers/src/StackRouter.tsx
+++ b/packages/routers/src/StackRouter.tsx
@@ -696,6 +696,10 @@ export function StackRouter(options: StackRouterOptions) {
       }
     },
 
+    getRoutesFromState(state) {
+      return [...state.routes, ...state.preloadedRoutes];
+    },
+
     actionCreators: StackActions,
   };
 

--- a/packages/routers/src/types.tsx
+++ b/packages/routers/src/types.tsx
@@ -229,6 +229,17 @@ export type Router<
   shouldActionChangeFocus(action: NavigationAction): boolean;
 
   /**
+   * Get the list of routes from the navigation state.
+   *
+   * By default, `state.routes` is used.
+   * But in some cases (like `preloadedRoutes` in stack),
+   * the actual list of routes may be different.
+   *
+   * @param state Navigation state to get the routes from.
+   */
+  getRoutesFromState?(state: State): Route<string>[];
+
+  /**
    * Action creators for the router.
    */
   actionCreators?: ActionCreators<Action>;

--- a/packages/stack/src/navigators/createStackNavigator.tsx
+++ b/packages/stack/src/navigators/createStackNavigator.tsx
@@ -39,7 +39,7 @@ function StackNavigator({
 }: StackNavigatorProps) {
   const { direction } = useLocale();
 
-  const { state, describe, descriptors, navigation, NavigationContent } =
+  const { state, descriptors, navigation, NavigationContent } =
     useNavigationBuilder<
       StackNavigationState<ParamListBase>,
       StackRouterOptions,
@@ -89,7 +89,6 @@ function StackNavigator({
         {...rest}
         direction={direction}
         state={state}
-        describe={describe}
         descriptors={descriptors}
         navigation={navigation}
       />

--- a/packages/stack/src/views/Stack/CardStack.tsx
+++ b/packages/stack/src/views/Stack/CardStack.tsx
@@ -59,7 +59,6 @@ type Props = {
   insets: EdgeInsets;
   state: StackNavigationState<ParamListBase>;
   descriptors: StackDescriptorMap;
-  preloadedDescriptors: StackDescriptorMap;
   routes: Route<string>[];
   openingRouteKeys: string[];
   closingRouteKeys: string[];
@@ -280,8 +279,7 @@ export class CardStack extends React.Component<Props, State> {
       ...props.routes,
       ...props.state.preloadedRoutes,
     ].reduce<GestureValues>((acc, curr) => {
-      const descriptor =
-        props.descriptors[curr.key] || props.preloadedDescriptors[curr.key];
+      const descriptor = props.descriptors[curr.key];
       const { animation } = descriptor?.options || {};
 
       acc[curr.key] =
@@ -303,10 +301,7 @@ export class CardStack extends React.Component<Props, State> {
 
     const modalRouteKeys = getModalRouteKeys(
       [...props.routes, ...props.state.preloadedRoutes],
-      {
-        ...props.descriptors,
-        ...props.preloadedDescriptors,
-      }
+      props.descriptors
     );
 
     const scenes = [...props.routes, ...props.state.preloadedRoutes].map(
@@ -325,9 +320,7 @@ export class CardStack extends React.Component<Props, State> {
         const nextGesture = nextRoute ? gestures[nextRoute.key] : undefined;
 
         const descriptor =
-          (isPreloaded ? props.preloadedDescriptors : props.descriptors)[
-            route.key
-          ] ||
+          props.descriptors[route.key] ||
           state.descriptors[route.key] ||
           (oldScene ? oldScene.descriptor : FALLBACK_DESCRIPTOR);
 


### PR DESCRIPTION
preloaded routes will now have proper descriptors objects. this means they can now add listeners, set options, contain nested navigators etc.