### PR TITLE
refactor: improve parameter checks in SceneView component

### DIFF
--- a/packages/core/src/SceneView.tsx
+++ b/packages/core/src/SceneView.tsx
@@ -80,6 +80,7 @@ export function SceneView<
         // This will avoid the navigator trying to handle them again
         if (
           nextRoute.params &&
+          typeof nextRoute.params === 'object' &&
           (('state' in nextRoute.params &&
             typeof nextRoute.params.state === 'object' &&
             nextRoute.params.state !== null) ||


### PR DESCRIPTION
**Motivation**

Closes https://github.com/react-navigation/react-navigation/issues/12922

This PR adds a defensive runtime check in SceneView to avoid a crash when route.params is not an object.

As explained in https://github.com/react-navigation/react-navigation/issues/12922 and https://github.com/react-navigation/react-navigation/issues/12922#issuecomment-3749648700
 the crash was caused by a legacy navigation pattern where a string was passed as params to navigate. While this is invalid usage, the current logic assumes params is always an object and uses the in operator, which throws at runtime otherwise.

This change does not alter the public API or expected usage, but prevents hard crashes by making the validation logic more resilient to malformed or legacy params.

**Test plan**
- Run the existing test suite (lint, TypeScript, and tests).
- Verify that normal navigation with object-based params behaves unchanged.
- Confirm that passing invalid legacy params (e.g. a string) no longer crashes the app.

**Screenshot**

Before

https://github.com/user-attachments/assets/5769ff43-ae75-41a9-9b9e-1236933c7fe9

After

https://github.com/user-attachments/assets/ee20dc70-e963-4c23-8bd2-0752c607767e


