### PR TITLE
feat: add a component that uses `Activity` but keeps content visible

### DIFF
--- a/example/src/Screens/ActivityModes.tsx
+++ b/example/src/Screens/ActivityModes.tsx
@@ -1,0 +1,193 @@
+import {
+  PlatformPressable,
+  Text,
+  useHeaderHeight,
+} from '@react-navigation/elements';
+import { ActivityView } from '@react-navigation/elements/internal';
+import { useTheme } from '@react-navigation/native';
+import { useEffect, useRef, useState } from 'react';
+import { Animated, StyleSheet, View } from 'react-native';
+
+import { SegmentedPicker } from '../Shared/SegmentedPicker';
+
+function Content() {
+  const { colors } = useTheme();
+  const dotAnim = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    const animation = Animated.loop(
+      Animated.sequence([
+        Animated.timing(dotAnim, {
+          toValue: 1,
+          duration: 1000,
+          useNativeDriver: true,
+        }),
+        Animated.timing(dotAnim, {
+          toValue: 0,
+          duration: 1000,
+          useNativeDriver: true,
+        }),
+      ])
+    );
+
+    animation.start();
+
+    return () => {
+      animation.stop();
+    };
+  }, [dotAnim]);
+
+  const [time, setTime] = useState(() => new Date());
+  const [offset, setOffset] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setTime(new Date());
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  const formattedTime = new Date(
+    time.getTime() + offset * 1000 * 60 * 60
+  ).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+
+  return (
+    <View
+      style={[
+        styles.clock,
+        { borderColor: colors.border, backgroundColor: colors.card },
+      ]}
+    >
+      <Text style={[styles.time, { color: colors.text }]}>{formattedTime}</Text>
+      <View style={styles.buttons}>
+        <PlatformPressable onPress={() => setOffset((o) => --o)}>
+          <Text style={styles.button}>↓</Text>
+        </PlatformPressable>
+        <PlatformPressable onPress={() => setOffset((o) => ++o)}>
+          <Text style={styles.button}>↑</Text>
+        </PlatformPressable>
+      </View>
+      <Animated.View
+        style={[
+          styles.dot,
+          {
+            backgroundColor: colors.text,
+            transform: [
+              {
+                translateX: dotAnim.interpolate({
+                  inputRange: [0, 1],
+                  outputRange: [0, CLOCK_SIZE - SPACING * 2 - DOT_SIZE],
+                }),
+              },
+            ],
+          },
+        ]}
+      />
+    </View>
+  );
+}
+
+export function ActivityModes() {
+  const headerHeight = useHeaderHeight();
+
+  const [mode, setMode] =
+    useState<React.ComponentProps<typeof ActivityView>['mode']>('normal');
+
+  const [visible, setVisible] = useState(true);
+
+  return (
+    <View style={[styles.container, { marginTop: -headerHeight }]}>
+      <ActivityView mode={mode} visible={visible} style={styles.content}>
+        <Content />
+      </ActivityView>
+      <View style={styles.controls}>
+        <SegmentedPicker
+          choices={[
+            { label: 'Normal', value: 'normal' },
+            { label: 'Inert', value: 'inert' },
+            { label: 'Paused', value: 'paused' },
+          ]}
+          value={mode}
+          onValueChange={(value) => setMode(value)}
+        />
+        <SegmentedPicker
+          choices={[
+            { label: 'Visible', value: true },
+            { label: 'Hidden', value: false },
+          ]}
+          value={visible}
+          onValueChange={(value) => setVisible(value)}
+        />
+      </View>
+    </View>
+  );
+}
+
+ActivityModes.title = 'Activity Modes';
+ActivityModes.linking = {};
+ActivityModes.options = {
+  headerShown: true,
+};
+
+const SPACING = 16;
+const CLOCK_SIZE = 160;
+const CLOCK_FONT_SIZE = 24;
+const BUTTON_FONT_SIZE = 18;
+const DOT_SIZE = 10;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: SPACING,
+  },
+  buttons: {
+    position: 'absolute',
+    flexDirection: 'row',
+    marginTop: CLOCK_FONT_SIZE + BUTTON_FONT_SIZE + SPACING,
+  },
+  button: {
+    fontSize: BUTTON_FONT_SIZE,
+    fontWeight: '600',
+    opacity: 0.5,
+    margin: SPACING / 2,
+  },
+  controls: {
+    alignItems: 'center',
+    gap: SPACING / 2,
+  },
+  content: {
+    minHeight: CLOCK_SIZE,
+    margin: SPACING,
+  },
+  clock: {
+    width: CLOCK_SIZE,
+    height: CLOCK_SIZE,
+    borderRadius: 10,
+    borderWidth: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    alignSelf: 'center',
+  },
+  time: {
+    fontSize: CLOCK_FONT_SIZE,
+    fontWeight: '600',
+    fontVariant: ['tabular-nums'],
+  },
+  dot: {
+    position: 'absolute',
+    bottom: SPACING,
+    left: SPACING,
+    width: DOT_SIZE,
+    height: DOT_SIZE,
+    borderRadius: DOT_SIZE / 2,
+    opacity: 0.3,
+  },
+});

--- a/example/src/Shared/SegmentedPicker.tsx
+++ b/example/src/Shared/SegmentedPicker.tsx
@@ -9,14 +9,14 @@ import {
   type ViewStyle,
 } from 'react-native';
 
-type Props<T extends string | number> = {
+type Props<T extends string | number | boolean> = {
   choices: { label: string; value: T }[];
   value: T;
   onValueChange: (value: T) => void;
   style?: StyleProp<ViewStyle>;
 };
 
-export function SegmentedPicker<T extends string | number>({
+export function SegmentedPicker<T extends string | number | boolean>({
   choices,
   value,
   onValueChange,
@@ -28,7 +28,7 @@ export function SegmentedPicker<T extends string | number>({
     <View style={[styles.container, style]}>
       {choices.map((option) => (
         <Pressable
-          key={option.value}
+          key={String(option.value)}
           onPress={() => onValueChange(option.value)}
           style={[
             styles.segment,

--- a/example/src/screens.tsx
+++ b/example/src/screens.tsx
@@ -1,5 +1,6 @@
 import type { StaticConfig } from '@react-navigation/native';
 
+import { ActivityModes } from './Screens/ActivityModes';
 import { AuthFlow } from './Screens/AuthFlow';
 import { BottomTabs } from './Screens/BottomTabs';
 import { BottomTabsDynamic } from './Screens/BottomTabsDynamic';
@@ -66,6 +67,7 @@ export const SCREENS = {
   NavigatorLayout,
   ScreenLayout,
   StaticConfigScreen,
+  ActivityModes,
 } as const satisfies {
   [key: string]:
     | (React.ComponentType<{ route: any }> & {

--- a/packages/elements/src/ActivityView.native.tsx
+++ b/packages/elements/src/ActivityView.native.tsx
@@ -1,0 +1,63 @@
+import { Activity } from 'react';
+import {
+  type HostComponent,
+  NativeComponentRegistry,
+  View,
+  type ViewProps,
+} from 'react-native';
+
+// eslint-disable-next-line import-x/extensions
+import type { Props } from './ActivityView.tsx';
+import { Container } from './Container';
+
+export function ActivityView({ mode, visible, style, children }: Props) {
+  return (
+    <Container inert={mode !== 'normal'} style={style}>
+      <Activity mode={mode === 'paused' ? 'hidden' : 'visible'}>
+        <ActivityContentView style={{ display: 'contents' }}>
+          <View
+            style={{
+              /**
+               * The visibility of the nested view is controlled by `Activity`
+               * It'll be overridden to `display: 'none'` when `mode="hidden"` regardless of what we set
+               * So we set the visibility on another view instead
+               */
+              display: visible ? 'contents' : 'none',
+            }}
+          >
+            {children}
+          </View>
+        </ActivityContentView>
+      </Activity>
+    </Container>
+  );
+}
+
+const STYLE: Record<string, true | { process?: (arg1: any) => any }> = {
+  display: {
+    /**
+     * React `Activity` sets `display: 'none'` when `mode="hidden"` to unmount effects
+     * But we want to keep the content visible, so we switch it to `display: 'contents'`
+     */
+    process: () => 'contents',
+  },
+};
+
+const VIEW_CONFIG = {
+  uiViewClassName: 'RCTView',
+  validAttributes: {
+    style: STYLE,
+  },
+};
+
+type ActivityContentViewProps = Omit<ViewProps, 'style'> & {
+  style?: {
+    display?: 'contents';
+  };
+};
+
+const ActivityContentView: HostComponent<ActivityContentViewProps> =
+  NativeComponentRegistry.get<ActivityContentViewProps>(
+    'ReactNavigationActivityContentView',
+    () => VIEW_CONFIG
+  );

--- a/packages/elements/src/ActivityView.tsx
+++ b/packages/elements/src/ActivityView.tsx
@@ -1,0 +1,99 @@
+import { Activity, useCallback } from 'react';
+import { Platform, View, type ViewStyle } from 'react-native';
+
+import { Container } from './Container';
+
+export type Props = {
+  /**
+   * Mode of the activity view
+   * - `normal`: The view renders normally
+   * - `inert`: Content is not interactive
+   * - `paused`: Effects are unmounted and content is not interactive
+   */
+  mode: 'normal' | 'inert' | 'paused';
+  /**
+   * Whether the content is visible or not
+   */
+  visible: boolean;
+  /**
+   * The style for the container view
+   */
+  style?: React.CSSProperties & ViewStyle;
+  /**
+   * The content of the activity view
+   */
+  children: React.ReactNode;
+};
+
+export function ActivityView({ mode, visible, style, children }: Props) {
+  /**
+   * Activity has 2 modes, visible and hidden - hidden unmounts effects
+   * But what we want is to unmount effects, without hiding content
+   * So we use hidden mode, but unset display: none to make content visible
+   */
+  const onRef = useCallback((node: HTMLDivElement | View | null) => {
+    if (Platform.OS !== 'web' || !(node && node instanceof HTMLElement)) {
+      return;
+    }
+
+    const observers: MutationObserver[] = [];
+
+    const observe = () => {
+      // Remove previous observers
+      observers.forEach((o) => o.disconnect());
+      observers.length = 0;
+
+      const children = node.childNodes;
+
+      // When the style attribute for children is updated by React
+      // We observe it and update display to make content visible
+      children.forEach((child) => {
+        if (child instanceof HTMLElement) {
+          const o = new MutationObserver(() => {
+            child.style.display = 'contents';
+          });
+
+          o.observe(child, {
+            attributes: true,
+            attributeFilter: ['style'],
+          });
+
+          observers.push(o);
+        }
+      });
+    };
+
+    observe();
+
+    // React removes refs when `Activity` is hidden
+    // So we render outside of the `Activity` and observer child list
+    const observer = new MutationObserver(observe);
+
+    observer.observe(node, {
+      childList: true,
+    });
+
+    return () => {
+      observer.disconnect();
+      observers.forEach((o) => o.disconnect());
+    };
+  }, []);
+
+  return (
+    <Container ref={onRef} inert={mode !== 'normal'} style={style}>
+      <Activity mode={mode === 'paused' ? 'hidden' : 'visible'}>
+        <Container
+          style={{
+            display: 'contents',
+            /**
+             * We use `visibility` to hide content instead to keep layout
+             */
+            visibility: visible ? 'visible' : 'hidden',
+          }}
+        >
+          {children}
+        </Container>
+      </Activity>
+    </Container>
+  );
+}

--- a/packages/elements/src/Container.tsx
+++ b/packages/elements/src/Container.tsx
@@ -1,6 +1,7 @@
 import { Platform, View, type ViewStyle } from 'react-native';
 
 export type Props = {
+  ref?: React.Ref<HTMLDivElement | View>;
   inert?: boolean;
   style?: ViewStyle &
     Omit<React.CSSProperties, 'backgroundColor'> & {
@@ -9,12 +10,13 @@ export type Props = {
   children: React.ReactNode;
 };
 
-export function Container({ inert, children, style }: Props) {
+export function Container({ ref, inert, children, style }: Props) {
   if (Platform.OS === 'web') {
     const { backgroundColor, ...rest } = style ?? {};
 
     return (
       <div
+        ref={ref as React.Ref<HTMLDivElement> | undefined}
         inert={inert}
         aria-hidden={inert}
         style={{
@@ -32,6 +34,7 @@ export function Container({ inert, children, style }: Props) {
 
   return (
     <View
+      ref={ref as React.Ref<View> | undefined}
       aria-hidden={inert}
       style={[{ pointerEvents: inert ? 'none' : 'box-none' }, style]}
       collapsable={false}

--- a/packages/elements/src/internal.tsx
+++ b/packages/elements/src/internal.tsx
@@ -1,3 +1,4 @@
+export { ActivityView } from './ActivityView';
 export { Color } from './Color';
 export { Container, type Props as ContainerProps } from './Container';
 export { Lazy } from './Lazy';

--- a/packages/native/android/src/main/java/org/reactnavigation/ReactNavigationPackage.kt
+++ b/packages/native/android/src/main/java/org/reactnavigation/ReactNavigationPackage.kt
@@ -9,7 +9,9 @@ import com.facebook.react.uimanager.ViewManager
 
 class ReactNavigationPackage : BaseReactPackage() {
   override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {
-    return listOf(MaterialSymbolViewManager())
+    return listOf(
+      MaterialSymbolViewManager()
+    )
   }
 
   override fun getModule(name: String, reactContext: ReactApplicationContext): NativeModule? {


### PR DESCRIPTION
This adds a component that uses `<Activity mode="hidden">` but keeps the content visible. The primitive will be used for screens in a navigator to freeze inactive screens.

https://github.com/user-attachments/assets/012f33da-1377-4d2b-af85-250361e80af3

