### PR TITLE
fix(types): handle missing canPreventDefault in EventListenerCallback generic

### DIFF
--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -220,13 +220,11 @@ export type EventArg<
 export type EventListenerCallback<
   EventMap extends EventMapBase,
   EventName extends keyof EventMap,
-  EventCanPreventDefault extends
-    | boolean
-    | undefined = EventMap[EventName]['canPreventDefault'],
+  EventCanPreventDefault = EventMap[EventName]['canPreventDefault'],
 > = (
   e: EventArg<
     EventName,
-    undefined extends EventCanPreventDefault ? false : EventCanPreventDefault,
+    EventCanPreventDefault extends true ? true : false,
     EventMap[EventName]['data']
   >
 ) => void;


### PR DESCRIPTION
## Problem

When downstream consumers wrap react-navigation navigators and tsc emits `.d.ts`, `EventListenerCallback`'s 3rd generic parameter resolves to `unknown` for events that don't declare `canPreventDefault`. This `unknown` violates the `extends boolean | undefined` constraint, producing TS2344 for any consumer with `skipLibCheck: false`.

Repro: https://github.com/YevheniiKotyrlo/repro-navigation-canpreventdefault-direct ([CI](https://github.com/YevheniiKotyrlo/repro-navigation-canpreventdefault-direct/actions/runs/23257409850/job/67616198044))

## Fix

Two changes to `EventListenerCallback` in `packages/core/src/types.tsx`:

1. **Remove the constraint** on `EventCanPreventDefault` — allows `unknown` (from expanded generics) without TS2344
2. **Flip the conditional** from `undefined extends EventCanPreventDefault ? false : EventCanPreventDefault` to `EventCanPreventDefault extends true ? true : false` — always produces `boolean`, satisfying `EventArg`'s constraint

The behavior is identical: only events with `canPreventDefault: true` (like `beforeRemove`) get `preventDefault()`. All others resolve to `false`.

1 file, +2/−4 lines. Zero runtime changes.
