### PR TITLE
docs: update sheetLargestUndimmedDetentIndex doc for keyboard handling

### DIFF
--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -724,7 +724,7 @@ export type NativeStackNavigationOptions = {
    * @remark
    * On iOS, the native implementation might resize the the sheet w/o explicitly changing the detent level, e.g. in case of keyboard appearance.
    * In case after such resize the sheet exceeds height for which in regular scenario a dimming view would be applied - it will be applied,
-   * even in the detent has not effectively been changed.
+   * even if the detent has not effectively been changed.
    *
    * Defaults to `none`, indicating that the dimming view should be always present.
    */


### PR DESCRIPTION
**Motivation**

For keyboard handling the DimmingView appears always, even if we set `sheetLargestUndimmedDetentIndex` to `last`, because the keyboard changes sheet's size and it exceeds the `largestUndimmedDetent` threshold

For more context, please look at: https://github.com/software-mansion/react-native-screens/issues/3577#issuecomment-3811404550

**Test plan**

N/A just, doc update