### PR TITLE
fix(types): make NavigationState/NavigationLeafRoute routes optional

### DIFF
--- a/packages/react-navigation/typescript/react-navigation.d.ts
+++ b/packages/react-navigation/typescript/react-navigation.d.ts
@@ -75,7 +75,7 @@ export interface NavigationState {
    * Index refers to the active child route in the routes array.
    */
   index: number;
-  routes: NavigationRoute[];
+  routes?: NavigationRoute[];
   isTransitioning: boolean;
   key: string;
   params?: NavigationParams | undefined;
@@ -117,7 +117,7 @@ export interface NavigationLeafRoute<Params = NavigationParams> {
   /**
    * Array containing the navigator's routes
    */
-  routes: NavigationRoute[];
+  routes?: NavigationRoute[];
   /**
    * Flag that indicates the transition state of the route
    */


### PR DESCRIPTION
## Summary
- make `NavigationState.routes` optional in the v4 TypeScript definitions
- make `NavigationLeafRoute.routes` optional to match runtime persisted state payloads
- keep scope minimal to the issue-reported typing mismatch

## Testing
- Not run locally: this repository's full TypeScript/lint/test workflow requires installing the monorepo dependencies, which is heavy for this constrained cron environment.
- Validation performed: inspected and diff-verified that only the two type fields reported in issue #9403 were changed.

## Related
Fixes #9403