### PR TITLE
feat: add a reuse option to preload

### DIFF
--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -363,12 +363,25 @@ type NavigationHelpersCommon<
    *
    * @param screen Name of the route to preload.
    * @param [params] Params object for the route.
+   * @param [options.reuse] Whether to reuse a matching route or preloaded route.
    */
   preload<RouteName extends keyof ParamList>(
     ...args: RouteName extends unknown
       ? undefined extends ParamList[RouteName]
-        ? [screen: RouteName, params?: ParamList[RouteName]]
-        : [screen: RouteName, params: ParamList[RouteName]]
+        ? [
+            screen: RouteName,
+            params?: ParamList[RouteName],
+            options?: {
+              reuse?: boolean | undefined;
+            },
+          ]
+        : [
+            screen: RouteName,
+            params: ParamList[RouteName],
+            options?: {
+              reuse?: boolean | undefined;
+            },
+          ]
       : never
   ): void;
 

--- a/packages/routers/src/CommonActions.tsx
+++ b/packages/routers/src/CommonActions.tsx
@@ -59,6 +59,7 @@ type PreloadAction = {
   payload: {
     name: string;
     params?: object | undefined;
+    reuse?: boolean | undefined;
   };
   source?: string | undefined;
   target?: string | undefined;
@@ -147,9 +148,15 @@ export function pushParams(params: object) {
   } as const satisfies PushParamsAction;
 }
 
-export function preload(name: string, params?: object | undefined) {
+export function preload(
+  name: string,
+  params?: object | undefined,
+  options?: {
+    reuse?: boolean | undefined;
+  }
+) {
   return {
     type: 'PRELOAD',
-    payload: { name, params },
+    payload: { name, params, reuse: options?.reuse },
   } as const satisfies PreloadAction;
 }

--- a/packages/routers/src/StackRouter.tsx
+++ b/packages/routers/src/StackRouter.tsx
@@ -722,29 +722,49 @@ export function StackRouter(options: StackRouterOptions) {
         case 'PRELOAD': {
           const getId = options.routeGetIdList[action.payload.name];
           const id = getId?.({ params: action.payload.params });
+          const params = createParamsFromAction({ action, routeParamList });
 
           let route: Route<string> | undefined;
 
+          if (action.payload.reuse) {
+            route = state.preloadedRoutes.findLast(
+              (route) =>
+                route.name === action.payload.name &&
+                (id === undefined || id === getId?.({ params: route.params }))
+            );
+
+            if (route) {
+              return {
+                ...state,
+                preloadedRoutes: state.preloadedRoutes.map((r) =>
+                  r.key === route?.key && r.params !== params
+                    ? { ...r, params }
+                    : r
+                ),
+              };
+            }
+          }
+
           if (id !== undefined) {
-            route = state.routes.find(
+            route = state.routes.findLast(
               (route) =>
                 route.name === action.payload.name &&
                 id === getId?.({ params: route.params })
+            );
+          } else if (action.payload.reuse) {
+            route = state.routes.findLast(
+              (route) => route.name === action.payload.name
             );
           }
 
           if (route) {
             return {
               ...state,
-              routes: state.routes.map((r) => {
-                if (r.key !== route?.key) {
-                  return r;
-                }
-                return {
-                  ...r,
-                  params: createParamsFromAction({ action, routeParamList }),
-                };
-              }),
+              routes: state.routes.map((r) =>
+                r.key === route.key && r.params !== params
+                  ? { ...r, params }
+                  : r
+              ),
             };
           } else {
             return {

--- a/packages/routers/src/__tests__/StackRouter.test.tsx
+++ b/packages/routers/src/__tests__/StackRouter.test.tsx
@@ -3109,7 +3109,6 @@ test('adds route to preloaded list with preload', () => {
           { key: 'qux', name: 'qux' },
         ],
       },
-
       CommonActions.preload('bar'),
       options
     )
@@ -3128,6 +3127,20 @@ test('adds route to preloaded list with preload', () => {
       { key: 'qux', name: 'qux' },
     ],
   });
+});
+
+test('updates an existing route with preload when the ID matches', () => {
+  const router = StackRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {
+      bar: { color: 'test' },
+      baz: { foo: 12 },
+    },
+    routeGetIdList: {
+      bar: ({ params }) => params?.answer,
+    },
+  };
 
   expect(
     router.getStateForAction(
@@ -3147,7 +3160,6 @@ test('adds route to preloaded list with preload', () => {
           { key: 'baz', name: 'baz' },
         ],
       },
-
       CommonActions.preload('bar', { answer: 42, something: 'else' }),
       options
     )
@@ -3167,6 +3179,82 @@ test('adds route to preloaded list with preload', () => {
       { key: 'baz', name: 'baz' },
     ],
   });
+});
+
+test('updates the last matching route with preload when the ID matches', () => {
+  const router = StackRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {
+      bar: { color: 'test' },
+      baz: { foo: 12 },
+    },
+    routeGetIdList: {
+      bar: ({ params }) => params?.answer,
+    },
+  };
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'stack',
+        key: 'root',
+        index: 2,
+        preloadedRoutes: [],
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          {
+            key: 'bar-first',
+            name: 'bar',
+            params: { answer: 42, toBe: 'first' },
+          },
+          { key: 'baz', name: 'baz' },
+          {
+            key: 'bar-last',
+            name: 'bar',
+            params: { answer: 42, toBe: 'last' },
+          },
+        ],
+      },
+      CommonActions.preload('bar', { answer: 42, something: 'else' }),
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'stack',
+    key: 'root',
+    index: 2,
+    preloadedRoutes: [],
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [
+      {
+        key: 'bar-first',
+        name: 'bar',
+        params: { answer: 42, toBe: 'first' },
+      },
+      { key: 'baz', name: 'baz' },
+      {
+        key: 'bar-last',
+        name: 'bar',
+        params: { answer: 42, color: 'test', something: 'else' },
+      },
+    ],
+  });
+});
+
+test('adds preloaded route with preload when the ID changes', () => {
+  const router = StackRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {
+      bar: { color: 'test' },
+      baz: { foo: 12 },
+    },
+    routeGetIdList: {
+      bar: ({ params }) => params?.answer,
+    },
+  };
 
   expect(
     router.getStateForAction(
@@ -3186,7 +3274,6 @@ test('adds route to preloaded list with preload', () => {
           { key: 'baz', name: 'baz' },
         ],
       },
-
       CommonActions.preload('bar', { answer: 43 }),
       options
     )
@@ -3204,6 +3291,266 @@ test('adds route to preloaded list with preload', () => {
         key: 'bar-test',
         name: 'bar',
         params: { answer: 42, toBe: 'notMerged' },
+      },
+      { key: 'baz', name: 'baz' },
+    ],
+  });
+});
+
+test('updates the last matching route by name with preload and reuse when getId is not provided', () => {
+  const router = StackRouter({});
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'stack',
+        key: 'root',
+        index: 2,
+        preloadedRoutes: [],
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          {
+            key: 'bar-first',
+            name: 'bar',
+            params: { answer: 1, toBe: 'first' },
+          },
+          { key: 'baz', name: 'baz' },
+          {
+            key: 'bar-last',
+            name: 'bar',
+            params: { answer: 2, toBe: 'last' },
+          },
+        ],
+      },
+      CommonActions.preload(
+        'bar',
+        { answer: 3 },
+        {
+          reuse: true,
+        }
+      ),
+      {
+        routeNames: ['baz', 'bar', 'qux'],
+        routeParamList: {},
+        routeGetIdList: {},
+      }
+    )
+  ).toEqual({
+    stale: false,
+    type: 'stack',
+    key: 'root',
+    index: 2,
+    preloadedRoutes: [],
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [
+      {
+        key: 'bar-first',
+        name: 'bar',
+        params: { answer: 1, toBe: 'first' },
+      },
+      { key: 'baz', name: 'baz' },
+      {
+        key: 'bar-last',
+        name: 'bar',
+        params: { answer: 3 },
+      },
+    ],
+  });
+});
+
+test('updates the last matching route with preload and reuse', () => {
+  const router = StackRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {
+      bar: { color: 'test' },
+      baz: { foo: 12 },
+    },
+    routeGetIdList: {
+      bar: ({ params }) => params?.answer,
+    },
+  };
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'stack',
+        key: 'root',
+        index: 2,
+        preloadedRoutes: [],
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          {
+            key: 'bar-first',
+            name: 'bar',
+            params: { answer: 42, toBe: 'first' },
+          },
+          { key: 'baz', name: 'baz' },
+          {
+            key: 'bar-last',
+            name: 'bar',
+            params: { answer: 42, toBe: 'last' },
+          },
+        ],
+      },
+      CommonActions.preload(
+        'bar',
+        { answer: 42, something: 'else' },
+        { reuse: true }
+      ),
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'stack',
+    key: 'root',
+    index: 2,
+    preloadedRoutes: [],
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [
+      {
+        key: 'bar-first',
+        name: 'bar',
+        params: { answer: 42, toBe: 'first' },
+      },
+      { key: 'baz', name: 'baz' },
+      {
+        key: 'bar-last',
+        name: 'bar',
+        params: { answer: 42, color: 'test', something: 'else' },
+      },
+    ],
+  });
+});
+
+test('updates the last matching preloaded route with preload and reuse', () => {
+  const router = StackRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {
+      bar: { color: 'test' },
+      baz: { foo: 12 },
+    },
+    routeGetIdList: {
+      bar: ({ params }) => params?.answer,
+    },
+  };
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'stack',
+        key: 'root',
+        index: 1,
+        preloadedRoutes: [
+          {
+            key: 'bar-first',
+            name: 'bar',
+            params: { answer: 42, toBe: 'first' },
+          },
+          {
+            key: 'bar-last',
+            name: 'bar',
+            params: { answer: 42, toBe: 'last' },
+          },
+        ],
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [{ key: 'baz', name: 'baz' }],
+      },
+      CommonActions.preload(
+        'bar',
+        { answer: 42, something: 'else' },
+        { reuse: true }
+      ),
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'stack',
+    key: 'root',
+    index: 1,
+    preloadedRoutes: [
+      {
+        key: 'bar-first',
+        name: 'bar',
+        params: { answer: 42, toBe: 'first' },
+      },
+      {
+        key: 'bar-last',
+        name: 'bar',
+        params: { answer: 42, color: 'test', something: 'else' },
+      },
+    ],
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [{ key: 'baz', name: 'baz' }],
+  });
+});
+
+test('prefers a matching preloaded route over matching routes with preload and reuse', () => {
+  const router = StackRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {
+      bar: { color: 'test' },
+      baz: { foo: 12 },
+    },
+    routeGetIdList: {
+      bar: ({ params }) => params?.answer,
+    },
+  };
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'stack',
+        key: 'root',
+        index: 1,
+        preloadedRoutes: [
+          {
+            key: 'bar-preloaded',
+            name: 'bar',
+            params: { answer: 42, toBe: 'preloaded' },
+          },
+        ],
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          {
+            key: 'bar-route',
+            name: 'bar',
+            params: { answer: 42, toBe: 'route' },
+          },
+          { key: 'baz', name: 'baz' },
+        ],
+      },
+      CommonActions.preload(
+        'bar',
+        { answer: 42, something: 'else' },
+        { reuse: true }
+      ),
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'stack',
+    key: 'root',
+    index: 1,
+    preloadedRoutes: [
+      {
+        key: 'bar-preloaded',
+        name: 'bar',
+        params: { answer: 42, color: 'test', something: 'else' },
+      },
+    ],
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [
+      {
+        key: 'bar-route',
+        name: 'bar',
+        params: { answer: 42, toBe: 'route' },
       },
       { key: 'baz', name: 'baz' },
     ],

--- a/packages/routers/src/__tests__/TabRouter.test.tsx
+++ b/packages/routers/src/__tests__/TabRouter.test.tsx
@@ -2275,7 +2275,7 @@ test("doesn't merge params on jump to an existing screen", () => {
   });
 });
 
-test('handles screen preloading', () => {
+test('adds route key to preloadedRouteKeys with preload', () => {
   const router = TabRouter({});
   const options: RouterConfigOptions = {
     routeNames: ['baz', 'bar', 'qux'],
@@ -2318,6 +2318,17 @@ test('handles screen preloading', () => {
     ],
     history: [{ type: 'route', key: 'baz' }],
   });
+});
+
+test('updates an existing route with preload when the ID changes', () => {
+  const router = TabRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {
+      bar: ({ params }) => `bar-${params?.answer}`,
+    },
+  };
 
   expect(
     router.getStateForAction(
@@ -2352,6 +2363,17 @@ test('handles screen preloading', () => {
     ],
     history: [{ type: 'route', key: 'baz-test' }],
   });
+});
+
+test('replaces the preloaded route key with preload when the ID changes', () => {
+  const router = TabRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {
+      bar: ({ params }) => `bar-${params?.answer}`,
+    },
+  };
 
   expect(
     router.getStateForAction(
@@ -2390,6 +2412,17 @@ test('handles screen preloading', () => {
     ],
     history: [{ type: 'route', key: 'baz-test' }],
   });
+});
+
+test('updates an existing route with preload when the ID matches', () => {
+  const router = TabRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {
+      bar: ({ params }) => `bar-${params?.answer}`,
+    },
+  };
 
   expect(
     router.getStateForAction(
@@ -2432,6 +2465,17 @@ test('handles screen preloading', () => {
     ],
     history: [{ type: 'route', key: 'baz-test' }],
   });
+});
+
+test('removes focused route from preloadedRouteKeys on navigate', () => {
+  const router = TabRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {
+      bar: ({ params }) => `bar-${params?.answer}`,
+    },
+  };
 
   expect(
     router.getStateForAction(
@@ -2477,6 +2521,17 @@ test('handles screen preloading', () => {
       { type: 'route', key: 'qux-test' },
     ],
   });
+});
+
+test('removes focused route from preloadedRouteKeys on goBack', () => {
+  const router = TabRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {
+      bar: ({ params }) => `bar-${params?.answer}`,
+    },
+  };
 
   expect(
     router.getStateForAction(
@@ -2522,6 +2577,17 @@ test('handles screen preloading', () => {
     ],
     history: [{ type: 'route', key: 'baz-test' }],
   });
+});
+
+test('adds an existing route key to preloadedRouteKeys with preload and reuse', () => {
+  const router = TabRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {
+      bar: ({ params }) => `bar-${params?.answer}`,
+    },
+  };
 
   expect(
     router.getStateForAction(
@@ -2546,7 +2612,7 @@ test('handles screen preloading', () => {
           { type: 'route', key: 'qux-test' },
         ],
       },
-      CommonActions.preload('bar', { answer: 42 }),
+      CommonActions.preload('bar', { answer: 42 }, { reuse: true }),
       options
     )
   ).toEqual({
@@ -2570,6 +2636,73 @@ test('handles screen preloading', () => {
       { type: 'route', key: 'qux-test' },
     ],
   });
+});
+
+test('updates a preloaded route with preload and reuse when the ID changes', () => {
+  const router = TabRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {
+      bar: ({ params }) => `bar-${params?.answer}`,
+    },
+  };
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'tab',
+        preloadedRouteKeys: ['bar-some'],
+        key: 'root',
+        index: 2,
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          { key: 'baz-test', name: 'baz' },
+          {
+            key: 'bar-some',
+            name: 'bar',
+            params: { answer: 42, willBe: 'untouched' },
+          },
+          { key: 'qux-test', name: 'qux' },
+        ],
+        history: [
+          { type: 'route', key: 'bar-some' },
+          { type: 'route', key: 'qux-test' },
+        ],
+      },
+      CommonActions.preload('bar', { answer: 43 }, { reuse: true }),
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'tab',
+    preloadedRouteKeys: ['bar-test'],
+    key: 'root',
+    index: 2,
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [
+      { key: 'baz-test', name: 'baz' },
+      {
+        key: 'bar-test',
+        name: 'bar',
+        params: { answer: 43 },
+      },
+      { key: 'qux-test', name: 'qux' },
+    ],
+    history: [{ type: 'route', key: 'qux-test' }],
+  });
+});
+
+test('creates a new preloaded route with preload when the ID changes', () => {
+  const router = TabRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {
+      bar: ({ params }) => `bar-${params?.answer}`,
+    },
+  };
 
   expect(
     router.getStateForAction(


### PR DESCRIPTION
this adds a `reuse` option to `CommonActions.preload`. for a stack navigator, when `reuse` is `true`:

- it will check if it's already preloaded or present in the stack, and update the existing route's params instead of preloading again
- otherwise it'll preload as normal

for tab and drawer, this is already how it worked so there are no changes.