### PR TITLE
fix(stack): preserve autoFocus on TextInput when navigating forward

### DIFF
--- a/packages/stack/src/utils/__tests__/useKeyboardManager.test.tsx
+++ b/packages/stack/src/utils/__tests__/useKeyboardManager.test.tsx
@@ -10,7 +10,7 @@ describe('useKeyboardManager', () => {
   describe('onPageChangeConfirm', () => {
     test('calls onPageChangeCancel when closing is false', () => {
       const { result } = renderHook(() =>
-        useKeyboardManager({ enabled: true })
+        useKeyboardManager({ enabled: true, focused: true })
       );
 
       const blurMock = jest.fn();
@@ -36,7 +36,7 @@ describe('useKeyboardManager', () => {
       const dismissSpy = jest.spyOn(Keyboard, 'dismiss');
 
       const { result } = renderHook(() =>
-        useKeyboardManager({ enabled: true })
+        useKeyboardManager({ enabled: true, focused: true })
       );
 
       act(() =>
@@ -54,7 +54,7 @@ describe('useKeyboardManager', () => {
 
     test('blurs previously focused input when closing with gesture and active', () => {
       const { result } = renderHook(() =>
-        useKeyboardManager({ enabled: true })
+        useKeyboardManager({ enabled: true, focused: true })
       );
 
       const blurMock = jest.fn();
@@ -81,34 +81,72 @@ describe('useKeyboardManager', () => {
   });
 
   describe('useLayoutEffect keyboard dismiss on focus loss', () => {
-    test('dismisses keyboard when enabled transitions from true to false', () => {
+    test('dismisses keyboard when focused transitions from true to false', () => {
       const dismissSpy = jest.spyOn(Keyboard, 'dismiss');
 
       const { rerender } = renderHook(
-        ({ enabled }: { enabled: boolean }) => useKeyboardManager({ enabled }),
-        { initialProps: { enabled: true } }
+        (props: { enabled: boolean; focused: boolean }) =>
+          useKeyboardManager(props),
+        { initialProps: { enabled: true, focused: true } }
       );
 
       dismissSpy.mockClear();
 
-      rerender({ enabled: false });
+      rerender({ enabled: false, focused: false });
 
       expect(dismissSpy).toHaveBeenCalled();
 
       dismissSpy.mockRestore();
     });
 
-    test('does not dismiss keyboard when enabled stays false', () => {
+    test('does not dismiss keyboard when focused stays false', () => {
       const dismissSpy = jest.spyOn(Keyboard, 'dismiss');
 
       const { rerender } = renderHook(
-        ({ enabled }: { enabled: boolean }) => useKeyboardManager({ enabled }),
-        { initialProps: { enabled: false } }
+        (props: { enabled: boolean; focused: boolean }) =>
+          useKeyboardManager(props),
+        { initialProps: { enabled: false, focused: false } }
       );
 
       dismissSpy.mockClear();
 
-      rerender({ enabled: false });
+      rerender({ enabled: false, focused: false });
+
+      expect(dismissSpy).not.toHaveBeenCalled();
+
+      dismissSpy.mockRestore();
+    });
+
+    test('does not dismiss keyboard when only enabled changes without focus changing', () => {
+      const dismissSpy = jest.spyOn(Keyboard, 'dismiss');
+
+      const { rerender } = renderHook(
+        (props: { enabled: boolean; focused: boolean }) =>
+          useKeyboardManager(props),
+        { initialProps: { enabled: true, focused: true } }
+      );
+
+      dismissSpy.mockClear();
+
+      rerender({ enabled: false, focused: true });
+
+      expect(dismissSpy).not.toHaveBeenCalled();
+
+      dismissSpy.mockRestore();
+    });
+
+    test('does not dismiss keyboard when losing focus while disabled', () => {
+      const dismissSpy = jest.spyOn(Keyboard, 'dismiss');
+
+      const { rerender } = renderHook(
+        (props: { enabled: boolean; focused: boolean }) =>
+          useKeyboardManager(props),
+        { initialProps: { enabled: false, focused: true } }
+      );
+
+      dismissSpy.mockClear();
+
+      rerender({ enabled: false, focused: false });
 
       expect(dismissSpy).not.toHaveBeenCalled();
 

--- a/packages/stack/src/utils/useKeyboardManager.tsx
+++ b/packages/stack/src/utils/useKeyboardManager.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
 import { type HostInstance, Keyboard, TextInput } from 'react-native';
 
-export function useKeyboardManager({ enabled }: { enabled: boolean }) {
+export function useKeyboardManager({
+  enabled,
+  focused,
+}: {
+  enabled: boolean;
+  focused: boolean;
+}) {
   // Numeric id of the previously focused text input
   // When a gesture didn't change the tab, we can restore the focused input with this
   const previouslyFocusedTextInputRef = React.useRef<HostInstance>(undefined);
@@ -109,12 +115,14 @@ export function useKeyboardManager({ enabled }: { enabled: boolean }) {
   // This handles the "navigate forward" case so we don't dismiss the new screen's
   // auto-focused input from handleTransition.
   React.useLayoutEffect(() => {
-    if (enabledRef.current && !enabled) {
+    if (enabledRef.current && !focused) {
       Keyboard.dismiss();
     }
+  }, [focused]);
 
+  React.useLayoutEffect(() => {
     enabledRef.current = enabled;
-  }, [enabled]);
+  });
 
   React.useEffect(() => {
     return () => clearKeyboardTimeout();

--- a/packages/stack/src/views/Stack/CardContainer.tsx
+++ b/packages/stack/src/views/Stack/CardContainer.tsx
@@ -105,7 +105,7 @@ function CardContainerInner({
   const enabled = focused && options.keyboardHandlingEnabled !== false;
 
   const { onPageChangeStart, onPageChangeCancel, onPageChangeConfirm } =
-    useKeyboardManager({ enabled });
+    useKeyboardManager({ enabled, focused });
 
   const handleOpen = () => {
     const { route } = scene.descriptor;


### PR DESCRIPTION
## Motivation

Fixes [react-navigation/react-navigation#13016](https://github.com/react-navigation/react-navigation/issues/13016).

When the user navigates to a screen that contains a text input with `autoFocus`, the input briefly receives focus (cursor may appear for a moment) and then immediately loses it. The user must tap the input manually to start typing.

**Expected:** The input should automatically receive focus and stay focused so the user can start typing immediately without tapping the input first.

## Test plan

1. **RN TextInput (bug: focus then onBlur):**
   - Start the app: `npm run web`
   - Open DevTools console (F12 or Cmd+Option+I)
   - From the home screen, tap **/rn-text-input**
   - Observe the console logs

   **Expected:** `[RN TextInput] onFocus - gained focus` only (input stays focused).

   **Actual (before fix):** `[RN TextInput] onFocus - gained focus` followed by `[RN TextInput] onBlur - lost focus` (input loses focus immediately after gaining it).

2. **Lint and types:**
   ```bash
   npm run lint
   npx tsc --noEmit
   ```

3. **Tests:**
   ```bash
   npm test
   ```
