### PR TITLE
fix: improve aria-hidden handling during stack animations

### DIFF
--- a/packages/stack/src/views/Stack/CardA11yWrapper.tsx
+++ b/packages/stack/src/views/Stack/CardA11yWrapper.tsx
@@ -27,6 +27,11 @@ export const CardA11yWrapper = React.forwardRef(
     return (
       <View
         aria-hidden={!focused}
+        // On web, aria-hidden alone doesn't prevent keyboard Tab navigation
+        // to focusable elements. The inert attribute blocks both screen reader
+        // access and keyboard focus, which is needed when animations keep the
+        // screen visible in the DOM.
+        inert={!focused || undefined}
         style={[
           StyleSheet.absoluteFill,
           {

--- a/packages/stack/src/views/Stack/__tests__/CardA11yWrapper.test.tsx
+++ b/packages/stack/src/views/Stack/__tests__/CardA11yWrapper.test.tsx
@@ -1,0 +1,74 @@
+import 'react-native-gesture-handler/jestSetup';
+
+import { expect, jest, test } from '@jest/globals';
+import { Text } from '@react-navigation/elements';
+import { NavigationContainer } from '@react-navigation/native';
+import { act, fireEvent, render } from '@testing-library/react-native';
+import { Button, View } from 'react-native';
+
+import { createStackNavigator, type StackScreenProps } from '../../../index';
+
+type StackParamList = {
+  A: undefined;
+  B: undefined;
+};
+
+jest.useFakeTimers();
+
+function findA11yWrapper(element: any) {
+  let node = element.parent;
+  while (node && node.props['aria-hidden'] === undefined) {
+    node = node.parent;
+  }
+  return node;
+}
+
+test('focused screen is not aria-hidden', () => {
+  const Stack = createStackNavigator<StackParamList>();
+
+  const { getByText } = render(
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="A">{() => <Text>Screen A</Text>}</Stack.Screen>
+        <Stack.Screen name="B">{() => <Text>Screen B</Text>}</Stack.Screen>
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+
+  const wrapper = findA11yWrapper(getByText('Screen A'));
+
+  expect(wrapper).not.toBeNull();
+  expect(wrapper!.props['aria-hidden']).toBe(false);
+});
+
+test('unfocused screen is aria-hidden after navigation', () => {
+  const TestScreen = ({
+    navigation,
+  }: StackScreenProps<StackParamList, 'A'>) => (
+    <View>
+      <Text>Screen A</Text>
+      <Button onPress={() => navigation.navigate('B')} title="Go to B" />
+    </View>
+  );
+
+  const Stack = createStackNavigator<StackParamList>();
+
+  const { getByText } = render(
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="A" component={TestScreen} />
+        <Stack.Screen name="B">{() => <Text>Screen B</Text>}</Stack.Screen>
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+
+  fireEvent.press(getByText('Go to B'));
+  act(() => jest.runAllTimers());
+
+  const wrapper = findA11yWrapper(
+    getByText('Screen A', { includeHiddenElements: true })
+  );
+
+  expect(wrapper).not.toBeNull();
+  expect(wrapper!.props['aria-hidden']).toBe(true);
+});


### PR DESCRIPTION
**Motivation**

Fixes https://github.com/react-navigation/react-navigation/issues/12583

When stack animations are enabled on web, non-focused screens remain reachable via keyboard Tab navigation. The existing `aria-hidden={!focused}` hides screens from screen readers but doesn't prevent keyboard focus on focusable elements (buttons, links, etc.).

Without animations, `visibility: hidden` is applied to non-focused screens, which blocks both screen reader access and keyboard focus. But with animations enabled, `visibility` stays `visible` (needed for the animation to render), so keyboard focus leaks through to the previous screen.

This adds the `inert` attribute to non-focused screens, which blocks both screen reader access and keyboard focus — matching the behavior that `visibility: hidden` already provides when animations are disabled.

**Test plan**

- Added unit tests for `CardA11yWrapper` verifying `aria-hidden` behavior on focused and unfocused screens
- All existing tests pass (`yarn test packages/stack/` — 36 tests, 5 suites)
- Lint, typecheck, and commitlint all pass
- The `inert` attribute is a web DOM feature that can be verified by inspecting elements in browser DevTools during stack transitions