### PR TITLE
fix(types): add exactOptionalPropertyTypes support to routers package

### DIFF
--- a/packages/routers/src/CommonActions.tsx
+++ b/packages/routers/src/CommonActions.tsx
@@ -9,59 +9,59 @@ type ResetState =
 
 type GoBackAction = {
   type: 'GO_BACK';
-  source?: string;
-  target?: string;
+  source?: string | undefined;
+  target?: string | undefined;
 };
 
 type NavigateAction = {
   type: 'NAVIGATE';
   payload: {
     name: string;
-    params?: object;
-    path?: string;
-    merge?: boolean;
-    pop?: boolean;
+    params?: object | undefined;
+    path?: string | undefined;
+    merge?: boolean | undefined;
+    pop?: boolean | undefined;
   };
-  source?: string;
-  target?: string;
+  source?: string | undefined;
+  target?: string | undefined;
 };
 
 type ResetAction = {
   type: 'RESET';
   payload: ResetState;
-  source?: string;
-  target?: string;
+  source?: string | undefined;
+  target?: string | undefined;
 };
 
 type SetParamsAction = {
   type: 'SET_PARAMS';
-  payload: { params?: object };
-  source?: string;
-  target?: string;
+  payload: { params?: object | undefined };
+  source?: string | undefined;
+  target?: string | undefined;
 };
 
 type ReplaceParamsAction = {
   type: 'REPLACE_PARAMS';
-  payload: { params?: object };
-  source?: string;
-  target?: string;
+  payload: { params?: object | undefined };
+  source?: string | undefined;
+  target?: string | undefined;
 };
 
 type PushParamsAction = {
   type: 'PUSH_PARAMS';
-  payload: { params?: object };
-  source?: string;
-  target?: string;
+  payload: { params?: object | undefined };
+  source?: string | undefined;
+  target?: string | undefined;
 };
 
 type PreloadAction = {
   type: 'PRELOAD';
   payload: {
     name: string;
-    params?: object;
+    params?: object | undefined;
   };
-  source?: string;
-  target?: string;
+  source?: string | undefined;
+  target?: string | undefined;
 };
 
 export type Action =

--- a/packages/routers/src/DrawerRouter.tsx
+++ b/packages/routers/src/DrawerRouter.tsx
@@ -20,12 +20,12 @@ export type DrawerActionType =
   | TabActionType
   | {
       type: 'OPEN_DRAWER' | 'CLOSE_DRAWER' | 'TOGGLE_DRAWER';
-      source?: string;
-      target?: string;
+      source?: string | undefined;
+      target?: string | undefined;
     };
 
 export type DrawerRouterOptions = TabRouterOptions & {
-  defaultStatus?: DrawerStatus;
+  defaultStatus?: DrawerStatus | undefined;
 };
 
 export type DrawerNavigationState<ParamList extends ParamListBase> = Omit<

--- a/packages/routers/src/StackRouter.tsx
+++ b/packages/routers/src/StackRouter.tsx
@@ -16,36 +16,36 @@ import type {
 export type StackActionType =
   | {
       type: 'REPLACE';
-      payload: { name: string; params?: object };
-      source?: string;
-      target?: string;
+      payload: { name: string; params?: object | undefined };
+      source?: string | undefined;
+      target?: string | undefined;
     }
   | {
       type: 'PUSH';
-      payload: { name: string; params?: object };
-      source?: string;
-      target?: string;
+      payload: { name: string; params?: object | undefined };
+      source?: string | undefined;
+      target?: string | undefined;
     }
   | {
       type: 'POP';
       payload: { count: number };
-      source?: string;
-      target?: string;
+      source?: string | undefined;
+      target?: string | undefined;
     }
   | {
       type: 'POP_TO_TOP';
-      source?: string;
-      target?: string;
+      source?: string | undefined;
+      target?: string | undefined;
     }
   | {
       type: 'POP_TO';
       payload: {
         name: string;
-        params?: object;
-        merge?: boolean;
+        params?: object | undefined;
+        merge?: boolean | undefined;
       };
-      source?: string;
-      target?: string;
+      source?: string | undefined;
+      target?: string | undefined;
     };
 
 export type StackRouterOptions = DefaultRouterOptions;

--- a/packages/routers/src/TabRouter.tsx
+++ b/packages/routers/src/TabRouter.tsx
@@ -14,9 +14,9 @@ import type {
 
 export type TabActionType = {
   type: 'JUMP_TO';
-  payload: { name: string; params?: object };
-  source?: string;
-  target?: string;
+  payload: { name: string; params?: object | undefined };
+  source?: string | undefined;
+  target?: string | undefined;
 };
 
 export type BackBehavior =
@@ -37,7 +37,7 @@ export type TabRouterOptions = DefaultRouterOptions & {
    * - `fullHistory` - return to last visited route; doesn't drop duplicate entries unlike `history` - matches behavior of web pages
    * - `none` - do not handle going back
    */
-  backBehavior?: BackBehavior;
+  backBehavior?: BackBehavior | undefined;
 };
 
 export type TabNavigationState<ParamList extends ParamListBase> = Omit<

--- a/packages/routers/src/createParamsFromAction.tsx
+++ b/packages/routers/src/createParamsFromAction.tsx
@@ -4,7 +4,7 @@ type Options = {
   action: {
     payload: {
       name: string;
-      params?: object;
+      params?: object | undefined;
     };
   };
   routeParamList: ParamListBase;

--- a/packages/routers/src/createRouteFromAction.tsx
+++ b/packages/routers/src/createRouteFromAction.tsx
@@ -7,7 +7,7 @@ type Options = {
   action: {
     payload: {
       name: string;
-      params?: object;
+      params?: object | undefined;
     };
   };
   routeParamList: ParamListBase;

--- a/packages/routers/src/types.tsx
+++ b/packages/routers/src/types.tsx
@@ -6,7 +6,7 @@ export type NavigationRoute<
   ParamList extends ParamListBase,
   RouteName extends keyof ParamList,
 > = Route<Extract<RouteName, string>, ParamList[RouteName]> & {
-  state?: NavigationState | PartialState<NavigationState>;
+  state?: NavigationState | PartialState<NavigationState> | undefined;
 };
 
 export type NavigationState<ParamList extends ParamListBase = ParamListBase> =
@@ -26,7 +26,7 @@ export type NavigationState<ParamList extends ParamListBase = ParamListBase> =
     /**
      * Alternative entries for history.
      */
-    history?: unknown[];
+    history?: unknown[] | undefined;
     /**
      * List of rendered routes.
      */
@@ -50,15 +50,15 @@ export type InitialState = Readonly<
 >;
 
 export type PartialRoute<R extends Route<string>> = Omit<R, 'key'> & {
-  key?: string;
-  state?: PartialState<NavigationState>;
+  key?: string | undefined;
+  state?: PartialState<NavigationState> | undefined;
 };
 
 export type PartialState<State extends NavigationState> = Partial<
   Omit<State, 'stale' | 'routes'>
 > &
   Readonly<{
-    stale?: true;
+    stale?: true | undefined;
     routes: PartialRoute<Route<State['routeNames'][number]>>[];
   }>;
 
@@ -79,18 +79,18 @@ export type Route<
      * Path associated with the route.
      * Usually present when the screen was opened from a deep link.
      */
-    path?: string;
+    path?: string | undefined;
     /**
      * History of param changes for this route.
      */
-    history?: { type: 'params'; params: object }[];
+    history?: { type: 'params'; params: object }[] | undefined;
   } & Readonly<
     undefined extends Params
       ? {
           /**
            * Params for this route
            */
-          params?: Readonly<Params>;
+          params?: Readonly<Params> | undefined;
         }
       : {
           /**
@@ -111,15 +111,15 @@ export type NavigationAction = Readonly<{
   /**
    * Additional data for the action
    */
-  payload?: object;
+  payload?: object | undefined;
   /**
    * Key of the route which dispatched this action.
    */
-  source?: string;
+  source?: string | undefined;
   /**
    * Key of the navigator which should handle this action.
    */
-  target?: string;
+  target?: string | undefined;
 }>;
 
 export type ActionCreators<Action extends NavigationAction> = {
@@ -131,7 +131,7 @@ export type DefaultRouterOptions<RouteName extends string = string> = {
    * Name of the route to focus by on initial render.
    * If not specified, usually the first route is used.
    */
-  initialRouteName?: RouteName;
+  initialRouteName?: RouteName | undefined;
 };
 
 export type RouterFactory<
@@ -145,7 +145,9 @@ export type RouterConfigOptions = {
   routeParamList: ParamListBase;
   routeGetIdList: Record<
     string,
-    | ((options: { params?: Record<string, any> }) => string | undefined)
+    | ((options: {
+        params?: Record<string, any> | undefined;
+      }) => string | undefined)
     | undefined
   >;
 };


### PR DESCRIPTION
## Motivation

Projects that enable TypeScript's [`exactOptionalPropertyTypes`](https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes) hit type errors in `@react-navigation/routers` when compiling with `skipLibCheck: false`. This flag is increasingly common in strict TypeScript setups and is part of TypeScript's "beyond strict" configuration.

This is PR 1 of 4 in a stacked series to enable `exactOptionalPropertyTypes` across the react-navigation monorepo. This PR fixes all type definitions in the `routers` package by adding explicit `| undefined` to optional properties — the standard pattern for `exactOptionalPropertyTypes` compatibility.

### Stacked PR series

1. **#12990 — routers** (this PR)
2. #12992 — core + native + elements
3. #12994 — navigator packages
4. #12995 — example app + external `@ts-expect-error` + enable flag

### What changed

With `exactOptionalPropertyTypes`, `prop?: T` means "if present, value is exactly `T`" — passing `undefined` explicitly is an error. The fix is `prop?: T | undefined`, which means "optional, and if present, value is `T` or `undefined`".

Applied to all optional properties in:
- **`types.tsx`** — `NavigationAction` (`payload`, `source`, `target`), `Route` (`path`, `history`), `NavigationRoute` (`state`), `NavigationState` (`history`), `PartialRoute` (`key`, `state`), `PartialState` (`stale`), `RouterConfigOptions` (`routeGetIdList` params), `DefaultRouterOptions` (`initialRouteName`)
- **`CommonActions.tsx`** — All action types (`NavigateAction`, `ResetAction`, `SetParamsAction`, `ReplaceParamsAction`, `PushParamsAction`, `PreloadAction`)
- **`StackRouter.tsx`** — `StackActionType` (all 5 variants)
- **`TabRouter.tsx`** — `TabActionType`, `TabRouterOptions`, `TabNavigationState`
- **`DrawerRouter.tsx`** — `DrawerActionType`, `DrawerRouterOptions`
- **`createParamsFromAction.tsx`** / **`createRouteFromAction.tsx`** — local `Options` types

All changes are type-level only — zero runtime impact.

## Test Plan

- `yarn typecheck` — passes with zero errors
- `yarn lint` — passes with zero errors
- `yarn test --maxWorkers=2` — 47 suites, 613 tests, 134 snapshots all passing
- All lefthook pre-commit hooks pass (types, lint, test, commitlint)
